### PR TITLE
Remove Go 1.4 from test build. Bump license.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - redis-server
 
 go:
-  - 1.4
   - 1.5
   - 1.6
   - tip

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2012 The Redis Go Client Authors. All rights reserved.
+Copyright (c) 2016 The github.com/go-redis/redis Contributors.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,9 +11,6 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT


### PR DESCRIPTION
Go 1.4 race build timeouts 4 times of 5. I think it is easier to remove it, because I plan to add more race tests, not to remove/simplify existing race tests.