### PR TITLE
commands: Reduce memory allocations in ZAdd

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -870,9 +870,12 @@ type ZStore struct {
 }
 
 func (c *commandable) ZAdd(key string, members ...Z) *IntCmd {
-	args := []string{"ZADD", key}
-	for _, m := range members {
-		args = append(args, formatFloat(m.Score), m.Member)
+	args := make([]string, 2+2*len(members))
+	args[0] = "ZADD"
+	args[1] = key
+	for i, m := range members {
+		args[2+2*i] = formatFloat(m.Score)
+		args[2+2*i+1] = m.Member
 	}
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)

--- a/redis_test.go
+++ b/redis_test.go
@@ -264,6 +264,23 @@ func BenchmarkPipeline(b *testing.B) {
 	})
 }
 
+func BenchmarkZAddAllocs(b *testing.B) {
+	client := redis.NewClient(&redis.Options{
+		Addr: redisAddr,
+	})
+	defer client.Close()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := client.ZAdd("key", redis.Z{float64(1), "hello"}).Err(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 //------------------------------------------------------------------------------
 
 // Replaces ginkgo's Eventually.


### PR DESCRIPTION
When adding lots of data in Redis, the allocations in ZAdd can put quite some pressure on the GC... Using the benchmark in https://gist.github.com/abustany/8f2cf2ee3b968020b75e , I get the following results:

```
benchmark              old ns/op     new ns/op     delta
BenchmarkRedisZAdd     22371         21779         -2.65%

benchmark              old allocs     new allocs     delta
BenchmarkRedisZAdd     10             9              -10.00%

benchmark              old bytes     new bytes     delta
BenchmarkRedisZAdd     373           343           -8.04%
```

There are probably a couple of places in the library where we could use a sync.Pool, for example for the commands, to reduce GC pressure, but that'd be the subject of another pull request...