### PR TITLE
fix panic on ReceiveMessage from closed pubsub

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -78,7 +78,7 @@ func (c *ClusterClient) getClient(addr string) (*Client, error) {
 	c.clientsMx.Lock()
 	if c.closed {
 		c.clientsMx.Unlock()
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 
 	client, ok = c.clients[addr]

--- a/cluster_pipeline.go
+++ b/cluster_pipeline.go
@@ -28,7 +28,7 @@ func (pipe *ClusterPipeline) process(cmd Cmder) {
 // Discard resets the pipeline and discards queued commands.
 func (pipe *ClusterPipeline) Discard() error {
 	if pipe.closed {
-		return errClosed
+		return ErrClientClosed
 	}
 	pipe.cmds = pipe.cmds[:0]
 	return nil
@@ -36,7 +36,7 @@ func (pipe *ClusterPipeline) Discard() error {
 
 func (pipe *ClusterPipeline) Exec() (cmds []Cmder, retErr error) {
 	if pipe.closed {
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 	if len(pipe.cmds) == 0 {
 		return []Cmder{}, nil

--- a/multi.go
+++ b/multi.go
@@ -120,7 +120,7 @@ func (c *Multi) Discard() error {
 // failed command or nil.
 func (c *Multi) Exec(f func() error) ([]Cmder, error) {
 	if c.closed {
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 
 	c.cmds = []Cmder{NewStatusCmd("MULTI")}

--- a/pipeline.go
+++ b/pipeline.go
@@ -60,7 +60,7 @@ func (pipe *Pipeline) Discard() error {
 	defer pipe.mu.Unlock()
 	pipe.mu.Lock()
 	if pipe.isClosed() {
-		return errClosed
+		return ErrClientClosed
 	}
 	pipe.cmds = pipe.cmds[:0]
 	return nil
@@ -73,7 +73,7 @@ func (pipe *Pipeline) Discard() error {
 // command if any.
 func (pipe *Pipeline) Exec() (cmds []Cmder, retErr error) {
 	if pipe.isClosed() {
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 
 	defer pipe.mu.Unlock()

--- a/ring.go
+++ b/ring.go
@@ -148,7 +148,7 @@ func (ring *Ring) getClient(key string) (*Client, error) {
 	ring.mx.RLock()
 
 	if ring.closed {
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 
 	name := ring.hash.Get(hashKey(key))
@@ -276,7 +276,7 @@ func (pipe *RingPipeline) process(cmd Cmder) {
 // Discard resets the pipeline and discards queued commands.
 func (pipe *RingPipeline) Discard() error {
 	if pipe.closed {
-		return errClosed
+		return ErrClientClosed
 	}
 	pipe.cmds = pipe.cmds[:0]
 	return nil
@@ -286,7 +286,7 @@ func (pipe *RingPipeline) Discard() error {
 // command if any.
 func (pipe *RingPipeline) Exec() (cmds []Cmder, retErr error) {
 	if pipe.closed {
-		return nil, errClosed
+		return nil, ErrClientClosed
 	}
 	if len(pipe.cmds) == 0 {
 		return pipe.cmds, nil


### PR DESCRIPTION
This fixes #198.

Usage:

	package main

	import (
		"time"

		"gopkg.in/redis.v3"
	)

	func main() {
		connection := redis.NewClient(&redis.Options{Addr: "127.0.0.1:6379"})
		subscribe, err := connection.Subscribe("test")
		if err != nil {
			return
		}

		go func() {
			time.Sleep(time.Second)
			subscribe.Close()
		}()

		for {
			_, err := subscribe.ReceiveMessage()
			if err == redis.ErrClientClosed {
				return
			}
		}
	}