### PR TITLE
Minimise connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -64,6 +64,10 @@ func (cn *conn) init(opt *Options) error {
 	return nil
 }
 
+func (cn *conn) IsStale(timeout time.Duration) bool {
+	return timeout > 0 && time.Since(cn.UsedAt) > timeout
+}
+
 func (cn *conn) writeCmds(cmds ...Cmder) error {
 	buf := cn.buf[:0]
 	for _, cmd := range cmds {

--- a/pool.go
+++ b/pool.go
@@ -37,7 +37,7 @@ type pool interface {
 	Stats() *PoolStats
 }
 
-// connStack is used as a LIFO to maintain free connection
+// connStack is used as a LIFO to maintain free connections
 type connStack struct {
 	cns  []*conn
 	free chan struct{}
@@ -67,7 +67,8 @@ func (s *connStack) ShiftStale(timeout time.Duration) *conn {
 		defer s.mx.Unlock()
 
 		if cn := s.cns[0]; cn.IsStale(timeout) {
-			s.cns = s.cns[1:]
+			copy(s.cns, s.cns[1:])
+			s.cns = s.cns[:len(s.cns)-1]
 			return cn
 		}
 		return nil


### PR DESCRIPTION
So this one serves two purposes: 

1. The connection pool currently slows down substantially, when many connections are used. If we raise the PoolSize above a certain threshold, we end up with more and more pool timeouts. Our timeout settings are relatively low, but increasing the pool size seems to make matters only worse. I suspect it's due to the iterations on `connList.Remove` and `connList.Replace`. As these happen within a mutex, a failing connection effectively takes down everything else, causing the pool to block. I have turned the slice into a map, which should reduce the time spent within the lock.
2. We are using channels to hold our `freeConn` and they are FIFO by design. It also means that we round-robin across all our connections in the pool and large pools never actually shrink. I have replaced the channel with a LIFO stack which forces us to reuse connections that were most recently returned and reap unused connections.

I would also like to default `IdleTimeout` to something like `time.Hour`, if not provided.