### PR TITLE
Get rid of custom bufio package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ go:
   - tip
 
 install:
-  - go get gopkg.in/bufio.v1
   - go get gopkg.in/bsm/ratelimit.v1
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega

--- a/cluster_pipeline.go
+++ b/cluster_pipeline.go
@@ -99,7 +99,7 @@ func (pipe *ClusterPipeline) execClusterCmds(
 
 	var firstCmdErr error
 	for i, cmd := range cmds {
-		err := cmd.parseReply(cn.rd)
+		err := cmd.parseReply(cn)
 		if err == nil {
 			continue
 		}

--- a/multi.go
+++ b/multi.go
@@ -115,14 +115,14 @@ func (c *Multi) execCmds(cn *conn, cmds []Cmder) error {
 
 	// Parse queued replies.
 	for i := 0; i < cmdsLen; i++ {
-		if err := statusCmd.parseReply(cn.rd); err != nil {
+		if err := statusCmd.parseReply(cn); err != nil {
 			setCmdsErr(cmds[1:len(cmds)-1], err)
 			return err
 		}
 	}
 
 	// Parse number of replies.
-	line, err := readLine(cn.rd)
+	line, err := readLine(cn)
 	if err != nil {
 		setCmdsErr(cmds[1:len(cmds)-1], err)
 		return err
@@ -143,7 +143,7 @@ func (c *Multi) execCmds(cn *conn, cmds []Cmder) error {
 	// Loop starts from 1 to omit MULTI cmd.
 	for i := 1; i < cmdsLen; i++ {
 		cmd := cmds[i]
-		if err := cmd.parseReply(cn.rd); err != nil {
+		if err := cmd.parseReply(cn); err != nil {
 			if firstCmdErr == nil {
 				firstCmdErr = err
 			}

--- a/pipeline.go
+++ b/pipeline.go
@@ -97,7 +97,7 @@ func execCmds(cn *conn, cmds []Cmder) ([]Cmder, error) {
 	var firstCmdErr error
 	var failedCmds []Cmder
 	for _, cmd := range cmds {
-		err := cmd.parseReply(cn.rd)
+		err := cmd.parseReply(cn)
 		if err == nil {
 			continue
 		}

--- a/pool.go
+++ b/pool.go
@@ -243,7 +243,7 @@ func (p *connPool) Get() (*conn, error) {
 
 func (p *connPool) Put(cn *conn) error {
 	if cn.rd.Buffered() != 0 {
-		b, _ := cn.rd.ReadN(cn.rd.Buffered())
+		b, _ := cn.rd.Peek(cn.rd.Buffered())
 		log.Printf("redis: connection has unread data: %q", b)
 		return p.Remove(cn)
 	}

--- a/pubsub.go
+++ b/pubsub.go
@@ -146,7 +146,7 @@ func (c *PubSub) ReceiveTimeout(timeout time.Duration) (interface{}, error) {
 	cn.ReadTimeout = timeout
 
 	cmd := NewSliceCmd()
-	if err := cmd.parseReply(cn.rd); err != nil {
+	if err := cmd.parseReply(cn); err != nil {
 		return nil, err
 	}
 	return newMessage(cmd.Val())

--- a/redis.go
+++ b/redis.go
@@ -69,7 +69,7 @@ func (c *baseClient) process(cmd Cmder) {
 			return
 		}
 
-		err = cmd.parseReply(cn.rd)
+		err = cmd.parseReply(cn)
 		c.putConn(cn, err)
 		if shouldRetry(err) {
 			continue


### PR DESCRIPTION
```
benchmark                         old ns/op     new ns/op     delta
BenchmarkParseReplyStatus-4       104           106           +1.92%
BenchmarkParseReplyInt-4          139           142           +2.16%
BenchmarkParseReplyError-4        202           208           +2.97%
BenchmarkParseReplyString-4       180           202           +12.22%
BenchmarkParseReplySlice-4        889           949           +6.75%
BenchmarkAppendArgs-4             228           228           +0.00%
BenchmarkRedisClusterPing-4       11370         11477         +0.94%
BenchmarkPool-4                   215           213           -0.93%
BenchmarkRedisPing-4              7073          6933          -1.98%
BenchmarkRedisSet-4               20163         19978         -0.92%
BenchmarkRedisGetNil-4            7055          7192          +1.94%
BenchmarkRedisSetGet64Bytes-4     15489         15449         -0.26%
BenchmarkRedisSetGet1KB-4         19774         18265         -7.63%
BenchmarkRedisSetGet10KB-4        69657         54929         -21.14%
BenchmarkRedisSetGet1MB-4         3493441       2901501       -16.94%
BenchmarkRedisSetGetBytes-4       53624         40511         -24.45%
BenchmarkRedisMGet-4              7331          7449          +1.61%
BenchmarkSetExpire-4              15758         15555         -1.29%
BenchmarkPipeline-4               9800          9720          -0.82%
BenchmarkZAdd-4                   8150          8394          +2.99%

benchmark                         old allocs     new allocs     delta
BenchmarkParseReplyStatus-4       1              1              +0.00%
BenchmarkParseReplyInt-4          2              2              +0.00%
BenchmarkParseReplyError-4        2              2              +0.00%
BenchmarkParseReplyString-4       2              2              +0.00%
BenchmarkParseReplySlice-4        11             11             +0.00%
BenchmarkAppendArgs-4             0              0              +0.00%
BenchmarkRedisClusterPing-4       5              5              +0.00%
BenchmarkPool-4                   0              0              +0.00%
BenchmarkRedisPing-4              5              5              +0.00%
BenchmarkRedisSet-4               8              8              +0.00%
BenchmarkRedisGetNil-4            5              5              +0.00%
BenchmarkRedisSetGet64Bytes-4     16             15             -6.25%
BenchmarkRedisSetGet1KB-4         16             15             -6.25%
BenchmarkRedisSetGet10KB-4        17             16             -5.88%
BenchmarkRedisSetGet1MB-4         37             31             -16.22%
BenchmarkRedisSetGetBytes-4       16             15             -6.25%
BenchmarkRedisMGet-4              16             16             +0.00%
BenchmarkSetExpire-4              15             15             +0.00%
BenchmarkPipeline-4               20             19             -5.00%
BenchmarkZAdd-4                   10             10             +0.00%

benchmark                         old bytes     new bytes     delta
BenchmarkParseReplyStatus-4       32            32            +0.00%
BenchmarkParseReplyInt-4          32            32            +0.00%
BenchmarkParseReplyError-4        32            32            +0.00%
BenchmarkParseReplyString-4       48            48            +0.00%
BenchmarkParseReplySlice-4        240           240           +0.00%
BenchmarkAppendArgs-4             0             0             +0.00%
BenchmarkRedisClusterPing-4       160           161           +0.63%
BenchmarkPool-4                   0             0             +0.00%
BenchmarkRedisPing-4              160           160           +0.00%
BenchmarkRedisSet-4               10754         10754         +0.00%
BenchmarkRedisGetNil-4            176           176           +0.00%
BenchmarkRedisSetGet64Bytes-4     720           592           -17.78%
BenchmarkRedisSetGet1KB-4         3664          2512          -31.44%
BenchmarkRedisSetGet10KB-4        42464         31964         -24.73%
BenchmarkRedisSetGet1MB-4         4212478       3163646       -24.90%
BenchmarkRedisSetGetBytes-4       31979         21477         -32.84%
BenchmarkRedisMGet-4              432           432           +0.00%
BenchmarkSetExpire-4              480           480           +0.00%
BenchmarkPipeline-4               992           864           -12.90%
BenchmarkZAdd-4                   288           288           +0.00%
```