### PR TITLE
Disable unsafe.

### DIFF
--- a/unsafe.go
+++ b/unsafe.go
@@ -2,13 +2,6 @@
 
 package redis
 
-import (
-	"reflect"
-	"unsafe"
-)
-
 func bytesToString(b []byte) string {
-	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	strHeader := reflect.StringHeader{bytesHeader.Data, bytesHeader.Len}
-	return *(*string)(unsafe.Pointer(&strHeader))
+	return string(b)
 }


### PR DESCRIPTION
Hopefully this will fix

```
runtime: bad pointer in frame gopkg.in/redis%2ev3.(*BoolCmd).parseReply at 0xc840b9ec68: 0x6
fatal error: invalid stack pointer

runtime stack:
runtime.throw(0xbe16b0, 0x15)
        /usr/local/go/src/runtime/panic.go:527 +0x90 fp=0x7f92b2d288c0 sp=0x7f92b2d288a8
runtime.adjustpointers(0xc840b9ec08, 0x7f92b2d28a38, 0x7f92b2d28c28, 0xd8d130)
        /usr/local/go/src/runtime/stack1.go:438 +0x2d4 fp=0x7f92b2d289b8 sp=0x7f92b2d288c0
runtime.adjustframe(0x7f92b2d28b48, 0x7f92b2d28c28, 0x1)
        /usr/local/go/src/runtime/stack1.go:505 +0x1b5 fp=0x7f92b2d28a70 sp=0x7f92b2d289b8
runtime.gentraceback(0x412e40, 0xc840b9ebb8, 0x0, 0xc8202adc80, 0x0, 0x0, 0x7fffffff, 0xc980e0, 0x7f92b2d28c28, 0x0, ...)
```