### PR TITLE
Allow setting and scaning interface{} values.

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ var (
 )
 
 type Cmder interface {
-	args() []string
+	args() []interface{}
 	parseReply(*bufio.Reader) error
 	setErr(error)
 	reset()
@@ -38,7 +39,7 @@ type Cmder interface {
 	clusterKey() string
 
 	Err() error
-	String() string
+	fmt.Stringer
 }
 
 func setCmdsErr(cmds []Cmder, e error) {
@@ -54,12 +55,21 @@ func resetCmds(cmds []Cmder) {
 }
 
 func cmdString(cmd Cmder, val interface{}) string {
-	s := strings.Join(cmd.args(), " ")
+	var ss []string
+	for _, arg := range cmd.args() {
+		ss = append(ss, fmt.Sprint(arg))
+	}
+	s := strings.Join(ss, " ")
 	if err := cmd.Err(); err != nil {
 		return s + ": " + err.Error()
 	}
 	if val != nil {
-		return s + ": " + fmt.Sprint(val)
+		switch vv := val.(type) {
+		case []byte:
+			return s + ": " + string(vv)
+		default:
+			return s + ": " + fmt.Sprint(val)
+		}
 	}
 	return s
 
@@ -68,7 +78,7 @@ func cmdString(cmd Cmder, val interface{}) string {
 //------------------------------------------------------------------------------
 
 type baseCmd struct {
-	_args []string
+	_args []interface{}
 
 	err error
 
@@ -84,7 +94,7 @@ func (cmd *baseCmd) Err() error {
 	return nil
 }
 
-func (cmd *baseCmd) args() []string {
+func (cmd *baseCmd) args() []interface{} {
 	return cmd._args
 }
 
@@ -102,7 +112,7 @@ func (cmd *baseCmd) writeTimeout() *time.Duration {
 
 func (cmd *baseCmd) clusterKey() string {
 	if cmd._clusterKeyPos > 0 && cmd._clusterKeyPos < len(cmd._args) {
-		return cmd._args[cmd._clusterKeyPos]
+		return fmt.Sprint(cmd._args[cmd._clusterKeyPos])
 	}
 	return ""
 }
@@ -123,7 +133,7 @@ type Cmd struct {
 	val interface{}
 }
 
-func NewCmd(args ...string) *Cmd {
+func NewCmd(args ...interface{}) *Cmd {
 	return &Cmd{baseCmd: baseCmd{_args: args}}
 }
 
@@ -146,6 +156,11 @@ func (cmd *Cmd) String() string {
 
 func (cmd *Cmd) parseReply(rd *bufio.Reader) error {
 	cmd.val, cmd.err = parseReply(rd, parseSlice)
+	// Convert to string to preserve old behaviour.
+	// TODO: remove in v4
+	if v, ok := cmd.val.([]byte); ok {
+		cmd.val = string(v)
+	}
 	return cmd.err
 }
 
@@ -157,7 +172,7 @@ type SliceCmd struct {
 	val []interface{}
 }
 
-func NewSliceCmd(args ...string) *SliceCmd {
+func NewSliceCmd(args ...interface{}) *SliceCmd {
 	return &SliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -196,11 +211,11 @@ type StatusCmd struct {
 	val string
 }
 
-func NewStatusCmd(args ...string) *StatusCmd {
+func NewStatusCmd(args ...interface{}) *StatusCmd {
 	return &StatusCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
-func newKeylessStatusCmd(args ...string) *StatusCmd {
+func newKeylessStatusCmd(args ...interface{}) *StatusCmd {
 	return &StatusCmd{baseCmd: baseCmd{_args: args}}
 }
 
@@ -227,7 +242,7 @@ func (cmd *StatusCmd) parseReply(rd *bufio.Reader) error {
 		cmd.err = err
 		return err
 	}
-	cmd.val = v.(string)
+	cmd.val = string(v.([]byte))
 	return nil
 }
 
@@ -239,7 +254,7 @@ type IntCmd struct {
 	val int64
 }
 
-func NewIntCmd(args ...string) *IntCmd {
+func NewIntCmd(args ...interface{}) *IntCmd {
 	return &IntCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -279,7 +294,7 @@ type DurationCmd struct {
 	precision time.Duration
 }
 
-func NewDurationCmd(precision time.Duration, args ...string) *DurationCmd {
+func NewDurationCmd(precision time.Duration, args ...interface{}) *DurationCmd {
 	return &DurationCmd{
 		precision: precision,
 		baseCmd:   baseCmd{_args: args, _clusterKeyPos: 1},
@@ -321,7 +336,7 @@ type BoolCmd struct {
 	val bool
 }
 
-func NewBoolCmd(args ...string) *BoolCmd {
+func NewBoolCmd(args ...interface{}) *BoolCmd {
 	return &BoolCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -342,6 +357,8 @@ func (cmd *BoolCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
+var ok = []byte("OK")
+
 func (cmd *BoolCmd) parseReply(rd *bufio.Reader) error {
 	v, err := parseReply(rd, nil)
 	// `SET key value NX` returns nil when key already exists.
@@ -357,8 +374,8 @@ func (cmd *BoolCmd) parseReply(rd *bufio.Reader) error {
 	case int64:
 		cmd.val = vv == 1
 		return nil
-	case string:
-		cmd.val = vv == "OK"
+	case []byte:
+		cmd.val = bytes.Equal(vv, ok)
 		return nil
 	default:
 		return fmt.Errorf("got %T, wanted int64 or string")
@@ -370,23 +387,27 @@ func (cmd *BoolCmd) parseReply(rd *bufio.Reader) error {
 type StringCmd struct {
 	baseCmd
 
-	val string
+	val []byte
 }
 
-func NewStringCmd(args ...string) *StringCmd {
+func NewStringCmd(args ...interface{}) *StringCmd {
 	return &StringCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
 func (cmd *StringCmd) reset() {
-	cmd.val = ""
+	cmd.val = nil
 	cmd.err = nil
 }
 
 func (cmd *StringCmd) Val() string {
-	return cmd.val
+	return string(cmd.val)
 }
 
 func (cmd *StringCmd) Result() (string, error) {
+	return cmd.Val(), cmd.err
+}
+
+func (cmd *StringCmd) Bytes() ([]byte, error) {
 	return cmd.val, cmd.err
 }
 
@@ -394,21 +415,28 @@ func (cmd *StringCmd) Int64() (int64, error) {
 	if cmd.err != nil {
 		return 0, cmd.err
 	}
-	return strconv.ParseInt(cmd.val, 10, 64)
+	return strconv.ParseInt(cmd.Val(), 10, 64)
 }
 
 func (cmd *StringCmd) Uint64() (uint64, error) {
 	if cmd.err != nil {
 		return 0, cmd.err
 	}
-	return strconv.ParseUint(cmd.val, 10, 64)
+	return strconv.ParseUint(cmd.Val(), 10, 64)
 }
 
 func (cmd *StringCmd) Float64() (float64, error) {
 	if cmd.err != nil {
 		return 0, cmd.err
 	}
-	return strconv.ParseFloat(cmd.val, 64)
+	return strconv.ParseFloat(cmd.Val(), 64)
+}
+
+func (cmd *StringCmd) Scan(val interface{}) error {
+	if cmd.err != nil {
+		return cmd.err
+	}
+	return scan(cmd.val, val)
 }
 
 func (cmd *StringCmd) String() string {
@@ -421,7 +449,9 @@ func (cmd *StringCmd) parseReply(rd *bufio.Reader) error {
 		cmd.err = err
 		return err
 	}
-	cmd.val = v.(string)
+	b := v.([]byte)
+	cmd.val = make([]byte, len(b))
+	copy(cmd.val, b)
 	return nil
 }
 
@@ -433,7 +463,7 @@ type FloatCmd struct {
 	val float64
 }
 
-func NewFloatCmd(args ...string) *FloatCmd {
+func NewFloatCmd(args ...interface{}) *FloatCmd {
 	return &FloatCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -456,7 +486,7 @@ func (cmd *FloatCmd) parseReply(rd *bufio.Reader) error {
 		cmd.err = err
 		return err
 	}
-	cmd.val, cmd.err = strconv.ParseFloat(v.(string), 64)
+	cmd.val, cmd.err = strconv.ParseFloat(string(v.([]byte)), 64)
 	return cmd.err
 }
 
@@ -468,7 +498,7 @@ type StringSliceCmd struct {
 	val []string
 }
 
-func NewStringSliceCmd(args ...string) *StringSliceCmd {
+func NewStringSliceCmd(args ...interface{}) *StringSliceCmd {
 	return &StringSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -507,7 +537,7 @@ type BoolSliceCmd struct {
 	val []bool
 }
 
-func NewBoolSliceCmd(args ...string) *BoolSliceCmd {
+func NewBoolSliceCmd(args ...interface{}) *BoolSliceCmd {
 	return &BoolSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -546,7 +576,7 @@ type StringStringMapCmd struct {
 	val map[string]string
 }
 
-func NewStringStringMapCmd(args ...string) *StringStringMapCmd {
+func NewStringStringMapCmd(args ...interface{}) *StringStringMapCmd {
 	return &StringStringMapCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -585,7 +615,7 @@ type StringIntMapCmd struct {
 	val map[string]int64
 }
 
-func NewStringIntMapCmd(args ...string) *StringIntMapCmd {
+func NewStringIntMapCmd(args ...interface{}) *StringIntMapCmd {
 	return &StringIntMapCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -624,7 +654,7 @@ type ZSliceCmd struct {
 	val []Z
 }
 
-func NewZSliceCmd(args ...string) *ZSliceCmd {
+func NewZSliceCmd(args ...interface{}) *ZSliceCmd {
 	return &ZSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -664,7 +694,7 @@ type ScanCmd struct {
 	keys   []string
 }
 
-func NewScanCmd(args ...string) *ScanCmd {
+func NewScanCmd(args ...interface{}) *ScanCmd {
 	return &ScanCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 
@@ -720,7 +750,7 @@ type ClusterSlotCmd struct {
 	val []ClusterSlotInfo
 }
 
-func NewClusterSlotCmd(args ...string) *ClusterSlotCmd {
+func NewClusterSlotCmd(args ...interface{}) *ClusterSlotCmd {
 	return &ClusterSlotCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Command", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 	})
 
-	It("should have a plain string result", func() {
+	It("should implement Stringer", func() {
 		set := client.Set("foo", "bar", 0)
 		Expect(set.String()).To(Equal("SET foo bar: OK"))
 
@@ -115,6 +115,13 @@ var _ = Describe("Command", func() {
 		f, err := client.Get("key").Float64()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f).To(Equal(float64(10)))
+	})
+
+	It("Cmd should return string", func() {
+		cmd := redis.NewCmd("PING")
+		client.Process(cmd)
+		Expect(cmd.Err()).NotTo(HaveOccurred())
+		Expect(cmd.Val()).To(Equal("PONG"))
 	})
 
 	Describe("races", func() {

--- a/conn.go
+++ b/conn.go
@@ -67,7 +67,11 @@ func (cn *conn) init(opt *Options) error {
 func (cn *conn) writeCmds(cmds ...Cmder) error {
 	buf := cn.buf[:0]
 	for _, cmd := range cmds {
-		buf = appendArgs(buf, cmd.args())
+		var err error
+		buf, err = appendArgs(buf, cmd.args())
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err := cn.Write(buf)

--- a/multi.go
+++ b/multi.go
@@ -44,14 +44,22 @@ func (c *Multi) Close() error {
 }
 
 func (c *Multi) Watch(keys ...string) *StatusCmd {
-	args := append([]string{"WATCH"}, keys...)
+	args := make([]interface{}, 1+len(keys))
+	args[0] = "WATCH"
+	for i, key := range keys {
+		args[1+i] = key
+	}
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *Multi) Unwatch(keys ...string) *StatusCmd {
-	args := append([]string{"UNWATCH"}, keys...)
+	args := make([]interface{}, 1+len(keys))
+	args[0] = "UNWATCH"
+	for i, key := range keys {
+		args[1+i] = key
+	}
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd

--- a/parser.go
+++ b/parser.go
@@ -17,18 +17,201 @@ var (
 
 //------------------------------------------------------------------------------
 
-func appendArgs(buf []byte, args []string) []byte {
-	buf = append(buf, '*')
-	buf = strconv.AppendUint(buf, uint64(len(args)), 10)
-	buf = append(buf, '\r', '\n')
-	for _, arg := range args {
-		buf = append(buf, '$')
-		buf = strconv.AppendUint(buf, uint64(len(arg)), 10)
-		buf = append(buf, '\r', '\n')
-		buf = append(buf, arg...)
-		buf = append(buf, '\r', '\n')
+// Copy of encoding.BinaryMarshaler.
+type binaryMarshaler interface {
+	MarshalBinary() (data []byte, err error)
+}
+
+// Copy of encoding.BinaryUnmarshaler.
+type binaryUnmarshaler interface {
+	UnmarshalBinary(data []byte) error
+}
+
+func appendString(b []byte, s string) []byte {
+	b = append(b, '$')
+	b = strconv.AppendUint(b, uint64(len(s)), 10)
+	b = append(b, '\r', '\n')
+	b = append(b, s...)
+	b = append(b, '\r', '\n')
+	return b
+}
+
+func appendBytes(b, bb []byte) []byte {
+	b = append(b, '$')
+	b = strconv.AppendUint(b, uint64(len(bb)), 10)
+	b = append(b, '\r', '\n')
+	b = append(b, bb...)
+	b = append(b, '\r', '\n')
+	return b
+}
+
+func appendArg(b []byte, val interface{}) ([]byte, error) {
+	switch v := val.(type) {
+	case nil:
+		b = appendString(b, "")
+	case string:
+		b = appendString(b, v)
+	case []byte:
+		b = appendBytes(b, v)
+	case int:
+		b = appendString(b, formatInt(int64(v)))
+	case int8:
+		b = appendString(b, formatInt(int64(v)))
+	case int16:
+		b = appendString(b, formatInt(int64(v)))
+	case int32:
+		b = appendString(b, formatInt(int64(v)))
+	case int64:
+		b = appendString(b, formatInt(v))
+	case uint:
+		b = appendString(b, formatUint(uint64(v)))
+	case uint8:
+		b = appendString(b, formatUint(uint64(v)))
+	case uint16:
+		b = appendString(b, formatUint(uint64(v)))
+	case uint32:
+		b = appendString(b, formatUint(uint64(v)))
+	case uint64:
+		b = appendString(b, formatUint(v))
+	case float32:
+		b = appendString(b, formatFloat(float64(v)))
+	case float64:
+		b = appendString(b, formatFloat(v))
+	case bool:
+		if v {
+			b = appendString(b, "1")
+		} else {
+			b = appendString(b, "0")
+		}
+	default:
+		if bm, ok := val.(binaryMarshaler); ok {
+			bb, err := bm.MarshalBinary()
+			if err != nil {
+				return nil, err
+			}
+			b = appendBytes(b, bb)
+		} else {
+			err := fmt.Errorf(
+				"redis: can't marshal %T (consider implementing BinaryMarshaler)", val)
+			return nil, err
+		}
 	}
-	return buf
+	return b, nil
+}
+
+func appendArgs(b []byte, args []interface{}) ([]byte, error) {
+	b = append(b, '*')
+	b = strconv.AppendUint(b, uint64(len(args)), 10)
+	b = append(b, '\r', '\n')
+	for _, arg := range args {
+		var err error
+		b, err = appendArg(b, arg)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+func scan(b []byte, val interface{}) error {
+	switch v := val.(type) {
+	case nil:
+		return errorf("redis: Scan(nil)")
+	case *string:
+		*v = string(b)
+		return nil
+	case *[]byte:
+		*v = b
+		return nil
+	case *int:
+		var err error
+		*v, err = strconv.Atoi(string(b))
+		return err
+	case *int8:
+		n, err := strconv.ParseInt(string(b), 10, 8)
+		if err != nil {
+			return err
+		}
+		*v = int8(n)
+		return nil
+	case *int16:
+		n, err := strconv.ParseInt(string(b), 10, 16)
+		if err != nil {
+			return err
+		}
+		*v = int16(n)
+		return nil
+	case *int32:
+		n, err := strconv.ParseInt(string(b), 10, 16)
+		if err != nil {
+			return err
+		}
+		*v = int32(n)
+		return nil
+	case *int64:
+		n, err := strconv.ParseInt(string(b), 10, 64)
+		if err != nil {
+			return err
+		}
+		*v = n
+		return nil
+	case *uint:
+		n, err := strconv.ParseUint(string(b), 10, 64)
+		if err != nil {
+			return err
+		}
+		*v = uint(n)
+		return nil
+	case *uint8:
+		n, err := strconv.ParseUint(string(b), 10, 8)
+		if err != nil {
+			return err
+		}
+		*v = uint8(n)
+		return nil
+	case *uint16:
+		n, err := strconv.ParseUint(string(b), 10, 16)
+		if err != nil {
+			return err
+		}
+		*v = uint16(n)
+		return nil
+	case *uint32:
+		n, err := strconv.ParseUint(string(b), 10, 32)
+		if err != nil {
+			return err
+		}
+		*v = uint32(n)
+		return nil
+	case *uint64:
+		n, err := strconv.ParseUint(string(b), 10, 64)
+		if err != nil {
+			return err
+		}
+		*v = n
+		return nil
+	case *float32:
+		n, err := strconv.ParseFloat(string(b), 32)
+		if err != nil {
+			return err
+		}
+		*v = float32(n)
+		return err
+	case *float64:
+		var err error
+		*v, err = strconv.ParseFloat(string(b), 64)
+		return err
+	case *bool:
+		*v = len(b) == 1 && b[0] == '1'
+		return nil
+	default:
+		if bu, ok := val.(binaryUnmarshaler); ok {
+			return bu.UnmarshalBinary(b)
+		}
+		err := fmt.Errorf(
+			"redis: can't unmarshal %T (consider implementing BinaryUnmarshaler)", val)
+		return err
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -120,7 +303,7 @@ func parseReply(rd *bufio.Reader, p multiBulkParser) (interface{}, error) {
 	case '-':
 		return nil, errorf(string(line[1:]))
 	case '+':
-		return string(line[1:]), nil
+		return line[1:], nil
 	case ':':
 		v, err := strconv.ParseInt(string(line[1:]), 10, 64)
 		if err != nil {
@@ -141,7 +324,7 @@ func parseReply(rd *bufio.Reader, p multiBulkParser) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return string(b[:replyLen]), nil
+		return b[:replyLen], nil
 	case '*':
 		if len(line) == 3 && line[1] == '-' && line[2] == '1' {
 			return nil, Nil
@@ -166,7 +349,12 @@ func parseSlice(rd *bufio.Reader, n int64) (interface{}, error) {
 		} else if err != nil {
 			return nil, err
 		} else {
-			vals = append(vals, v)
+			switch vv := v.(type) {
+			case []byte:
+				vals = append(vals, string(vv))
+			default:
+				vals = append(vals, v)
+			}
 		}
 	}
 	return vals, nil
@@ -179,11 +367,11 @@ func parseStringSlice(rd *bufio.Reader, n int64) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		v, ok := viface.(string)
+		v, ok := viface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", viface)
 		}
-		vals = append(vals, v)
+		vals = append(vals, string(v))
 	}
 	return vals, nil
 }
@@ -211,7 +399,7 @@ func parseStringStringMap(rd *bufio.Reader, n int64) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		key, ok := keyiface.(string)
+		key, ok := keyiface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", keyiface)
 		}
@@ -220,12 +408,12 @@ func parseStringStringMap(rd *bufio.Reader, n int64) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		value, ok := valueiface.(string)
+		value, ok := valueiface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", valueiface)
 		}
 
-		m[key] = value
+		m[string(key)] = string(value)
 	}
 	return m, nil
 }
@@ -237,7 +425,7 @@ func parseStringIntMap(rd *bufio.Reader, n int64) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		key, ok := keyiface.(string)
+		key, ok := keyiface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", keyiface)
 		}
@@ -248,15 +436,14 @@ func parseStringIntMap(rd *bufio.Reader, n int64) (interface{}, error) {
 		}
 		switch value := valueiface.(type) {
 		case int64:
-			m[key] = value
+			m[string(key)] = value
 		case string:
-			m[key], err = strconv.ParseInt(value, 10, 64)
+			m[string(key)], err = strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("got %v, expected number", value)
 			}
 		default:
 			return nil, fmt.Errorf("got %T, expected number or string", valueiface)
-
 		}
 	}
 	return m, nil
@@ -271,21 +458,21 @@ func parseZSlice(rd *bufio.Reader, n int64) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		member, ok := memberiface.(string)
+		member, ok := memberiface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", memberiface)
 		}
-		z.Member = member
+		z.Member = string(member)
 
 		scoreiface, err := parseReply(rd, nil)
 		if err != nil {
 			return nil, err
 		}
-		scorestr, ok := scoreiface.(string)
+		scoreb, ok := scoreiface.([]byte)
 		if !ok {
 			return nil, fmt.Errorf("got %T, expected string", scoreiface)
 		}
-		score, err := strconv.ParseFloat(scorestr, 64)
+		score, err := strconv.ParseFloat(string(scoreb), 64)
 		if err != nil {
 			return nil, err
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -47,7 +47,7 @@ func benchmarkParseReply(b *testing.B, reply string, p multiBulkParser, wanterr 
 
 func BenchmarkAppendArgs(b *testing.B) {
 	buf := make([]byte, 0, 64)
-	args := []string{"hello", "world", "foo", "bar"}
+	args := []interface{}{"hello", "world", "foo", "bar"}
 	for i := 0; i < b.N; i++ {
 		appendArgs(buf, args)
 	}


### PR DESCRIPTION
Should make client a little bit more convenient to use. @dim?

Fixes https://github.com/go-redis/redis/issues/121. Before

```
BenchmarkRedisBytes	   10000	    120101 ns/op	   52809 B/op	      16 allocs/op
BenchmarkRedisSet	   30000	     45606 ns/op	   10666 B/op	       7 allocs/op
```

After

```
BenchmarkRedisBytes	   10000	    108434 ns/op	   32022 B/op	      21 allocs/op
BenchmarkRedisSet	   30000	     46389 ns/op	   10762 B/op	      10 allocs/op
```