### PR TITLE
Bugfix: pubsub/psubscribe should register a pattern rather than channel

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -74,7 +74,7 @@ func (c *PubSub) Subscribe(channels ...string) error {
 func (c *PubSub) PSubscribe(patterns ...string) error {
 	err := c.subscribe("PSUBSCRIBE", patterns...)
 	if err == nil {
-		c.channels = append(c.channels, patterns...)
+		c.patterns = append(c.patterns, patterns...)
 	}
 	return err
 }


### PR DESCRIPTION
Noticed that when the connection got interrupted, my PSUBSCRIBE pubsub connection had turned into a SUBSCRIBE pubsub connection. I believe this fixes it.