### PR TITLE
Implement SetName and GetName

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1367,6 +1367,18 @@ func (c *commandable) ClientPause(dur time.Duration) *BoolCmd {
 	return cmd
 }
 
+func (c *commandable) SetName(name string) *StatusCmd {
+	cmd := NewStatusCmd("CLIENT", "SETNAME", name)
+	c.Process(cmd)
+	return cmd
+}
+
+func (c *Client) GetName() *StringCmd {
+	cmd := NewStringCmd("CLIENT", "GETNAME")
+	c.Process(cmd)
+	return cmd
+}
+
 func (c *commandable) ConfigGet(parameter string) *SliceCmd {
 	cmd := NewSliceCmd("CONFIG", "GET", parameter)
 	cmd._clusterKeyPos = 0

--- a/commands_test.go
+++ b/commands_test.go
@@ -90,6 +90,16 @@ var _ = Describe("Commands", func() {
 			}, "1s").ShouldNot(HaveOccurred())
 		})
 
+		It("should SetName", func() {
+			isSet, err := client.SetName("theclientname").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isSet).To(Equal("OK"))
+
+			val, err := client.GetName().Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("theclientname"))
+		})
+
 		It("should ConfigGet", func() {
 			r := client.ConfigGet("*")
 			Expect(r.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION
Allows setting and getting the client connection name.

http://redis.io/commands/client-setname
http://redis.io/commands/client-getname