### PR TITLE
multi: remove confusing comment.

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -7,7 +7,8 @@ import (
 
 var errDiscard = errors.New("redis: Discard can be used only inside Exec")
 
-// Not thread-safe.
+// Multi implements Redis transactions as described in
+// http://redis.io/topics/transactions.
 type Multi struct {
 	commandable
 


### PR DESCRIPTION
Remove comment since there are no use cases when `Multi` can be used from different goroutines. Should help with https://github.com/go-redis/redis/issues/111