### PR TITLE
Implement non-blocking connection pool

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -17,8 +17,7 @@ var _ = Describe("Commands", func() {
 
 	BeforeEach(func() {
 		client = redis.NewTCPClient(&redis.Options{
-			Addr:        redisAddr,
-			PoolTimeout: 30 * time.Second,
+			Addr: redisAddr,
 		})
 	})
 

--- a/redis.go
+++ b/redis.go
@@ -125,7 +125,6 @@ type options struct {
 	WriteTimeout time.Duration
 
 	PoolSize    int
-	PoolTimeout time.Duration
 	IdleTimeout time.Duration
 }
 
@@ -160,11 +159,6 @@ type Options struct {
 	// The maximum number of socket connections.
 	// Default: 10
 	PoolSize int
-	// If all socket connections is the pool are busy, the pool will wait
-	// this amount of time for a conection to become available, before
-	// returning an error.
-	// Default: 5s
-	PoolTimeout time.Duration
 	// Evict connections from the pool after they have been idle for longer
 	// than specified in this option.
 	// Default: 0 = no eviction
@@ -192,13 +186,6 @@ func (opt *Options) getDialTimeout() time.Duration {
 	return opt.DialTimeout
 }
 
-func (opt *Options) getPoolTimeout() time.Duration {
-	if opt.PoolTimeout == 0 {
-		return 5 * time.Second
-	}
-	return opt.PoolTimeout
-}
-
 func (opt *Options) options() *options {
 	return &options{
 		DB:       opt.DB,
@@ -209,7 +196,6 @@ func (opt *Options) options() *options {
 		WriteTimeout: opt.WriteTimeout,
 
 		PoolSize:    opt.getPoolSize(),
-		PoolTimeout: opt.getPoolTimeout(),
 		IdleTimeout: opt.IdleTimeout,
 	}
 }

--- a/sentinel.go
+++ b/sentinel.go
@@ -37,11 +37,6 @@ type FailoverOptions struct {
 	// The maximum number of socket connections.
 	// Default: 10
 	PoolSize int
-	// If all socket connections is the pool are busy, the pool will wait
-	// this amount of time for a conection to become available, before
-	// returning an error.
-	// Default: 5s
-	PoolTimeout time.Duration
 	// Evict connections from the pool after they have been idle for longer
 	// than specified in this option.
 	// Default: 0 = no eviction
@@ -53,13 +48,6 @@ func (opt *FailoverOptions) getPoolSize() int {
 		return 10
 	}
 	return opt.PoolSize
-}
-
-func (opt *FailoverOptions) getPoolTimeout() time.Duration {
-	if opt.PoolTimeout == 0 {
-		return 5 * time.Second
-	}
-	return opt.PoolTimeout
 }
 
 func (opt *FailoverOptions) getDialTimeout() time.Duration {
@@ -79,7 +67,6 @@ func (opt *FailoverOptions) options() *options {
 		WriteTimeout: opt.WriteTimeout,
 
 		PoolSize:    opt.getPoolSize(),
-		PoolTimeout: opt.getPoolTimeout(),
 		IdleTimeout: opt.IdleTimeout,
 	}
 }
@@ -197,7 +184,6 @@ func (d *sentinelFailover) MasterAddr() (string, error) {
 			WriteTimeout: d.opt.WriteTimeout,
 
 			PoolSize:    d.opt.PoolSize,
-			PoolTimeout: d.opt.PoolTimeout,
 			IdleTimeout: d.opt.IdleTimeout,
 		})
 		masterAddr, err := sentinel.GetMasterAddrByName(d.masterName).Result()


### PR DESCRIPTION
We are seeing quite substantial latency issues with the current pool implementation. The main reason is that connections are not always returned back to the pool and `pool.wait` might wait for a connection that will never appear, eventually timing out after `PoolTimeout`. Example:

1. `pool.Get()` is called
2. `pool.First()` has no free connection available
3. `pool.size` is max, so resume by `pool.wait()`
4. Previously checked out connections are removed via `pool.Remove()`, `pool.size` is decremented
5. `pool.wait()` still waits for a connection until it times out

This patch implements a non-blocking pool and removes PoolTimeout. If no idle connection is available, we don't `wait` but go straight to `new`. Pools are not allowed to over-commit themselves, which seems an OK compromise given that we are rate-limiting new connections anyway.