### PR TITLE
Correct method accessors

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -583,7 +583,7 @@ func (c *commandable) SetNX(key string, value interface{}, expiration time.Durat
 // Redis `SET key value [expiration] XX` command.
 //
 // Zero expiration means the key has no expiration time.
-func (c *Client) SetXX(key string, value interface{}, expiration time.Duration) *BoolCmd {
+func (c *commandable) SetXX(key string, value interface{}, expiration time.Duration) *BoolCmd {
 	var cmd *BoolCmd
 	if usePrecise(expiration) {
 		cmd = NewBoolCmd("SET", key, value, "PX", formatMs(expiration), "XX")
@@ -1282,7 +1282,7 @@ func (c *commandable) ZRevRangeByScore(key string, opt ZRangeByScore) *StringSli
 	return c.zRevRangeBy("ZREVRANGEBYSCORE", key, opt)
 }
 
-func (c commandable) ZRevRangeByLex(key string, opt ZRangeByScore) *StringSliceCmd {
+func (c *commandable) ZRevRangeByLex(key string, opt ZRangeByScore) *StringSliceCmd {
 	return c.zRevRangeBy("ZREVRANGEBYLEX", key, opt)
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,7 +11,7 @@ import (
 type Pipeline struct {
 	commandable
 
-	client *baseClient
+	client baseClient
 
 	mu   sync.Mutex // protects cmds
 	cmds []Cmder

--- a/redis.go
+++ b/redis.go
@@ -183,12 +183,12 @@ func (opt *Options) getIdleTimeout() time.Duration {
 // underlying connections. It's safe for concurrent use by multiple
 // goroutines.
 type Client struct {
-	*baseClient
+	baseClient
 	commandable
 }
 
 func newClient(opt *Options, pool pool) *Client {
-	base := &baseClient{opt: opt, connPool: pool}
+	base := baseClient{opt: opt, connPool: pool}
 	return &Client{
 		baseClient:  base,
 		commandable: commandable{process: base.process},


### PR DESCRIPTION
Minor but nevertheless:

* the `SetXX` method was only on `Client`, not on `commandable`
* some methods we exposed on the element and not the pointer: 
  * https://godoc.org/gopkg.in/redis.v3#Client.Close
  * https://godoc.org/gopkg.in/redis.v3#Client.String 
  * https://godoc.org/gopkg.in/redis.v3#Client.ZRevRangeByLex
