### PR TITLE
Fix pool waiting for connection that was removed.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -256,29 +256,13 @@ type ClusterOptions struct {
 	// giving up. Default: 16
 	MaxRedirects int
 
-	// The maximum number of TCP sockets per connection. Default: 5
-	PoolSize int
-
-	// Timeout settings
-	DialTimeout, ReadTimeout, WriteTimeout, IdleTimeout time.Duration
-}
-
-func (opt *ClusterOptions) getPoolSize() int {
-	if opt.PoolSize < 1 {
-		return 5
-	}
-	return opt.PoolSize
-}
-
-func (opt *ClusterOptions) getDialTimeout() time.Duration {
-	if opt.DialTimeout == 0 {
-		return 5 * time.Second
-	}
-	return opt.DialTimeout
+	// Following options are copied from `redis.Options`.
+	PoolSize                                                         int
+	DialTimeout, ReadTimeout, WriteTimeout, PoolTimeout, IdleTimeout time.Duration
 }
 
 func (opt *ClusterOptions) getMaxRedirects() int {
-	if opt.MaxRedirects < 1 {
+	if opt.MaxRedirects == 0 {
 		return 16
 	}
 	return opt.MaxRedirects
@@ -289,11 +273,12 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		DB:       0,
 		Password: opt.Password,
 
-		DialTimeout:  opt.getDialTimeout(),
+		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolSize:    opt.getPoolSize(),
+		PoolSize:    opt.PoolSize,
+		PoolTimeout: opt.PoolTimeout,
 		IdleTimeout: opt.IdleTimeout,
 	}
 }

--- a/redis.go
+++ b/redis.go
@@ -160,10 +160,8 @@ type Options struct {
 	// The maximum number of socket connections.
 	// Default: 10
 	PoolSize int
-	// If all socket connections is the pool are busy, the pool will wait
-	// this amount of time for a conection to become available, before
-	// returning an error.
-	// Default: 5s
+	// PoolTimeout specifies amount of time client waits for a free
+	// connection in the pool. Default timeout is 1s.
 	PoolTimeout time.Duration
 	// Evict connections from the pool after they have been idle for longer
 	// than specified in this option.
@@ -194,7 +192,7 @@ func (opt *Options) getDialTimeout() time.Duration {
 
 func (opt *Options) getPoolTimeout() time.Duration {
 	if opt.PoolTimeout == 0 {
-		return 5 * time.Second
+		return 1 * time.Second
 	}
 	return opt.PoolTimeout
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Client", func() {
 	It("should support idle-timeouts", func() {
 		idle := redis.NewTCPClient(&redis.Options{
 			Addr:        redisAddr,
-			IdleTimeout: time.Nanosecond,
+			IdleTimeout: 100 * time.Microsecond,
 		})
 		defer idle.Close()
 


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/88

@dim PTAL.

I also changed default `PoolTimeout` because 5 seconds it too much for Redis and usually indicates that you have to increase pool size. 