### PR TITLE
Cleanup error handling code.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -195,12 +195,12 @@ func (c *ClusterClient) process(cmd Cmder) {
 
 		// If there is no (real) error, we are done!
 		err := cmd.Err()
-		if err == nil || err == Nil || err == TxFailedErr {
+		if err == nil {
 			return
 		}
 
 		// On network errors try random node.
-		if isNetworkError(err) {
+		if shouldRetry(err) {
 			client, err = c.randomClient()
 			if err != nil {
 				return

--- a/redis.go
+++ b/redis.go
@@ -104,7 +104,7 @@ func (c *baseClient) process(cmd Cmder) {
 		if err := writeCmd(cn, cmd); err != nil {
 			c.putConn(cn, err, false)
 			cmd.setErr(err)
-			if shouldRetry(err) {
+			if err != nil && shouldRetry(err) {
 				continue
 			}
 			return
@@ -112,7 +112,7 @@ func (c *baseClient) process(cmd Cmder) {
 
 		err = cmd.readReply(cn)
 		c.putConn(cn, err, readTimeout != nil)
-		if shouldRetry(err) {
+		if err != nil && shouldRetry(err) {
 			continue
 		}
 


### PR DESCRIPTION
This change makes cluster to retry command only in 2 cases:
- network error
- MOVED/ASK error response

Previously it retried on all error replies such as:

```
-ERR unknown command 'foobar'
-WRONGTYPE Operation against a key holding the wrong kind of value
```

etc

I took a chance to speedup `isMovedError` since it is called more often now.