### PR TITLE
Set hash keys as Go map with HMSetMap

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -696,12 +696,12 @@ func (c *commandable) HMSet(key, field, value string, pairs ...string) *StatusCm
 	return cmd
 }
 
-func (c *commandable) HMSetMap(key string, slice map[string]string) *StatusCmd {
+func (c *commandable) HMSetMap(key string, fields map[string]string) *StatusCmd {
 	args := make([]interface{}, 2+len(slice)*2)
 	args[0] = "HMSET"
 	args[1] = key
 	i := 2
-	for k, v := range slice {
+	for k, v := range fields {
 		args[i] = k
 		args[i+1] = v
 		i += 2

--- a/commands.go
+++ b/commands.go
@@ -696,6 +696,18 @@ func (c *commandable) HMSet(key, field, value string, pairs ...string) *StatusCm
 	return cmd
 }
 
+func (c *commandable) HMSetMap(key, slice map[string]string) *StatusCmd {
+	args := make([]interface{}, 2+len(slice)*2)
+	args[0] = "HMSET"
+	args[1] = key
+	for k, v := range slice {
+		append(args, k, v)
+	}
+	cmd := NewStatusCmd(args...)
+	c.Process(cmd)
+	return cmd
+}
+
 func (c *commandable) HSet(key, field, value string) *BoolCmd {
 	cmd := NewBoolCmd("HSET", key, field, value)
 	c.Process(cmd)

--- a/commands.go
+++ b/commands.go
@@ -696,7 +696,7 @@ func (c *commandable) HMSet(key, field, value string, pairs ...string) *StatusCm
 	return cmd
 }
 
-func (c *commandable) HMSetMap(key, slice map[string]string) *StatusCmd {
+func (c *commandable) HMSetMap(key string, slice map[string]string) *StatusCmd {
 	args := make([]interface{}, 2+len(slice)*2)
 	args[0] = "HMSET"
 	args[1] = key

--- a/commands.go
+++ b/commands.go
@@ -700,8 +700,11 @@ func (c *commandable) HMSetMap(key, slice map[string]string) *StatusCmd {
 	args := make([]interface{}, 2+len(slice)*2)
 	args[0] = "HMSET"
 	args[1] = key
+	i := 2
 	for k, v := range slice {
-		append(args, k, v)
+		args[i] = k
+		args[i+1] = v
+		i += 2
 	}
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)

--- a/commands.go
+++ b/commands.go
@@ -697,7 +697,7 @@ func (c *commandable) HMSet(key, field, value string, pairs ...string) *StatusCm
 }
 
 func (c *commandable) HMSetMap(key string, fields map[string]string) *StatusCmd {
-	args := make([]interface{}, 2+len(slice)*2)
+	args := make([]interface{}, 2+len(fields)*2)
 	args[0] = "HMSET"
 	args[1] = key
 	i := 2

--- a/commands_test.go
+++ b/commands_test.go
@@ -1195,6 +1195,24 @@ var _ = Describe("Commands", func() {
 			Expect(hGet.Val()).To(Equal("hello2"))
 		})
 
+		It("should HMSetMap", func() {
+			slice := map[string]string{
+				"key3": "hello3",
+				"key4": "hello4",
+			}
+			hMSetMap := client.HMSetMap("hash", slice)
+			Expect(hMSetMap.Err()).NotTo(HaveOccurred())
+			Expect(hMSetMap.Val()).To(Equal("OK"))
+
+			hGet := client.HGet("hash", "key3")
+			Expect(hGet.Err()).NotTo(HaveOccurred())
+			Expect(hGet.Val()).To(Equal("hello3"))
+
+			hGet = client.HGet("hash", "key4")
+			Expect(hGet.Err()).NotTo(HaveOccurred())
+			Expect(hGet.Val()).To(Equal("hello4"))
+		})
+
 		It("should HSet", func() {
 			hSet := client.HSet("hash", "key", "hello")
 			Expect(hSet.Err()).NotTo(HaveOccurred())

--- a/commands_test.go
+++ b/commands_test.go
@@ -1196,11 +1196,10 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HMSetMap", func() {
-			slice := map[string]string{
+			hMSetMap := client.HMSetMap("hash", map[string]string{
 				"key3": "hello3",
 				"key4": "hello4",
-			}
-			hMSetMap := client.HMSetMap("hash", slice)
+			})
 			Expect(hMSetMap.Err()).NotTo(HaveOccurred())
 			Expect(hMSetMap.Val()).To(Equal("OK"))
 


### PR DESCRIPTION
`HMSetMap` allows you to set hash keys and values using by passing a `map[string]string`. This works nicely with `HGetAllMap`