### PR TITLE
Add bitpos command.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -289,6 +289,7 @@ func (c *Client) Append(key, value string) *IntCmd {
 	return cmd
 }
 
+// Deprecated. Use BitPos instead.
 type BitCount struct {
 	Start, End int64
 }
@@ -329,6 +330,23 @@ func (c *Client) BitOpXor(destKey string, keys ...string) *IntCmd {
 
 func (c *Client) BitOpNot(destKey string, key string) *IntCmd {
 	return c.bitOp("NOT", destKey, key)
+}
+
+type BitPos struct {
+	Start, End int64
+}
+
+func (c *Client) BitPos(key string, bit int64, pos *BitPos) *IntCmd {
+	args := []string{"BITPOS", key, strconv.FormatInt(bit, 10)}
+	if pos != nil {
+		args = append(args, strconv.FormatInt(pos.Start, 10))
+		if pos.End != 0 {
+			args = append(args, strconv.FormatInt(pos.End, 10))
+		}
+	}
+	cmd := NewIntCmd(args...)
+	c.Process(cmd)
+	return cmd
 }
 
 func (c *Client) Decr(key string) *IntCmd {

--- a/redis_test.go
+++ b/redis_test.go
@@ -964,6 +964,42 @@ func (t *RedisTest) TestStringsBitOpNot(c *C) {
 	c.Assert(get.Val(), Equals, "\xff")
 }
 
+func (t *RedisTest) TestStringsBitPos(c *C) {
+	c.Assert(t.client.Set("mykey", "\xff\xf0\x00").Err(), IsNil)
+
+	pos, err := t.client.BitPos("mykey", 0, nil).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(12))
+
+	pos, err = t.client.BitPos("mykey", 1, nil).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(0))
+
+	pos, err = t.client.BitPos("mykey", 0, &redis.BitPos{Start: 2}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(16))
+
+	pos, err = t.client.BitPos("mykey", 1, &redis.BitPos{Start: 2}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(-1))
+
+	pos, err = t.client.BitPos("mykey", 0, &redis.BitPos{Start: -1}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(16))
+
+	pos, err = t.client.BitPos("mykey", 1, &redis.BitPos{Start: -1}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(-1))
+
+	pos, err = t.client.BitPos("mykey", 0, &redis.BitPos{Start: 2, End: 1}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(-1))
+
+	pos, err = t.client.BitPos("mykey", 0, &redis.BitPos{End: -3}).Result()
+	c.Assert(err, IsNil)
+	c.Assert(pos, Equals, int64(-1))
+}
+
 func (t *RedisTest) TestStringsDecr(c *C) {
 	set := t.client.Set("key", "10")
 	c.Assert(set.Err(), IsNil)


### PR DESCRIPTION
One problem with this implementation is that it is impossible to issue command like:

```
bitpos key 1 0 0
```