### PR TITLE
Ensure all new connections are initialised

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -178,8 +178,8 @@ func (p *connPool) new() (*conn, error) {
 		return nil, err
 	}
 
-	if err := p.init(cn); err != nil {
-		p.Remove(cn)
+	if err := p.initConn(cn); err != nil {
+		cn.Close()
 		return nil, err
 	}
 
@@ -187,7 +187,7 @@ func (p *connPool) new() (*conn, error) {
 }
 
 // Initialize connection
-func (p *connPool) init(cn *conn) error {
+func (p *connPool) initConn(cn *conn) error {
 	if p.opt.Password == "" && p.opt.DB == 0 {
 		return nil
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Pool", func() {
 	})
 
 	It("should remove broken connections", func() {
-		cn, _, err := client.Pool().Get()
+		cn, err := client.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cn.Close()).NotTo(HaveOccurred())
 		Expect(client.Pool().Put(cn)).NotTo(HaveOccurred())
@@ -140,12 +140,12 @@ var _ = Describe("Pool", func() {
 		pool := client.Pool()
 
 		// Reserve one connection.
-		cn, _, err := client.Pool().Get()
+		cn, err := client.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Reserve the rest of connections.
 		for i := 0; i < 9; i++ {
-			_, _, err := client.Pool().Get()
+			_, err := client.Pool().Get()
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -190,7 +190,7 @@ func BenchmarkPool(b *testing.B) {
 	pool := client.Pool()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			conn, _, err := pool.Get()
+			conn, err := pool.Get()
 			if err != nil {
 				b.Fatalf("no error expected on pool.Get but received: %s", err.Error())
 			}

--- a/pool_test.go
+++ b/pool_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Pool", func() {
 
 		err = client.Ping().Err()
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("use of closed network connection"))
+		Expect(err.Error()).To(ContainSubstring("use of closed network connection"))
 
 		val, err := client.Ping().Result()
 		Expect(err).NotTo(HaveOccurred())

--- a/redis.go
+++ b/redis.go
@@ -12,45 +12,7 @@ type baseClient struct {
 }
 
 func (c *baseClient) conn() (*conn, error) {
-	cn, isNew, err := c.connPool.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	if isNew {
-		if err := c.initConn(cn); err != nil {
-			c.putConn(cn, err)
-			return nil, err
-		}
-	}
-
-	return cn, nil
-}
-
-func (c *baseClient) initConn(cn *conn) error {
-	if c.opt.Password == "" && c.opt.DB == 0 {
-		return nil
-	}
-
-	pool := newSingleConnPool(c.connPool, false)
-	pool.SetConn(cn)
-
-	// Client is not closed because we want to reuse underlying connection.
-	client := newClient(c.opt, pool)
-
-	if c.opt.Password != "" {
-		if err := client.Auth(c.opt.Password).Err(); err != nil {
-			return err
-		}
-	}
-
-	if c.opt.DB > 0 {
-		if err := client.Select(c.opt.DB).Err(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return c.connPool.Get()
 }
 
 func (c *baseClient) putConn(cn *conn, ei error) {


### PR DESCRIPTION
We have noticed that `Password` and `DB` settings are not correctly applied to connections being created as part of `pool.Put`, here's a proposed solution. PTAL