### PR TITLE
Support multiple keys for the PFCOUNT command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1340,8 +1340,13 @@ func (c *commandable) PFAdd(key string, fields ...string) *IntCmd {
 	return cmd
 }
 
-func (c *commandable) PFCount(key string) *IntCmd {
-	cmd := NewIntCmd("PFCOUNT", key)
+func (c *commandable) PFCount(keys ...string) *IntCmd {
+	args := make([]interface{}, 1+len(keys))
+	args[0] = "PFCOUNT"
+	for i, key := range keys {
+		args[1+i] = key
+	}
+	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1203,6 +1203,10 @@ var _ = Describe("Commands", func() {
 			pfCount = client.PFCount("hllMerged")
 			Expect(pfCount.Err()).NotTo(HaveOccurred())
 			Expect(pfCount.Val()).To(Equal(int64(10)))
+
+			pfCount = client.PFCount("hll1", "hll2")
+			Expect(pfCount.Err()).NotTo(HaveOccurred())
+			Expect(pfCount.Val()).To(Equal(int64(10)))
 		})
 	})
 


### PR DESCRIPTION
From http://redis.io/commands/pfcount:
> When called with multiple keys, returns the approximated cardinality of the union of the HyperLogLogs passed, by internally merging the HyperLogLogs stored at the provided keys into a temporary HyperLogLog.