### PR TITLE
Add MaxRetries to FailoverOptions

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -31,6 +31,8 @@ type FailoverOptions struct {
 	PoolSize    int
 	PoolTimeout time.Duration
 	IdleTimeout time.Duration
+
+	MaxRetries int
 }
 
 func (opt *FailoverOptions) options() *Options {
@@ -47,6 +49,8 @@ func (opt *FailoverOptions) options() *Options {
 		PoolSize:    opt.PoolSize,
 		PoolTimeout: opt.PoolTimeout,
 		IdleTimeout: opt.IdleTimeout,
+
+		MaxRetries: opt.MaxRetries,
 	}
 }
 


### PR DESCRIPTION
To follow on https://github.com/go-redis/redis/issues/148, my use case does'nt allow me to make use of redis cluster, so I make this small PR to fix my issue.