### PR TITLE
Enable unsafe.

### DIFF
--- a/unsafe.go
+++ b/unsafe.go
@@ -2,6 +2,13 @@
 
 package redis
 
+import (
+	"reflect"
+	"unsafe"
+)
+
 func bytesToString(b []byte) string {
-	return string(b)
+	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	strHeader := reflect.StringHeader{bytesHeader.Data, bytesHeader.Len}
+	return *(*string)(unsafe.Pointer(&strHeader))
 }


### PR DESCRIPTION
Reverts https://github.com/go-redis/redis/pull/157

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkParseReplyStatus-4       108           105           -2.78%
BenchmarkParseReplyInt-4          148           104           -29.73%
BenchmarkParseReplyError-4        211           211           +0.00%
BenchmarkParseReplyString-4       206           163           -20.87%
BenchmarkParseReplySlice-4        962           825           -14.24%
BenchmarkAppendArgs-4             234           234           +0.00%
BenchmarkRedisClusterPing-4       11694         11125         -4.87%
BenchmarkPool-4                   198           168           -15.15%
BenchmarkRedisPing-4              7222          7349          +1.76%
BenchmarkRedisSet-4               19931         19725         -1.03%
BenchmarkRedisGetNil-4            7418          7219          -2.68%
BenchmarkRedisSetGet64Bytes-4     15916         15682         -1.47%
BenchmarkRedisSetGet1KB-4         18826         16984         -9.78%
BenchmarkRedisSetGet10KB-4        52723         40823         -22.57%
BenchmarkRedisSetGet1MB-4         2518158       1614401       -35.89%
BenchmarkRedisSetGetBytes-4       41362         41162         -0.48%
BenchmarkRedisMGet-4              7863          7821          -0.53%
BenchmarkSetExpire-4              17238         16440         -4.63%
BenchmarkPipeline-4               10620         9859          -7.17%
BenchmarkZAdd-4                   8754          8685          -0.79%

benchmark                         old allocs     new allocs     delta
BenchmarkParseReplyStatus-4       1              1              +0.00%
BenchmarkParseReplyInt-4          2              1              -50.00%
BenchmarkParseReplyError-4        2              2              +0.00%
BenchmarkParseReplyString-4       2              1              -50.00%
BenchmarkParseReplySlice-4        11             8              -27.27%
BenchmarkAppendArgs-4             0              0              +0.00%
BenchmarkRedisClusterPing-4       5              5              +0.00%
BenchmarkPool-4                   0              0              +0.00%
BenchmarkRedisPing-4              5              5              +0.00%
BenchmarkRedisSet-4               8              8              +0.00%
BenchmarkRedisGetNil-4            5              5              +0.00%
BenchmarkRedisSetGet64Bytes-4     15             13             -13.33%
BenchmarkRedisSetGet1KB-4         15             13             -13.33%
BenchmarkRedisSetGet10KB-4        16             14             -12.50%
BenchmarkRedisSetGet1MB-4         25             17             -32.00%
BenchmarkRedisSetGetBytes-4       15             14             -6.67%
BenchmarkRedisMGet-4              16             13             -18.75%
BenchmarkSetExpire-4              15             14             -6.67%
BenchmarkPipeline-4               19             18             -5.26%
BenchmarkZAdd-4                   10             9              -10.00%

benchmark                         old bytes     new bytes     delta
BenchmarkParseReplyStatus-4       32            32            +0.00%
BenchmarkParseReplyInt-4          32            16            -50.00%
BenchmarkParseReplyError-4        32            32            +0.00%
BenchmarkParseReplyString-4       48            32            -33.33%
BenchmarkParseReplySlice-4        240           192           -20.00%
BenchmarkAppendArgs-4             0             0             +0.00%
BenchmarkRedisClusterPing-4       160           160           +0.00%
BenchmarkPool-4                   0             0             +0.00%
BenchmarkRedisPing-4              160           160           +0.00%
BenchmarkRedisSet-4               10753         10753         +0.00%
BenchmarkRedisGetNil-4            176           176           +0.00%
BenchmarkRedisSetGet64Bytes-4     592           512           -13.51%
BenchmarkRedisSetGet1KB-4         2512          1472          -41.40%
BenchmarkRedisSetGet10KB-4        31959         21443         -32.90%
BenchmarkRedisSetGet1MB-4         3163258       2114221       -33.16%
BenchmarkRedisSetGetBytes-4       21475         21459         -0.07%
BenchmarkRedisMGet-4              432           384           -11.11%
BenchmarkSetExpire-4              480           464           -3.33%
BenchmarkPipeline-4               864           848           -1.85%
BenchmarkZAdd-4                   288           272           -5.56%
```