### PR TITLE
Fix pool to close all connections when client is closed.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,96 @@
+package redis
+
+import (
+	"net"
+	"time"
+
+	"gopkg.in/bufio.v1"
+)
+
+type conn struct {
+	netcn net.Conn
+	rd    *bufio.Reader
+	buf   []byte
+
+	usedAt       time.Time
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+func newConnDialer(opt *options) func() (*conn, error) {
+	return func() (*conn, error) {
+		netcn, err := opt.Dialer()
+		if err != nil {
+			return nil, err
+		}
+		cn := &conn{
+			netcn: netcn,
+			buf:   make([]byte, 0, 64),
+		}
+		cn.rd = bufio.NewReader(cn)
+		return cn, cn.init(opt)
+	}
+}
+
+func (cn *conn) init(opt *options) error {
+	if opt.Password == "" && opt.DB == 0 {
+		return nil
+	}
+
+	// Use connection to connect to redis
+	pool := newSingleConnPool(nil, false)
+	pool.SetConn(cn)
+
+	// Client is not closed because we want to reuse underlying connection.
+	client := newClient(opt, pool)
+
+	if opt.Password != "" {
+		if err := client.Auth(opt.Password).Err(); err != nil {
+			return err
+		}
+	}
+
+	if opt.DB > 0 {
+		if err := client.Select(opt.DB).Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cn *conn) writeCmds(cmds ...Cmder) error {
+	buf := cn.buf[:0]
+	for _, cmd := range cmds {
+		buf = appendArgs(buf, cmd.args())
+	}
+
+	_, err := cn.Write(buf)
+	return err
+}
+
+func (cn *conn) Read(b []byte) (int, error) {
+	if cn.readTimeout != 0 {
+		cn.netcn.SetReadDeadline(time.Now().Add(cn.readTimeout))
+	} else {
+		cn.netcn.SetReadDeadline(zeroTime)
+	}
+	return cn.netcn.Read(b)
+}
+
+func (cn *conn) Write(b []byte) (int, error) {
+	if cn.writeTimeout != 0 {
+		cn.netcn.SetWriteDeadline(time.Now().Add(cn.writeTimeout))
+	} else {
+		cn.netcn.SetWriteDeadline(zeroTime)
+	}
+	return cn.netcn.Write(b)
+}
+
+func (cn *conn) RemoteAddr() net.Addr {
+	return cn.netcn.RemoteAddr()
+}
+
+func (cn *conn) Close() error {
+	return cn.netcn.Close()
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -48,9 +48,9 @@ var _ = Describe("Pool", func() {
 		})
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(BeNumerically("<=", 10))
 		Expect(pool.Len()).To(BeNumerically("<=", 10))
-		Expect(pool.Size()).To(Equal(pool.Len()))
+		Expect(pool.FreeLen()).To(BeNumerically("<=", 10))
+		Expect(pool.Len()).To(Equal(pool.FreeLen()))
 	})
 
 	It("should respect max on multi", func() {
@@ -70,9 +70,9 @@ var _ = Describe("Pool", func() {
 		})
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(BeNumerically("<=", 10))
 		Expect(pool.Len()).To(BeNumerically("<=", 10))
-		Expect(pool.Size()).To(Equal(pool.Len()))
+		Expect(pool.FreeLen()).To(BeNumerically("<=", 10))
+		Expect(pool.Len()).To(Equal(pool.FreeLen()))
 	})
 
 	It("should respect max on pipelines", func() {
@@ -88,9 +88,9 @@ var _ = Describe("Pool", func() {
 		})
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(BeNumerically("<=", 10))
 		Expect(pool.Len()).To(BeNumerically("<=", 10))
-		Expect(pool.Size()).To(Equal(pool.Len()))
+		Expect(pool.FreeLen()).To(BeNumerically("<=", 10))
+		Expect(pool.Len()).To(Equal(pool.FreeLen()))
 	})
 
 	It("should respect max on pubsub", func() {
@@ -101,8 +101,8 @@ var _ = Describe("Pool", func() {
 		})
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(Equal(10))
 		Expect(pool.Len()).To(Equal(10))
+		Expect(pool.FreeLen()).To(Equal(10))
 	})
 
 	It("should remove broken connections", func() {
@@ -120,8 +120,8 @@ var _ = Describe("Pool", func() {
 		Expect(val).To(Equal("PONG"))
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(Equal(1))
 		Expect(pool.Len()).To(Equal(1))
+		Expect(pool.FreeLen()).To(Equal(1))
 	})
 
 	It("should reuse connections", func() {
@@ -132,8 +132,8 @@ var _ = Describe("Pool", func() {
 		}
 
 		pool := client.Pool()
-		Expect(pool.Size()).To(Equal(1))
 		Expect(pool.Len()).To(Equal(1))
+		Expect(pool.FreeLen()).To(Equal(1))
 	})
 
 	It("should unblock client when connection is removed", func() {

--- a/redis_test.go
+++ b/redis_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Client", func() {
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		client.Close()
 	})
 
 	It("should ping", func() {

--- a/sentinel.go
+++ b/sentinel.go
@@ -104,14 +104,9 @@ type sentinelClient struct {
 
 func newSentinel(clOpt *Options) *sentinelClient {
 	opt := clOpt.options()
-	opt.Password = ""
-	opt.DB = 0
-	dialer := func() (net.Conn, error) {
-		return net.DialTimeout("tcp", clOpt.Addr, opt.DialTimeout)
-	}
 	base := &baseClient{
 		opt:      opt,
-		connPool: newConnPool(newConnFunc(dialer), opt),
+		connPool: newConnPool(opt.connPoolOptions()),
 	}
 	return &sentinelClient{
 		baseClient:  base,
@@ -163,7 +158,8 @@ func (d *sentinelFailover) dial() (net.Conn, error) {
 
 func (d *sentinelFailover) Pool() pool {
 	d.poolOnce.Do(func() {
-		d.pool = newConnPool(newConnFunc(d.dial), d.opt)
+		d.opt.Dialer = d.dial
+		d.pool = newConnPool(d.opt.connPoolOptions())
 	})
 	return d.pool
 }


### PR DESCRIPTION
This is very useful when you want application to exit gracefully. Existing `BenchmarkPool` numbers are not changed.

Pool was refactored a bit since I want to reuse it in https://github.com/go-pg/pg/pull/52

/cc @dim 