### PR TITLE
Fix names and add comments.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1367,13 +1367,15 @@ func (c *commandable) ClientPause(dur time.Duration) *BoolCmd {
 	return cmd
 }
 
-func (c *commandable) SetName(name string) *StatusCmd {
-	cmd := NewStatusCmd("CLIENT", "SETNAME", name)
+// ClientSetName assigns a name to the one of many connections in the pool.
+func (c *commandable) ClientSetName(name string) *BoolCmd {
+	cmd := NewBoolCmd("CLIENT", "SETNAME", name)
 	c.Process(cmd)
 	return cmd
 }
 
-func (c *Client) GetName() *StringCmd {
+// ClientGetName returns the name of the one of many connections in the pool.
+func (c *Client) ClientGetName() *StringCmd {
 	cmd := NewStringCmd("CLIENT", "GETNAME")
 	c.Process(cmd)
 	return cmd

--- a/commands_test.go
+++ b/commands_test.go
@@ -90,12 +90,12 @@ var _ = Describe("Commands", func() {
 			}, "1s").ShouldNot(HaveOccurred())
 		})
 
-		It("should SetName", func() {
-			isSet, err := client.SetName("theclientname").Result()
+		It("should ClientSetName and ClientGetName", func() {
+			isSet, err := client.ClientSetName("theclientname").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(isSet).To(Equal("OK"))
+			Expect(isSet).To(BeTrue())
 
-			val, err := client.GetName().Result()
+			val, err := client.ClientGetName().Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("theclientname"))
 		})


### PR DESCRIPTION
Follow-up for https://github.com/go-redis/redis/pull/178. I could add something like `client.Conn()` that returns `*redis.Client` that operates only on 1 connection, but I think it will bring more confusion than it can possibly solve.