### PR TITLE
Add `func ClientForKey(string) (*Client, error)` for ClusterClient.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -72,6 +72,15 @@ func (c *ClusterClient) Close() error {
 	return nil
 }
 
+// Get all clients for some special operate like send FLUSHDB to all nodes
+func (c *ClusterClient) AllClients() []*Client {
+	clients := []*Client{}
+	for _, cli := range c.clients {
+		clients = append(clients, cli)
+	}
+	return clients
+}
+
 // getClient returns a Client for a given address.
 func (c *ClusterClient) getClient(addr string) (*Client, error) {
 	if addr == "" {

--- a/cluster.go
+++ b/cluster.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"strings"
@@ -42,6 +43,16 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	client.reloadSlots()
 	go client.reaper()
 	return client
+}
+
+// Get a single client connection for a specified key. Support Multi with
+// cluster client.
+func (c *ClusterClient) ClientForKey(key string) (*Client, error) {
+	addr := c.slotMasterAddr(hashSlot(key))
+	if addr == "" {
+		return nil, fmt.Errorf("client for `key` %s not found")
+	}
+	return c.getClient(addr)
 }
 
 // Close closes the cluster client, releasing any open resources.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -321,6 +321,10 @@ var _ = Describe("Cluster", func() {
 		It("should return a client for specify key", func() {
 			client.ClientForKey("test_key")
 		})
+
+		It("should get all active nodes", func() {
+			client.AllClients()
+		})
 	})
 })
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -317,6 +317,10 @@ var _ = Describe("Cluster", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("MOVED"))
 		})
+
+		It("should return a client for specify key", func() {
+			client.ClientForKey("test_key")
+		})
 	})
 })
 


### PR DESCRIPTION
patch for #203 