### PR TITLE
Convert bytes to string in Cmd.

### DIFF
--- a/command.go
+++ b/command.go
@@ -165,7 +165,12 @@ func (cmd *Cmd) readReply(cn *pool.Conn) error {
 		cmd.err = err
 		return cmd.err
 	}
-	cmd.val = val
+	if b, ok := val.([]byte); ok {
+		// Bytes must be copied, because underlying memory is reused.
+		cmd.val = string(b)
+	} else {
+		cmd.val = val
+	}
 	return nil
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/redis.v4"
 )
 
-var _ = Describe("Command", func() {
+var _ = Describe("Cmd", func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
@@ -19,7 +19,7 @@ var _ = Describe("Command", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 	})
 
-	It("should implement Stringer", func() {
+	It("implements Stringer", func() {
 		set := client.Set("foo", "bar", 0)
 		Expect(set.String()).To(Equal("SET foo bar: OK"))
 
@@ -27,7 +27,7 @@ var _ = Describe("Command", func() {
 		Expect(get.String()).To(Equal("GET foo: bar"))
 	})
 
-	It("should have correct val/err states", func() {
+	It("has val/err", func() {
 		set := client.Set("key", "hello", 0)
 		Expect(set.Err()).NotTo(HaveOccurred())
 		Expect(set.Val()).To(Equal("OK"))
@@ -40,7 +40,7 @@ var _ = Describe("Command", func() {
 		Expect(set.Val()).To(Equal("OK"))
 	})
 
-	It("should convert strings via helpers", func() {
+	It("has helpers", func() {
 		set := client.Set("key", "10", 0)
 		Expect(set.Err()).NotTo(HaveOccurred())
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -128,11 +128,15 @@ var _ = Describe("Client", func() {
 		Expect(db2.Close()).NotTo(HaveOccurred())
 	})
 
-	It("should process custom commands", func() {
+	It("processes custom commands", func() {
 		cmd := redis.NewCmd("PING")
 		client.Process(cmd)
+
+		// Flush buffers.
+		Expect(client.Echo("hello").Err()).NotTo(HaveOccurred())
+
 		Expect(cmd.Err()).NotTo(HaveOccurred())
-		Expect(cmd.Val()).To(Equal([]byte("PONG")))
+		Expect(cmd.Val()).To(Equal("PONG"))
 	})
 
 	It("should retry command on network error", func() {


### PR DESCRIPTION
This reverts https://github.com/go-redis/redis/pull/301 because
- string is slightly more preferable than []byte
- allocation number is the same
- previous change was backwards incompatible