### PR TITLE
Close connection on network timeout.

### DIFF
--- a/cluster_pipeline.go
+++ b/cluster_pipeline.go
@@ -79,7 +79,7 @@ func (pipe *ClusterPipeline) Exec() (cmds []Cmder, retErr error) {
 			if err != nil {
 				retErr = err
 			}
-			client.putConn(cn, err)
+			client.putConn(cn, err, false)
 		}
 
 		cmdsMap = failedCmds

--- a/command.go
+++ b/command.go
@@ -32,7 +32,6 @@ type Cmder interface {
 	setErr(error)
 	reset()
 
-	writeTimeout() *time.Duration
 	readTimeout() *time.Duration
 	clusterKey() string
 
@@ -82,7 +81,7 @@ type baseCmd struct {
 
 	_clusterKeyPos int
 
-	_writeTimeout, _readTimeout *time.Duration
+	_readTimeout *time.Duration
 }
 
 func (cmd *baseCmd) Err() error {
@@ -104,19 +103,11 @@ func (cmd *baseCmd) setReadTimeout(d time.Duration) {
 	cmd._readTimeout = &d
 }
 
-func (cmd *baseCmd) writeTimeout() *time.Duration {
-	return cmd._writeTimeout
-}
-
 func (cmd *baseCmd) clusterKey() string {
 	if cmd._clusterKeyPos > 0 && cmd._clusterKeyPos < len(cmd._args) {
 		return fmt.Sprint(cmd._args[cmd._clusterKeyPos])
 	}
 	return ""
-}
-
-func (cmd *baseCmd) setWriteTimeout(d time.Duration) {
-	cmd._writeTimeout = &d
 }
 
 func (cmd *baseCmd) setErr(e error) {

--- a/commands_test.go
+++ b/commands_test.go
@@ -1303,6 +1303,9 @@ var _ = Describe("Commands", func() {
 			bLPop := client.BLPop(time.Second, "list1")
 			Expect(bLPop.Val()).To(BeNil())
 			Expect(bLPop.Err()).To(Equal(redis.Nil))
+
+			stats := client.Pool().Stats()
+			Expect(stats.Requests - stats.Hits - stats.Waits).To(Equal(uint32(1)))
 		})
 
 		It("should BRPop", func() {

--- a/error.go
+++ b/error.go
@@ -33,15 +33,17 @@ func isNetworkError(err error) bool {
 	return ok
 }
 
-func isBadConn(err error) bool {
+func isBadConn(err error, allowTimeout bool) bool {
 	if err == nil {
 		return false
 	}
 	if _, ok := err.(redisError); ok {
 		return false
 	}
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return false
+	if allowTimeout {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			return false
+		}
 	}
 	return true
 }

--- a/export_test.go
+++ b/export_test.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"net"
-	"sync"
 	"time"
 )
 
@@ -20,18 +19,12 @@ func (cn *conn) SetNetConn(netcn net.Conn) {
 	cn.netcn = netcn
 }
 
-var timeMu sync.Mutex
-
 func SetTime(tm time.Time) {
-	timeMu.Lock()
 	now = func() time.Time {
 		return tm
 	}
-	timeMu.Unlock()
 }
 
 func RestoreTime() {
-	timeMu.Lock()
 	now = time.Now
-	timeMu.Unlock()
 }

--- a/export_test.go
+++ b/export_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"net"
+	"sync"
 	"time"
 )
 
@@ -19,12 +20,18 @@ func (cn *conn) SetNetConn(netcn net.Conn) {
 	cn.netcn = netcn
 }
 
+var timeMu sync.Mutex
+
 func SetTime(tm time.Time) {
+	timeMu.Lock()
 	now = func() time.Time {
 		return tm
 	}
+	timeMu.Unlock()
 }
 
 func RestoreTime() {
+	timeMu.Lock()
 	now = time.Now
+	timeMu.Unlock()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -98,9 +98,10 @@ func TestGinkgoSuite(t *testing.T) {
 
 //------------------------------------------------------------------------------
 
-func eventually(fn func() error, timeout time.Duration) (err error) {
+func eventually(fn func() error, timeout time.Duration) error {
 	done := make(chan struct{})
 	var exit int32
+	var err error
 	go func() {
 		for atomic.LoadInt32(&exit) == 0 {
 			err = fn()

--- a/multi.go
+++ b/multi.go
@@ -133,7 +133,7 @@ func (c *Multi) Exec(f func() error) ([]Cmder, error) {
 	}
 
 	err = c.execCmds(cn, cmds)
-	c.base.putConn(cn, err)
+	c.base.putConn(cn, err, false)
 	return retCmds, err
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -98,7 +98,7 @@ func (pipe *Pipeline) Exec() (cmds []Cmder, retErr error) {
 			resetCmds(failedCmds)
 		}
 		failedCmds, err = execCmds(cn, failedCmds)
-		pipe.client.putConn(cn, err)
+		pipe.client.putConn(cn, err, false)
 		if err != nil && retErr == nil {
 			retErr = err
 		}

--- a/pool.go
+++ b/pool.go
@@ -18,7 +18,8 @@ var (
 // PoolStats contains pool state information and accumulated stats.
 type PoolStats struct {
 	Requests uint32 // number of times a connection was requested by the pool
-	Waits    uint32 // number of times our pool had to wait for a connection
+	Hits     uint32 // number of times free connection was found in the pool
+	Waits    uint32 // number of times the pool had to wait for a connection
 	Timeouts uint32 // number of times a wait timeout occurred
 
 	TotalConns uint32 // the number of total connections in the pool
@@ -241,6 +242,7 @@ func (p *connPool) Get() (cn *conn, isNew bool, err error) {
 
 	// Fetch first non-idle connection, if available.
 	if cn = p.First(); cn != nil {
+		atomic.AddUint32(&p.stats.Hits, 1)
 		return
 	}
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -123,6 +123,12 @@ var _ = Describe("pool", func() {
 		pool := client.Pool()
 		Expect(pool.Len()).To(Equal(1))
 		Expect(pool.FreeLen()).To(Equal(1))
+
+		stats := pool.Stats()
+		Expect(stats.Requests).To(Equal(uint32(3)))
+		Expect(stats.Hits).To(Equal(uint32(2)))
+		Expect(stats.Waits).To(Equal(uint32(0)))
+		Expect(stats.Timeouts).To(Equal(uint32(0)))
 	})
 
 	It("should reuse connections", func() {
@@ -135,6 +141,12 @@ var _ = Describe("pool", func() {
 		pool := client.Pool()
 		Expect(pool.Len()).To(Equal(1))
 		Expect(pool.FreeLen()).To(Equal(1))
+
+		stats := pool.Stats()
+		Expect(stats.Requests).To(Equal(uint32(100)))
+		Expect(stats.Hits).To(Equal(uint32(99)))
+		Expect(stats.Waits).To(Equal(uint32(0)))
+		Expect(stats.Timeouts).To(Equal(uint32(0)))
 	})
 
 	It("should unblock client when connection is removed", func() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -297,7 +297,7 @@ func (c *PubSub) ReceiveMessage() (*Message, error) {
 }
 
 func (c *PubSub) putConn(cn *conn, err error) {
-	if !c.base.putConn(cn, err) {
+	if !c.base.putConn(cn, err, true) {
 		c.nsub = 0
 	}
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -245,10 +245,11 @@ func (c *PubSub) Receive() (interface{}, error) {
 	return c.ReceiveTimeout(0)
 }
 
-// ReceiveMessage returns a message or error. It automatically
-// reconnects to Redis in case of network errors.
+// ReceiveMessage returns a Message or error ignoring Subscription or Pong
+// messages. It automatically reconnects to Redis Server and resubscribes
+// to channels in case of network errors.
 func (c *PubSub) ReceiveMessage() (*Message, error) {
-	var errNum int
+	var errNum uint
 	for {
 		msgi, err := c.ReceiveTimeout(5 * time.Second)
 		if err != nil {
@@ -260,10 +261,9 @@ func (c *PubSub) ReceiveMessage() (*Message, error) {
 			if errNum < 3 {
 				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 					err := c.Ping("")
-					if err == nil {
-						continue
+					if err != nil {
+						Logger.Printf("PubSub.Ping failed: %s", err)
 					}
-					Logger.Printf("PubSub.Ping failed: %s", err)
 				}
 			} else {
 				// 3 consequent errors - connection is bad

--- a/ring.go
+++ b/ring.go
@@ -326,7 +326,7 @@ func (pipe *RingPipeline) Exec() (cmds []Cmder, retErr error) {
 				resetCmds(cmds)
 			}
 			failedCmds, err := execCmds(cn, cmds)
-			client.putConn(cn, err)
+			client.putConn(cn, err, false)
 			if err != nil && retErr == nil {
 				retErr = err
 			}


### PR DESCRIPTION
WIth this PR go-redis closes connection on network timeout error except 2 cases:
- PubSub.ReceiveTimeout()
- Migrate, BLPop, BRPop, BRPopLPush when they are used with timeout > 0

But I still have to write tests...

Fixes https://github.com/go-redis/redis/issues/262 and https://github.com/go-redis/redis/issues/267

/cc @dim @FZambia