### PR TITLE
Optimize pool.Remove.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -278,8 +278,8 @@ func BenchmarkZAdd(b *testing.B) {
 }
 
 func benchmarkPoolGetPut(b *testing.B, poolSize int) {
-	dial := func() (*pool.Conn, error) {
-		return pool.NewConn(&net.TCPConn{}), nil
+	dial := func() (net.Conn, error) {
+		return &net.TCPConn{}, nil
 	}
 	pool := pool.NewConnPool(dial, poolSize, time.Second, 0)
 
@@ -311,8 +311,8 @@ func BenchmarkPoolGetPut1000Conns(b *testing.B) {
 }
 
 func benchmarkPoolGetRemove(b *testing.B, poolSize int) {
-	dial := func() (*pool.Conn, error) {
-		return pool.NewConn(&net.TCPConn{}), nil
+	dial := func() (net.Conn, error) {
+		return &net.TCPConn{}, nil
 	}
 	pool := pool.NewConnPool(dial, poolSize, time.Second, 0)
 	removeReason := errors.New("benchmark")
@@ -325,7 +325,7 @@ func benchmarkPoolGetRemove(b *testing.B, poolSize int) {
 			if err != nil {
 				b.Fatalf("no error expected on pool.Get but received: %s", err.Error())
 			}
-			if err = pool.Remove(conn, removeReason); err != nil {
+			if err = pool.Replace(conn, removeReason); err != nil {
 				b.Fatalf("no error expected on pool.Remove but received: %s", err.Error())
 			}
 		}

--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -25,7 +25,7 @@ func (p *SingleConnPool) Put(cn *Conn) error {
 	return nil
 }
 
-func (p *SingleConnPool) Remove(cn *Conn, _ error) error {
+func (p *SingleConnPool) Replace(cn *Conn, _ error) error {
 	if p.cn != cn {
 		panic("p.cn != cn")
 	}

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -67,13 +67,13 @@ func (p *StickyConnPool) Put(cn *Conn) error {
 	return nil
 }
 
-func (p *StickyConnPool) remove(reason error) error {
-	err := p.pool.Remove(p.cn, reason)
+func (p *StickyConnPool) replace(reason error) error {
+	err := p.pool.Replace(p.cn, reason)
 	p.cn = nil
 	return err
 }
 
-func (p *StickyConnPool) Remove(cn *Conn, reason error) error {
+func (p *StickyConnPool) Replace(cn *Conn, reason error) error {
 	defer p.mx.Unlock()
 	p.mx.Lock()
 	if p.closed {
@@ -85,7 +85,7 @@ func (p *StickyConnPool) Remove(cn *Conn, reason error) error {
 	if cn != nil && p.cn != cn {
 		panic("p.cn != cn")
 	}
-	return p.remove(reason)
+	return p.replace(reason)
 }
 
 func (p *StickyConnPool) Len() int {
@@ -121,7 +121,7 @@ func (p *StickyConnPool) Close() error {
 			err = p.put()
 		} else {
 			reason := errors.New("redis: sticky not reusable connection")
-			err = p.remove(reason)
+			err = p.replace(reason)
 		}
 	}
 	return err

--- a/multi_test.go
+++ b/multi_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Multi", func() {
 		cn, _, err := client.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
 
-		cn.NetConn = &badConn{}
+		cn.SetNetConn(&badConn{})
 		err = client.Pool().Put(cn)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -172,7 +172,7 @@ var _ = Describe("Multi", func() {
 		cn, _, err := client.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
 
-		cn.NetConn = &badConn{}
+		cn.SetNetConn(&badConn{})
 		err = client.Pool().Put(cn)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -179,7 +179,7 @@ var _ = Describe("pool", func() {
 			// ok
 		}
 
-		err = pool.Remove(cn, errors.New("test"))
+		err = pool.Replace(cn, errors.New("test"))
 		Expect(err).NotTo(HaveOccurred())
 
 		// Check that Ping is unblocked.
@@ -203,7 +203,7 @@ var _ = Describe("pool", func() {
 				break
 			}
 
-			_ = pool.Remove(cn, errors.New("test"))
+			_ = pool.Replace(cn, errors.New("test"))
 		}
 
 		Expect(rateErr).To(MatchError(`redis: you open connections too fast (last_error="test")`))

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -291,10 +291,10 @@ var _ = Describe("PubSub", func() {
 	expectReceiveMessageOnError := func(pubsub *redis.PubSub) {
 		cn1, _, err := pubsub.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
-		cn1.NetConn = &badConn{
+		cn1.SetNetConn(&badConn{
 			readErr:  io.EOF,
 			writeErr: io.EOF,
-		}
+		})
 
 		done := make(chan bool, 1)
 		go func() {

--- a/redis_test.go
+++ b/redis_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Client", func() {
 		cn, _, err := client.Pool().Get()
 		Expect(err).NotTo(HaveOccurred())
 
-		cn.NetConn = &badConn{}
+		cn.SetNetConn(&badConn{})
 		err = client.Pool().Put(cn)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -267,7 +267,7 @@ func (d *sentinelFailover) closeOldConns(newMaster string) {
 				cn.RemoteAddr(),
 			)
 			Logger.Print(err)
-			d.pool.Remove(cn, err)
+			d.pool.Replace(cn, err)
 		} else {
 			cnsToPut = append(cnsToPut, cn)
 		}


### PR DESCRIPTION
```
benchmark                             old ns/op     new ns/op     delta
BenchmarkPoolGetPut10Conns-4          257           209           -18.68%
BenchmarkPoolGetPut100Conns-4         267           215           -19.48%
BenchmarkPoolGetPut1000Conns-4        242           236           -2.48%
BenchmarkPoolGetRemove10Conns-4       5559          319           -94.26%
BenchmarkPoolGetRemove100Conns-4      5751          294           -94.89%
BenchmarkPoolGetRemove1000Conns-4     5778          294           -94.91%

benchmark                             old allocs     new allocs     delta
BenchmarkPoolGetPut10Conns-4          0              0              +0.00%
BenchmarkPoolGetPut100Conns-4         0              0              +0.00%
BenchmarkPoolGetPut1000Conns-4        0              0              +0.00%
BenchmarkPoolGetRemove10Conns-4       7              3              -57.14%
BenchmarkPoolGetRemove100Conns-4      7              3              -57.14%
BenchmarkPoolGetRemove1000Conns-4     7              3              -57.14%

benchmark                             old bytes     new bytes     delta
BenchmarkPoolGetPut10Conns-4          0             0             +0.00%
BenchmarkPoolGetPut100Conns-4         0             0             +0.00%
BenchmarkPoolGetPut1000Conns-4        0             0             +0.00%
BenchmarkPoolGetRemove10Conns-4       8416          32            -99.62%
BenchmarkPoolGetRemove100Conns-4      8416          32            -99.62%
BenchmarkPoolGetRemove1000Conns-4     8416          32            -99.62%
```