### PR TITLE
cluster: user ClusterInfo instead of Ping to find live node.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -97,7 +97,7 @@ func (c *ClusterClient) slotAddrs(slot int) []string {
 	return addrs
 }
 
-// randomClient returns a Client for the first pingable node.
+// randomClient returns a Client for the first live node.
 func (c *ClusterClient) randomClient() (client *Client, err error) {
 	for i := 0; i < 10; i++ {
 		n := rand.Intn(len(c.addrs))
@@ -105,7 +105,7 @@ func (c *ClusterClient) randomClient() (client *Client, err error) {
 		if err != nil {
 			continue
 		}
-		err = client.Ping().Err()
+		err = client.ClusterInfo().Err()
 		if err == nil {
 			return client, nil
 		}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Cluster", func() {
 
 			Eventually(func() []string {
 				return client.SlotAddrs(slot)
-			}).Should(Equal([]string{"127.0.0.1:8221", "127.0.0.1:8224"}))
+			}, "5s").Should(Equal([]string{"127.0.0.1:8221", "127.0.0.1:8224"}))
 		})
 
 		It("should perform multi-pipelines", func() {


### PR DESCRIPTION
This check is much stricter since it verifies that node at least knows how to handle `CLUSTER INFO` command.