### PR TITLE
Latency Based Queries

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -312,7 +312,7 @@ func (c *ClusterClient) setNodesLatency() {
 					client.Ping()
 					node.Latency += int(time.Now().Sub(t1).Nanoseconds())
 				}
-				if c.opt.LatencyBased {
+				if c.opt.ReadOnly {
 					client.Readonly()
 				}
 				node.Latency = node.Latency / 10 / (1000 * 1000)
@@ -493,6 +493,7 @@ type ClusterOptions struct {
 	PoolTimeout        time.Duration
 	IdleTimeout        time.Duration
 	IdleCheckFrequency time.Duration
+	ReadOnly           bool
 	LatencyBased       bool
 }
 
@@ -517,6 +518,8 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		PoolSize:    opt.PoolSize,
 		PoolTimeout: opt.PoolTimeout,
 		IdleTimeout: opt.IdleTimeout,
+
+		ReadOnly: opt.ReadOnly,
 		// IdleCheckFrequency is not copied to disable reaper
 	}
 }

--- a/cluster.go
+++ b/cluster.go
@@ -189,7 +189,7 @@ func (c *ClusterClient) process(cmd Cmder) {
 	slot := hashtag.Slot(cmd.clusterKey())
 
 	var addr string
-	if c.opt.LatencyBased {
+	if c.opt.LatencyBased && !cmd.IsWriter() {
 		addr = c.slotCloserNodeAddr(slot)
 	} else {
 		addr = c.slotMasterAddr(slot)

--- a/cluster.go
+++ b/cluster.go
@@ -21,7 +21,9 @@ type ClusterClient struct {
 
 	slotsMx sync.RWMutex // protects slots and addrs
 	addrs   []string
-	slots   [][]string
+	slots   [][]*Node
+
+	nodes map[string]*Node
 
 	clientsMx sync.RWMutex // protects clients and closed
 	clients   map[string]*Client
@@ -32,13 +34,18 @@ type ClusterClient struct {
 	reloading uint32
 }
 
+type Node struct {
+	Addr    string
+	Latency int
+}
+
 // NewClusterClient returns a Redis Cluster client as described in
 // http://redis.io/topics/cluster-spec.
 func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	client := &ClusterClient{
 		opt:     opt,
 		addrs:   opt.Addrs,
-		slots:   make([][]string, hashtag.SlotNumber),
+		slots:   make([][]*Node, hashtag.SlotNumber),
 		clients: make(map[string]*Client),
 	}
 	client.commandable.process = client.process
@@ -132,19 +139,32 @@ func (c *ClusterClient) getClient(addr string) (*Client, error) {
 	return client, nil
 }
 
-func (c *ClusterClient) slotAddrs(slot int) []string {
+func (c *ClusterClient) slotNodes(slot int) []*Node {
 	c.slotsMx.RLock()
-	addrs := c.slots[slot]
+	nodes := c.slots[slot]
 	c.slotsMx.RUnlock()
-	return addrs
+	return nodes
 }
 
 func (c *ClusterClient) slotMasterAddr(slot int) string {
-	addrs := c.slotAddrs(slot)
-	if len(addrs) > 0 {
-		return addrs[0]
+	nodes := c.slotNodes(slot)
+	if len(nodes) > 0 {
+		return nodes[0].Addr
 	}
 	return ""
+}
+
+func (c *ClusterClient) slotCloserNodeAddr(slot int) string {
+	nodes := c.slotNodes(slot)
+	var addr string
+	var minLat int
+	for _, node := range nodes {
+		if node.Latency < minLat || minLat <= 0 {
+			minLat = node.Latency
+			addr = node.Addr
+		}
+	}
+	return addr
 }
 
 // randomClient returns a Client for the first live node.
@@ -168,7 +188,12 @@ func (c *ClusterClient) process(cmd Cmder) {
 
 	slot := hashtag.Slot(cmd.clusterKey())
 
-	addr := c.slotMasterAddr(slot)
+	var addr string
+	if c.opt.LatencyBased {
+		addr = c.slotCloserNodeAddr(slot)
+	} else {
+		addr = c.slotMasterAddr(slot)
+	}
 	client, err := c.getClient(addr)
 	if err != nil {
 		cmd.setErr(err)
@@ -238,31 +263,65 @@ func (c *ClusterClient) resetClients() (retErr error) {
 func (c *ClusterClient) setSlots(slots []ClusterSlot) {
 	c.slotsMx.Lock()
 
-	seen := make(map[string]struct{})
+	c.nodes = make(map[string]*Node)
 	for _, addr := range c.addrs {
-		seen[addr] = struct{}{}
+		c.nodes[addr] = &Node{
+			Addr: addr,
+		}
 	}
 
 	for i := 0; i < hashtag.SlotNumber; i++ {
 		c.slots[i] = c.slots[i][:0]
 	}
 	for _, slot := range slots {
-		var addrs []string
+		var nodes []*Node
 		for _, node := range slot.Nodes {
-			addrs = append(addrs, node.Addr)
+			n, ok := c.nodes[node.Addr]
+			if !ok {
+				n = &Node{
+					Addr: node.Addr,
+				}
+				c.nodes[node.Addr] = n
+				c.addrs = append(c.addrs, node.Addr)
+			}
+			nodes = append(nodes, n)
 		}
 
 		for i := slot.Start; i <= slot.End; i++ {
-			c.slots[i] = addrs
-		}
-
-		for _, node := range slot.Nodes {
-			if _, ok := seen[node.Addr]; !ok {
-				c.addrs = append(c.addrs, node.Addr)
-				seen[node.Addr] = struct{}{}
-			}
+			c.slots[i] = nodes
 		}
 	}
+
+	c.slotsMx.Unlock()
+}
+
+func (c *ClusterClient) setNodesLatency() {
+	c.slotsMx.Lock()
+
+	wg := sync.WaitGroup{}
+	for i, node := range c.nodes {
+		wg.Add(1)
+		go func(key string, node *Node) {
+			defer wg.Done()
+			if client, err := c.getClient(node.Addr); err != nil {
+				internal.Logf("getClient failed: %s (addr=%s)", err, node.Addr)
+			} else {
+				node.Latency = 0
+				for retries := 0; retries <= 10; retries++ {
+					t1 := time.Now()
+					client.Ping()
+					node.Latency += int(time.Now().Sub(t1).Nanoseconds())
+				}
+				if c.opt.LatencyBased {
+					client.Readonly()
+				}
+				node.Latency = node.Latency / 10 / (1000 * 1000)
+				c.nodes[key].Latency = node.Latency
+			}
+		}(i, node)
+	}
+
+	wg.Wait()
 
 	c.slotsMx.Unlock()
 }
@@ -282,6 +341,9 @@ func (c *ClusterClient) reloadSlots() {
 		return
 	}
 	c.setSlots(slots)
+	if c.opt.LatencyBased {
+		c.setNodesLatency()
+	}
 }
 
 func (c *ClusterClient) lazyReloadSlots() {
@@ -431,6 +493,7 @@ type ClusterOptions struct {
 	PoolTimeout        time.Duration
 	IdleTimeout        time.Duration
 	IdleCheckFrequency time.Duration
+	LatencyBased       bool
 }
 
 func (opt *ClusterOptions) getMaxRedirects() int {

--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -5,13 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (c *ClusterClient) SlotAddrs(slot int) []string {
-	return c.slotAddrs(slot)
+func (c *ClusterClient) SlotNodes(slot int) []*Node {
+	return c.slotNodes(slot)
 }
 
 // SwapSlot swaps a slot's master/slave address
 // for testing MOVED redirects
-func (c *ClusterClient) SwapSlot(pos int) []string {
+func (c *ClusterClient) SwapSlot(pos int) []*Node {
 	c.slotsMx.Lock()
 	defer c.slotsMx.Unlock()
 	c.slots[pos][0], c.slots[pos][1] = c.slots[pos][1], c.slots[pos][0]

--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -76,6 +76,6 @@ var _ = Describe("ClusterClient", func() {
 		Expect(subject.slots[8191]).To(BeEmpty())
 		Expect(subject.slots[8192]).To(BeEmpty())
 		Expect(subject.slots[16383]).To(BeEmpty())
-		Expect(subject.Ping().Err().Error()).To(Equal(" client is closed"))
+		Expect(subject.Ping().Err().Error()).To(Equal("redis: client is closed"))
 	})
 })

--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -47,14 +47,14 @@ var _ = Describe("ClusterClient", func() {
 
 	It("should update slots cache", func() {
 		populate()
-		Expect(subject.slots[0]).To(Equal([]string{"127.0.0.1:7000", "127.0.0.1:7004"}))
-		Expect(subject.slots[4095]).To(Equal([]string{"127.0.0.1:7000", "127.0.0.1:7004"}))
-		Expect(subject.slots[4096]).To(Equal([]string{"127.0.0.1:7001", "127.0.0.1:7005"}))
-		Expect(subject.slots[8191]).To(Equal([]string{"127.0.0.1:7001", "127.0.0.1:7005"}))
-		Expect(subject.slots[8192]).To(Equal([]string{"127.0.0.1:7002", "127.0.0.1:7006"}))
-		Expect(subject.slots[12287]).To(Equal([]string{"127.0.0.1:7002", "127.0.0.1:7006"}))
-		Expect(subject.slots[12288]).To(Equal([]string{"127.0.0.1:7003", "127.0.0.1:7007"}))
-		Expect(subject.slots[16383]).To(Equal([]string{"127.0.0.1:7003", "127.0.0.1:7007"}))
+		Expect(subject.slots[0]).To(Equal([]*Node{{Addr: "127.0.0.1:7000"}, {Addr: "127.0.0.1:7004"}}))
+		Expect(subject.slots[4095]).To(Equal([]*Node{{Addr: "127.0.0.1:7000"}, {Addr: "127.0.0.1:7004"}}))
+		Expect(subject.slots[4096]).To(Equal([]*Node{{Addr: "127.0.0.1:7001"}, {Addr: "127.0.0.1:7005"}}))
+		Expect(subject.slots[8191]).To(Equal([]*Node{{Addr: "127.0.0.1:7001"}, {Addr: "127.0.0.1:7005"}}))
+		Expect(subject.slots[8192]).To(Equal([]*Node{{Addr: "127.0.0.1:7002"}, {Addr: "127.0.0.1:7006"}}))
+		Expect(subject.slots[12287]).To(Equal([]*Node{{Addr: "127.0.0.1:7002"}, {Addr: "127.0.0.1:7006"}}))
+		Expect(subject.slots[12288]).To(Equal([]*Node{{Addr: "127.0.0.1:7003"}, {Addr: "127.0.0.1:7007"}}))
+		Expect(subject.slots[16383]).To(Equal([]*Node{{Addr: "127.0.0.1:7003"}, {Addr: "127.0.0.1:7007"}}))
 		Expect(subject.addrs).To(Equal([]string{
 			"127.0.0.1:6379",
 			"127.0.0.1:7003",
@@ -76,6 +76,6 @@ var _ = Describe("ClusterClient", func() {
 		Expect(subject.slots[8191]).To(BeEmpty())
 		Expect(subject.slots[8192]).To(BeEmpty())
 		Expect(subject.slots[16383]).To(BeEmpty())
-		Expect(subject.Ping().Err().Error()).To(Equal("redis: client is closed"))
+		Expect(subject.Ping().Err().Error()).To(Equal(" client is closed"))
 	})
 })

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -353,7 +353,7 @@ var _ = Describe("Cluster", func() {
 			Expect(client.Set("A", "VALUE", 0).Err()).NotTo(HaveOccurred())
 
 			slot := hashtag.Slot("A")
-			Expect(client.SwapSlot(slot)).To(Equal([]string{"127.0.0.1:8224", "127.0.0.1:8221"}))
+			Expect(client.SwapSlot(slot)).To(Equal([]*redis.Node{{Addr: "127.0.0.1:8224"}, {Addr: "127.0.0.1:8221"}}))
 
 			val, err := client.Get("A").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -371,7 +371,7 @@ var _ = Describe("Cluster", func() {
 			})
 
 			slot := hashtag.Slot("A")
-			Expect(client.SwapSlot(slot)).To(Equal([]string{"127.0.0.1:8224", "127.0.0.1:8221"}))
+			Expect(client.SwapSlot(slot)).To(Equal([]*redis.Node{{Addr: "127.0.0.1:8224"}, {Addr: "127.0.0.1:8221"}}))
 
 			err := client.Get("A").Err()
 			Expect(err).To(HaveOccurred())
@@ -435,7 +435,7 @@ var _ = Describe("Cluster", func() {
 
 		It("performs multi-pipelines", func() {
 			slot := hashtag.Slot("A")
-			Expect(client.SwapSlot(slot)).To(Equal([]string{"127.0.0.1:8224", "127.0.0.1:8221"}))
+			Expect(client.SwapSlot(slot)).To(Equal([]*redis.Node{{Addr: "127.0.0.1:8224"}, {Addr: "127.0.0.1:8221"}}))
 
 			pipe := client.Pipeline()
 			defer pipe.Close()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -359,9 +359,9 @@ var _ = Describe("Cluster", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("VALUE"))
 
-			Eventually(func() []string {
-				return client.SlotAddrs(slot)
-			}, "5s").Should(Equal([]string{"127.0.0.1:8221", "127.0.0.1:8224"}))
+			Eventually(func() []*redis.Node {
+				return client.SlotNodes(slot)
+			}, "5s").Should(Equal([]*redis.Node{{Addr: "127.0.0.1:8221"}, {Addr: "127.0.0.1:8224"}}))
 		})
 
 		It("should return error when there are no attempts left", func() {

--- a/command.go
+++ b/command.go
@@ -38,6 +38,7 @@ type Cmder interface {
 	clusterKey() string
 
 	Err() error
+	IsWriter() bool
 	fmt.Stringer
 }
 
@@ -98,6 +99,8 @@ type baseCmd struct {
 	_clusterKeyPos int
 
 	_readTimeout *time.Duration
+
+	_isWriter bool
 }
 
 func (cmd *baseCmd) Err() error {
@@ -130,6 +133,25 @@ func (cmd *baseCmd) setErr(e error) {
 	cmd.err = e
 }
 
+func (cmd *baseCmd) IsWriter() bool {
+	return cmd._isWriter
+}
+
+func NewBaseCmd(args []interface{}) baseCmd {
+	cmd := baseCmd{}
+	if len(args) > 0 {
+		if isWriter, ok := args[len(args)-1].(bool); ok {
+			cmd._isWriter = isWriter
+			if len(args) > 1 {
+				cmd._args = args[0 : len(args)-1]
+			}
+		} else {
+			cmd._args = args
+		}
+	}
+	return cmd
+}
+
 //------------------------------------------------------------------------------
 
 type Cmd struct {
@@ -139,7 +161,7 @@ type Cmd struct {
 }
 
 func NewCmd(args ...interface{}) *Cmd {
-	return &Cmd{baseCmd: baseCmd{_args: args}}
+	return &Cmd{baseCmd: NewBaseCmd(args)}
 }
 
 func (cmd *Cmd) reset() {
@@ -183,7 +205,9 @@ type SliceCmd struct {
 }
 
 func NewSliceCmd(args ...interface{}) *SliceCmd {
-	return &SliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &SliceCmd{baseCmd: cmd}
 }
 
 func (cmd *SliceCmd) reset() {
@@ -222,11 +246,13 @@ type StatusCmd struct {
 }
 
 func NewStatusCmd(args ...interface{}) *StatusCmd {
-	return &StatusCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &StatusCmd{baseCmd: cmd}
 }
 
 func newKeylessStatusCmd(args ...interface{}) *StatusCmd {
-	return &StatusCmd{baseCmd: baseCmd{_args: args}}
+	return &StatusCmd{baseCmd: NewBaseCmd(args)}
 }
 
 func (cmd *StatusCmd) reset() {
@@ -260,7 +286,9 @@ type IntCmd struct {
 }
 
 func NewIntCmd(args ...interface{}) *IntCmd {
-	return &IntCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &IntCmd{baseCmd: cmd}
 }
 
 func (cmd *IntCmd) reset() {
@@ -295,9 +323,11 @@ type DurationCmd struct {
 }
 
 func NewDurationCmd(precision time.Duration, args ...interface{}) *DurationCmd {
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
 	return &DurationCmd{
 		precision: precision,
-		baseCmd:   baseCmd{_args: args, _clusterKeyPos: 1},
+		baseCmd:   cmd,
 	}
 }
 
@@ -337,7 +367,9 @@ type BoolCmd struct {
 }
 
 func NewBoolCmd(args ...interface{}) *BoolCmd {
-	return &BoolCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &BoolCmd{baseCmd: cmd}
 }
 
 func (cmd *BoolCmd) reset() {
@@ -393,7 +425,9 @@ type StringCmd struct {
 }
 
 func NewStringCmd(args ...interface{}) *StringCmd {
-	return &StringCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &StringCmd{baseCmd: cmd}
 }
 
 func (cmd *StringCmd) reset() {
@@ -468,7 +502,9 @@ type FloatCmd struct {
 }
 
 func NewFloatCmd(args ...interface{}) *FloatCmd {
-	return &FloatCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &FloatCmd{baseCmd: cmd}
 }
 
 func (cmd *FloatCmd) reset() {
@@ -502,7 +538,9 @@ type StringSliceCmd struct {
 }
 
 func NewStringSliceCmd(args ...interface{}) *StringSliceCmd {
-	return &StringSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &StringSliceCmd{baseCmd: cmd}
 }
 
 func (cmd *StringSliceCmd) reset() {
@@ -541,7 +579,9 @@ type BoolSliceCmd struct {
 }
 
 func NewBoolSliceCmd(args ...interface{}) *BoolSliceCmd {
-	return &BoolSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &BoolSliceCmd{baseCmd: cmd}
 }
 
 func (cmd *BoolSliceCmd) reset() {
@@ -580,7 +620,9 @@ type StringStringMapCmd struct {
 }
 
 func NewStringStringMapCmd(args ...interface{}) *StringStringMapCmd {
-	return &StringStringMapCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &StringStringMapCmd{baseCmd: cmd}
 }
 
 func (cmd *StringStringMapCmd) reset() {
@@ -619,7 +661,9 @@ type StringIntMapCmd struct {
 }
 
 func NewStringIntMapCmd(args ...interface{}) *StringIntMapCmd {
-	return &StringIntMapCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &StringIntMapCmd{baseCmd: cmd}
 }
 
 func (cmd *StringIntMapCmd) Val() map[string]int64 {
@@ -658,7 +702,9 @@ type ZSliceCmd struct {
 }
 
 func NewZSliceCmd(args ...interface{}) *ZSliceCmd {
-	return &ZSliceCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &ZSliceCmd{baseCmd: cmd}
 }
 
 func (cmd *ZSliceCmd) reset() {
@@ -698,8 +744,10 @@ type ScanCmd struct {
 }
 
 func NewScanCmd(args ...interface{}) *ScanCmd {
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
 	return &ScanCmd{
-		baseCmd: baseCmd{_args: args, _clusterKeyPos: 1},
+		baseCmd: cmd,
 	}
 }
 
@@ -752,7 +800,9 @@ type ClusterSlotsCmd struct {
 }
 
 func NewClusterSlotsCmd(args ...interface{}) *ClusterSlotsCmd {
-	return &ClusterSlotsCmd{baseCmd: baseCmd{_args: args, _clusterKeyPos: 1}}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
+	return &ClusterSlotsCmd{baseCmd: cmd}
 }
 
 func (cmd *ClusterSlotsCmd) Val() []ClusterSlot {
@@ -833,12 +883,11 @@ func NewGeoLocationCmd(q *GeoRadiusQuery, args ...interface{}) *GeoLocationCmd {
 	if q.Sort != "" {
 		args = append(args, q.Sort)
 	}
+	cmd := NewBaseCmd(args)
+	cmd._clusterKeyPos = 1
 	return &GeoLocationCmd{
-		baseCmd: baseCmd{
-			_args:          args,
-			_clusterKeyPos: 1,
-		},
-		q: q,
+		baseCmd: cmd,
+		q:       q,
 	}
 }
 

--- a/command.go
+++ b/command.go
@@ -883,6 +883,7 @@ func NewGeoLocationCmd(q *GeoRadiusQuery, args ...interface{}) *GeoLocationCmd {
 	if q.Sort != "" {
 		args = append(args, q.Sort)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewBaseCmd(args)
 	cmd._clusterKeyPos = 1
 	return &GeoLocationCmd{

--- a/commands.go
+++ b/commands.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/redis.v4/internal"
 )
 
+const (
+	isWriter   = true
+	isReadOnly = false
+)
+
 func formatInt(i int64) string {
 	return strconv.FormatInt(i, 10)
 }
@@ -62,20 +67,20 @@ func (c *commandable) Process(cmd Cmder) {
 //------------------------------------------------------------------------------
 
 func (c *commandable) Auth(password string) *StatusCmd {
-	cmd := newKeylessStatusCmd("AUTH", password)
+	cmd := newKeylessStatusCmd("AUTH", password, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Echo(message string) *StringCmd {
-	cmd := NewStringCmd("ECHO", message)
+	cmd := NewStringCmd("ECHO", message, isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Ping() *StatusCmd {
-	cmd := newKeylessStatusCmd("PING")
+	cmd := newKeylessStatusCmd("PING", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -85,7 +90,7 @@ func (c *commandable) Quit() *StatusCmd {
 }
 
 func (c *commandable) Select(index int64) *StatusCmd {
-	cmd := newKeylessStatusCmd("SELECT", index)
+	cmd := newKeylessStatusCmd("SELECT", index, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -93,42 +98,43 @@ func (c *commandable) Select(index int64) *StatusCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) Del(keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "DEL"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Dump(key string) *StringCmd {
-	cmd := NewStringCmd("DUMP", key)
+	cmd := NewStringCmd("DUMP", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Exists(key string) *BoolCmd {
-	cmd := NewBoolCmd("EXISTS", key)
+	cmd := NewBoolCmd("EXISTS", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Expire(key string, expiration time.Duration) *BoolCmd {
-	cmd := NewBoolCmd("EXPIRE", key, formatSec(expiration))
+	cmd := NewBoolCmd("EXPIRE", key, formatSec(expiration), isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ExpireAt(key string, tm time.Time) *BoolCmd {
-	cmd := NewBoolCmd("EXPIREAT", key, tm.Unix())
+	cmd := NewBoolCmd("EXPIREAT", key, tm.Unix(), isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Keys(pattern string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("KEYS", pattern)
+	cmd := NewStringSliceCmd("KEYS", pattern, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -141,6 +147,7 @@ func (c *commandable) Migrate(host, port, key string, db int64, timeout time.Dur
 		key,
 		db,
 		formatMs(timeout),
+		isWriter,
 	)
 	cmd._clusterKeyPos = 3
 	cmd.setReadTimeout(readTimeout(timeout))
@@ -149,18 +156,19 @@ func (c *commandable) Migrate(host, port, key string, db int64, timeout time.Dur
 }
 
 func (c *commandable) Move(key string, db int64) *BoolCmd {
-	cmd := NewBoolCmd("MOVE", key, db)
+	cmd := NewBoolCmd("MOVE", key, db, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ObjectRefCount(keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "OBJECT"
 	args[1] = "REFCOUNT"
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isReadOnly
 	cmd := NewIntCmd(args...)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
@@ -168,12 +176,13 @@ func (c *commandable) ObjectRefCount(keys ...string) *IntCmd {
 }
 
 func (c *commandable) ObjectEncoding(keys ...string) *StringCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "OBJECT"
 	args[1] = "ENCODING"
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isReadOnly
 	cmd := NewStringCmd(args...)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
@@ -181,12 +190,13 @@ func (c *commandable) ObjectEncoding(keys ...string) *StringCmd {
 }
 
 func (c *commandable) ObjectIdleTime(keys ...string) *DurationCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "OBJECT"
 	args[1] = "IDLETIME"
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isReadOnly
 	cmd := NewDurationCmd(time.Second, args...)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
@@ -194,13 +204,13 @@ func (c *commandable) ObjectIdleTime(keys ...string) *DurationCmd {
 }
 
 func (c *commandable) Persist(key string) *BoolCmd {
-	cmd := NewBoolCmd("PERSIST", key)
+	cmd := NewBoolCmd("PERSIST", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) PExpire(key string, expiration time.Duration) *BoolCmd {
-	cmd := NewBoolCmd("PEXPIRE", key, formatMs(expiration))
+	cmd := NewBoolCmd("PEXPIRE", key, formatMs(expiration), isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -210,31 +220,32 @@ func (c *commandable) PExpireAt(key string, tm time.Time) *BoolCmd {
 		"PEXPIREAT",
 		key,
 		tm.UnixNano()/int64(time.Millisecond),
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) PTTL(key string) *DurationCmd {
-	cmd := NewDurationCmd(time.Millisecond, "PTTL", key)
+	cmd := NewDurationCmd(time.Millisecond, "PTTL", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RandomKey() *StringCmd {
-	cmd := NewStringCmd("RANDOMKEY")
+	cmd := NewStringCmd("RANDOMKEY", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Rename(key, newkey string) *StatusCmd {
-	cmd := NewStatusCmd("RENAME", key, newkey)
+	cmd := NewStatusCmd("RENAME", key, newkey, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RenameNX(key, newkey string) *BoolCmd {
-	cmd := NewBoolCmd("RENAMENX", key, newkey)
+	cmd := NewBoolCmd("RENAMENX", key, newkey, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -245,6 +256,7 @@ func (c *commandable) Restore(key string, ttl time.Duration, value string) *Stat
 		key,
 		formatMs(ttl),
 		value,
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
@@ -257,6 +269,7 @@ func (c *commandable) RestoreReplace(key string, ttl time.Duration, value string
 		formatMs(ttl),
 		value,
 		"REPLACE",
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
@@ -291,6 +304,7 @@ func (sort *Sort) args(key string) []interface{} {
 	if sort.Store != "" {
 		args = append(args, "STORE", sort.Store)
 	}
+	args = append(args, isWriter)
 	return args
 }
 
@@ -307,13 +321,13 @@ func (c *commandable) SortInterfaces(key string, sort Sort) *SliceCmd {
 }
 
 func (c *commandable) TTL(key string) *DurationCmd {
-	cmd := NewDurationCmd(time.Second, "TTL", key)
+	cmd := NewDurationCmd(time.Second, "TTL", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Type(key string) *StatusCmd {
-	cmd := NewStatusCmd("TYPE", key)
+	cmd := NewStatusCmd("TYPE", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -326,6 +340,7 @@ func (c *commandable) Scan(cursor uint64, match string, count int64) Scanner {
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewScanCmd(args...)
 	c.Process(cmd)
 	return Scanner{
@@ -342,6 +357,7 @@ func (c *commandable) SScan(key string, cursor uint64, match string, count int64
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewScanCmd(args...)
 	c.Process(cmd)
 	return Scanner{
@@ -358,6 +374,7 @@ func (c *commandable) HScan(key string, cursor uint64, match string, count int64
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewScanCmd(args...)
 	c.Process(cmd)
 	return Scanner{
@@ -374,6 +391,7 @@ func (c *commandable) ZScan(key string, cursor uint64, match string, count int64
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewScanCmd(args...)
 	c.Process(cmd)
 	return Scanner{
@@ -385,7 +403,7 @@ func (c *commandable) ZScan(key string, cursor uint64, match string, count int64
 //------------------------------------------------------------------------------
 
 func (c *commandable) Append(key, value string) *IntCmd {
-	cmd := NewIntCmd("APPEND", key, value)
+	cmd := NewIntCmd("APPEND", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -403,19 +421,21 @@ func (c *commandable) BitCount(key string, bitCount *BitCount) *IntCmd {
 			bitCount.End,
 		)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) bitOp(op, destKey string, keys ...string) *IntCmd {
-	args := make([]interface{}, 3+len(keys))
+	args := make([]interface{}, 4+len(keys))
 	args[0] = "BITOP"
 	args[1] = op
 	args[2] = destKey
 	for i, key := range keys {
 		args[3+i] = key
 	}
+	args[len(keys)+3] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -438,7 +458,7 @@ func (c *commandable) BitOpNot(destKey string, key string) *IntCmd {
 }
 
 func (c *commandable) BitPos(key string, bit int64, pos ...int64) *IntCmd {
-	args := make([]interface{}, 3+len(pos))
+	args := make([]interface{}, 4+len(pos))
 	args[0] = "BITPOS"
 	args[1] = key
 	args[2] = bit
@@ -452,93 +472,97 @@ func (c *commandable) BitPos(key string, bit int64, pos ...int64) *IntCmd {
 	default:
 		panic("too many arguments")
 	}
+	args[len(pos)+3] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Decr(key string) *IntCmd {
-	cmd := NewIntCmd("DECR", key)
+	cmd := NewIntCmd("DECR", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) DecrBy(key string, decrement int64) *IntCmd {
-	cmd := NewIntCmd("DECRBY", key, decrement)
+	cmd := NewIntCmd("DECRBY", key, decrement, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Get(key string) *StringCmd {
-	cmd := NewStringCmd("GET", key)
+	cmd := NewStringCmd("GET", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GetBit(key string, offset int64) *IntCmd {
-	cmd := NewIntCmd("GETBIT", key, offset)
+	cmd := NewIntCmd("GETBIT", key, offset, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GetRange(key string, start, end int64) *StringCmd {
-	cmd := NewStringCmd("GETRANGE", key, start, end)
+	cmd := NewStringCmd("GETRANGE", key, start, end, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GetSet(key string, value interface{}) *StringCmd {
-	cmd := NewStringCmd("GETSET", key, value)
+	cmd := NewStringCmd("GETSET", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Incr(key string) *IntCmd {
-	cmd := NewIntCmd("INCR", key)
+	cmd := NewIntCmd("INCR", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) IncrBy(key string, value int64) *IntCmd {
-	cmd := NewIntCmd("INCRBY", key, value)
+	cmd := NewIntCmd("INCRBY", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) IncrByFloat(key string, value float64) *FloatCmd {
-	cmd := NewFloatCmd("INCRBYFLOAT", key, value)
+	cmd := NewFloatCmd("INCRBYFLOAT", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) MGet(keys ...string) *SliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "MGET"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isReadOnly
 	cmd := NewSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) MSet(pairs ...string) *StatusCmd {
-	args := make([]interface{}, 1+len(pairs))
+	args := make([]interface{}, 2+len(pairs))
 	args[0] = "MSET"
 	for i, pair := range pairs {
 		args[1+i] = pair
 	}
+	args[len(pairs)+1] = isWriter
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) MSetNX(pairs ...string) *BoolCmd {
-	args := make([]interface{}, 1+len(pairs))
+	args := make([]interface{}, 2+len(pairs))
 	args[0] = "MSETNX"
 	for i, pair := range pairs {
 		args[1+i] = pair
 	}
+	args[len(pairs)+1] = isWriter
 	cmd := NewBoolCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -559,6 +583,7 @@ func (c *commandable) Set(key string, value interface{}, expiration time.Duratio
 			args = append(args, "EX", formatSec(expiration))
 		}
 	}
+	args = append(args, isWriter)
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -570,6 +595,7 @@ func (c *commandable) SetBit(key string, offset int64, value int) *IntCmd {
 		key,
 		offset,
 		value,
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
@@ -585,9 +611,9 @@ func (c *commandable) SetNX(key string, value interface{}, expiration time.Durat
 		cmd = NewBoolCmd("SETNX", key, value)
 	} else {
 		if usePrecise(expiration) {
-			cmd = NewBoolCmd("SET", key, value, "PX", formatMs(expiration), "NX")
+			cmd = NewBoolCmd("SET", key, value, "PX", formatMs(expiration), "NX", isWriter)
 		} else {
-			cmd = NewBoolCmd("SET", key, value, "EX", formatSec(expiration), "NX")
+			cmd = NewBoolCmd("SET", key, value, "EX", formatSec(expiration), "NX", isWriter)
 		}
 	}
 	c.Process(cmd)
@@ -600,22 +626,22 @@ func (c *commandable) SetNX(key string, value interface{}, expiration time.Durat
 func (c *commandable) SetXX(key string, value interface{}, expiration time.Duration) *BoolCmd {
 	var cmd *BoolCmd
 	if usePrecise(expiration) {
-		cmd = NewBoolCmd("SET", key, value, "PX", formatMs(expiration), "XX")
+		cmd = NewBoolCmd("SET", key, value, "PX", formatMs(expiration), "XX", isWriter)
 	} else {
-		cmd = NewBoolCmd("SET", key, value, "EX", formatSec(expiration), "XX")
+		cmd = NewBoolCmd("SET", key, value, "EX", formatSec(expiration), "XX", isWriter)
 	}
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SetRange(key string, offset int64, value string) *IntCmd {
-	cmd := NewIntCmd("SETRANGE", key, offset, value)
+	cmd := NewIntCmd("SETRANGE", key, offset, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) StrLen(key string) *IntCmd {
-	cmd := NewIntCmd("STRLEN", key)
+	cmd := NewIntCmd("STRLEN", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -623,73 +649,75 @@ func (c *commandable) StrLen(key string) *IntCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) HDel(key string, fields ...string) *IntCmd {
-	args := make([]interface{}, 2+len(fields))
+	args := make([]interface{}, 3+len(fields))
 	args[0] = "HDEL"
 	args[1] = key
 	for i, field := range fields {
 		args[2+i] = field
 	}
+	args[len(fields)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HExists(key, field string) *BoolCmd {
-	cmd := NewBoolCmd("HEXISTS", key, field)
+	cmd := NewBoolCmd("HEXISTS", key, field, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HGet(key, field string) *StringCmd {
-	cmd := NewStringCmd("HGET", key, field)
+	cmd := NewStringCmd("HGET", key, field, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HGetAll(key string) *StringStringMapCmd {
-	cmd := NewStringStringMapCmd("HGETALL", key)
+	cmd := NewStringStringMapCmd("HGETALL", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HIncrBy(key, field string, incr int64) *IntCmd {
-	cmd := NewIntCmd("HINCRBY", key, field, incr)
+	cmd := NewIntCmd("HINCRBY", key, field, incr, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HIncrByFloat(key, field string, incr float64) *FloatCmd {
-	cmd := NewFloatCmd("HINCRBYFLOAT", key, field, incr)
+	cmd := NewFloatCmd("HINCRBYFLOAT", key, field, incr, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HKeys(key string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("HKEYS", key)
+	cmd := NewStringSliceCmd("HKEYS", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HLen(key string) *IntCmd {
-	cmd := NewIntCmd("HLEN", key)
+	cmd := NewIntCmd("HLEN", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HMGet(key string, fields ...string) *SliceCmd {
-	args := make([]interface{}, 2+len(fields))
+	args := make([]interface{}, 3+len(fields))
 	args[0] = "HMGET"
 	args[1] = key
 	for i, field := range fields {
 		args[2+i] = field
 	}
+	args[len(fields)+2] = isReadOnly
 	cmd := NewSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HMSet(key string, fields map[string]string) *StatusCmd {
-	args := make([]interface{}, 2+len(fields)*2)
+	args := make([]interface{}, 3+len(fields)*2)
 	args[0] = "HMSET"
 	args[1] = key
 	i := 2
@@ -698,25 +726,26 @@ func (c *commandable) HMSet(key string, fields map[string]string) *StatusCmd {
 		args[i+1] = v
 		i += 2
 	}
+	args[len(fields)+2] = isWriter
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HSet(key, field, value string) *BoolCmd {
-	cmd := NewBoolCmd("HSET", key, field, value)
+	cmd := NewBoolCmd("HSET", key, field, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HSetNX(key, field, value string) *BoolCmd {
-	cmd := NewBoolCmd("HSETNX", key, field, value)
+	cmd := NewBoolCmd("HSETNX", key, field, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) HVals(key string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("HVALS", key)
+	cmd := NewStringSliceCmd("HVALS", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -724,7 +753,7 @@ func (c *commandable) HVals(key string) *StringSliceCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) BLPop(timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "BLPOP"
 	for i, key := range keys {
 		args[1+i] = key
@@ -737,12 +766,13 @@ func (c *commandable) BLPop(timeout time.Duration, keys ...string) *StringSliceC
 }
 
 func (c *commandable) BRPop(timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "BRPOP"
 	for i, key := range keys {
 		args[1+i] = key
 	}
-	args[len(args)-1] = formatSec(timeout)
+	args[len(keys)+1] = formatSec(timeout)
+	args[len(keys)+2] = isWriter
 	cmd := NewStringSliceCmd(args...)
 	cmd.setReadTimeout(readTimeout(timeout))
 	c.Process(cmd)
@@ -755,6 +785,7 @@ func (c *commandable) BRPopLPush(source, destination string, timeout time.Durati
 		source,
 		destination,
 		formatSec(timeout),
+		isWriter,
 	)
 	cmd.setReadTimeout(readTimeout(timeout))
 	c.Process(cmd)
@@ -762,43 +793,44 @@ func (c *commandable) BRPopLPush(source, destination string, timeout time.Durati
 }
 
 func (c *commandable) LIndex(key string, index int64) *StringCmd {
-	cmd := NewStringCmd("LINDEX", key, index)
+	cmd := NewStringCmd("LINDEX", key, index, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LInsert(key, op, pivot, value string) *IntCmd {
-	cmd := NewIntCmd("LINSERT", key, op, pivot, value)
+	cmd := NewIntCmd("LINSERT", key, op, pivot, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LLen(key string) *IntCmd {
-	cmd := NewIntCmd("LLEN", key)
+	cmd := NewIntCmd("LLEN", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LPop(key string) *StringCmd {
-	cmd := NewStringCmd("LPOP", key)
+	cmd := NewStringCmd("LPOP", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LPush(key string, values ...string) *IntCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]interface{}, 3+len(values))
 	args[0] = "LPUSH"
 	args[1] = key
 	for i, value := range values {
 		args[2+i] = value
 	}
+	args[len(values)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LPushX(key, value interface{}) *IntCmd {
-	cmd := NewIntCmd("LPUSHX", key, value)
+	cmd := NewIntCmd("LPUSHX", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -809,19 +841,20 @@ func (c *commandable) LRange(key string, start, stop int64) *StringSliceCmd {
 		key,
 		start,
 		stop,
+		isReadOnly,
 	)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LRem(key string, count int64, value interface{}) *IntCmd {
-	cmd := NewIntCmd("LREM", key, count, value)
+	cmd := NewIntCmd("LREM", key, count, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LSet(key string, index int64, value interface{}) *StatusCmd {
-	cmd := NewStatusCmd("LSET", key, index, value)
+	cmd := NewStatusCmd("LSET", key, index, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -832,37 +865,39 @@ func (c *commandable) LTrim(key string, start, stop int64) *StatusCmd {
 		key,
 		start,
 		stop,
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RPop(key string) *StringCmd {
-	cmd := NewStringCmd("RPOP", key)
+	cmd := NewStringCmd("RPOP", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RPopLPush(source, destination string) *StringCmd {
-	cmd := NewStringCmd("RPOPLPUSH", source, destination)
+	cmd := NewStringCmd("RPOPLPUSH", source, destination, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RPush(key string, values ...string) *IntCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]interface{}, 3+len(values))
 	args[0] = "RPUSH"
 	args[1] = key
 	for i, value := range values {
 		args[2+i] = value
 	}
+	args[len(values)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) RPushX(key string, value interface{}) *IntCmd {
-	cmd := NewIntCmd("RPUSHX", key, value)
+	cmd := NewIntCmd("RPUSHX", key, value, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -870,137 +905,145 @@ func (c *commandable) RPushX(key string, value interface{}) *IntCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) SAdd(key string, members ...string) *IntCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]interface{}, 3+len(members))
 	args[0] = "SADD"
 	args[1] = key
 	for i, member := range members {
 		args[2+i] = member
 	}
+	args[len(members)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SCard(key string) *IntCmd {
-	cmd := NewIntCmd("SCARD", key)
+	cmd := NewIntCmd("SCARD", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SDiff(keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "SDIFF"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isWriter
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SDiffStore(destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "SDIFFSTORE"
 	args[1] = destination
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SInter(keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "SINTER"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isReadOnly
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SInterStore(destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "SINTERSTORE"
 	args[1] = destination
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SIsMember(key string, member interface{}) *BoolCmd {
-	cmd := NewBoolCmd("SISMEMBER", key, member)
+	cmd := NewBoolCmd("SISMEMBER", key, member, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SMembers(key string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("SMEMBERS", key)
+	cmd := NewStringSliceCmd("SMEMBERS", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SMove(source, destination string, member interface{}) *BoolCmd {
-	cmd := NewBoolCmd("SMOVE", source, destination, member)
+	cmd := NewBoolCmd("SMOVE", source, destination, member, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SPop(key string) *StringCmd {
-	cmd := NewStringCmd("SPOP", key)
+	cmd := NewStringCmd("SPOP", key, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 // Redis `SRANDMEMBER key` command.
 func (c *commandable) SRandMember(key string) *StringCmd {
-	cmd := NewStringCmd("SRANDMEMBER", key)
+	cmd := NewStringCmd("SRANDMEMBER", key, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 // Redis `SRANDMEMBER key count` command.
 func (c *commandable) SRandMemberN(key string, count int64) *StringSliceCmd {
-	cmd := NewStringSliceCmd("SRANDMEMBER", key, count)
+	cmd := NewStringSliceCmd("SRANDMEMBER", key, count, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SRem(key string, members ...string) *IntCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]interface{}, 3+len(members))
 	args[0] = "SREM"
 	args[1] = key
 	for i, member := range members {
 		args[2+i] = member
 	}
+	args[len(members)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SUnion(keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "SUNION"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isReadOnly
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) SUnionStore(destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "SUNIONSTORE"
 	args[1] = destination
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1026,6 +1069,7 @@ func (c *commandable) zAdd(a []interface{}, n int, members ...Z) *IntCmd {
 		a[n+2*i] = m.Score
 		a[n+2*i+1] = m.Member
 	}
+	a = append(a, isWriter)
 	cmd := NewIntCmd(a...)
 	c.Process(cmd)
 	return cmd
@@ -1084,6 +1128,7 @@ func (c *commandable) zIncr(a []interface{}, n int, members ...Z) *FloatCmd {
 		a[n+2*i] = m.Score
 		a[n+2*i+1] = m.Member
 	}
+	a = append(a, isWriter)
 	cmd := NewFloatCmd(a...)
 	c.Process(cmd)
 	return cmd
@@ -1120,13 +1165,13 @@ func (c *commandable) ZCard(key string) *IntCmd {
 }
 
 func (c *commandable) ZCount(key, min, max string) *IntCmd {
-	cmd := NewIntCmd("ZCOUNT", key, min, max)
+	cmd := NewIntCmd("ZCOUNT", key, min, max, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZIncrBy(key string, increment float64, member string) *FloatCmd {
-	cmd := NewFloatCmd("ZINCRBY", key, increment, member)
+	cmd := NewFloatCmd("ZINCRBY", key, increment, member, isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -1148,6 +1193,7 @@ func (c *commandable) ZInterStore(destination string, store ZStore, keys ...stri
 	if store.Aggregate != "" {
 		args = append(args, "AGGREGATE", store.Aggregate)
 	}
+	args = append(args, isWriter)
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1163,6 +1209,7 @@ func (c *commandable) zRange(key string, start, stop int64, withScores bool) *St
 	if withScores {
 		args = append(args, "WITHSCORES")
 	}
+	args = append(args, isReadOnly)
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1173,7 +1220,7 @@ func (c *commandable) ZRange(key string, start, stop int64) *StringSliceCmd {
 }
 
 func (c *commandable) ZRangeWithScores(key string, start, stop int64) *ZSliceCmd {
-	cmd := NewZSliceCmd("ZRANGE", key, start, stop, "WITHSCORES")
+	cmd := NewZSliceCmd("ZRANGE", key, start, stop, "WITHSCORES", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1196,6 +1243,7 @@ func (c *commandable) zRangeBy(zcmd, key string, opt ZRangeBy, withScores bool) 
 			opt.Count,
 		)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1219,24 +1267,26 @@ func (c *commandable) ZRangeByScoreWithScores(key string, opt ZRangeBy) *ZSliceC
 			opt.Count,
 		)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewZSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRank(key, member string) *IntCmd {
-	cmd := NewIntCmd("ZRANK", key, member)
+	cmd := NewIntCmd("ZRANK", key, member, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRem(key string, members ...string) *IntCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]interface{}, 3+len(members))
 	args[0] = "ZREM"
 	args[1] = key
 	for i, member := range members {
 		args[2+i] = member
 	}
+	args[len(members)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1248,25 +1298,26 @@ func (c *commandable) ZRemRangeByRank(key string, start, stop int64) *IntCmd {
 		key,
 		start,
 		stop,
+		isWriter,
 	)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRemRangeByScore(key, min, max string) *IntCmd {
-	cmd := NewIntCmd("ZREMRANGEBYSCORE", key, min, max)
+	cmd := NewIntCmd("ZREMRANGEBYSCORE", key, min, max, isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRevRange(key string, start, stop int64) *StringSliceCmd {
-	cmd := NewStringSliceCmd("ZREVRANGE", key, start, stop)
+	cmd := NewStringSliceCmd("ZREVRANGE", key, start, stop, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRevRangeWithScores(key string, start, stop int64) *ZSliceCmd {
-	cmd := NewZSliceCmd("ZREVRANGE", key, start, stop, "WITHSCORES")
+	cmd := NewZSliceCmd("ZREVRANGE", key, start, stop, "WITHSCORES", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1281,6 +1332,7 @@ func (c *commandable) zRevRangeBy(zcmd, key string, opt ZRangeBy) *StringSliceCm
 			opt.Count,
 		)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1304,19 +1356,20 @@ func (c *commandable) ZRevRangeByScoreWithScores(key string, opt ZRangeBy) *ZSli
 			opt.Count,
 		)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewZSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZRevRank(key, member string) *IntCmd {
-	cmd := NewIntCmd("ZREVRANK", key, member)
+	cmd := NewIntCmd("ZREVRANK", key, member, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ZScore(key, member string) *FloatCmd {
-	cmd := NewFloatCmd("ZSCORE", key, member)
+	cmd := NewFloatCmd("ZSCORE", key, member, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1338,6 +1391,7 @@ func (c *commandable) ZUnionStore(dest string, store ZStore, keys ...string) *In
 	if store.Aggregate != "" {
 		args = append(args, "AGGREGATE", store.Aggregate)
 	}
+	args = append(args, isWriter)
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1346,35 +1400,38 @@ func (c *commandable) ZUnionStore(dest string, store ZStore, keys ...string) *In
 //------------------------------------------------------------------------------
 
 func (c *commandable) PFAdd(key string, fields ...string) *IntCmd {
-	args := make([]interface{}, 2+len(fields))
+	args := make([]interface{}, 3+len(fields))
 	args[0] = "PFADD"
 	args[1] = key
 	for i, field := range fields {
 		args[2+i] = field
 	}
+	args[len(fields)+2] = isWriter
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) PFCount(keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]interface{}, 2+len(keys))
 	args[0] = "PFCOUNT"
 	for i, key := range keys {
 		args[1+i] = key
 	}
+	args[len(keys)+1] = isReadOnly
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) PFMerge(dest string, keys ...string) *StatusCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]interface{}, 3+len(keys))
 	args[0] = "PFMERGE"
 	args[1] = dest
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	args[len(keys)+2] = isWriter
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1383,35 +1440,35 @@ func (c *commandable) PFMerge(dest string, keys ...string) *StatusCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) BgRewriteAOF() *StatusCmd {
-	cmd := NewStatusCmd("BGREWRITEAOF")
+	cmd := NewStatusCmd("BGREWRITEAOF", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) BgSave() *StatusCmd {
-	cmd := NewStatusCmd("BGSAVE")
+	cmd := NewStatusCmd("BGSAVE", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClientKill(ipPort string) *StatusCmd {
-	cmd := NewStatusCmd("CLIENT", "KILL", ipPort)
+	cmd := NewStatusCmd("CLIENT", "KILL", ipPort, isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClientList() *StringCmd {
-	cmd := NewStringCmd("CLIENT", "LIST")
+	cmd := NewStringCmd("CLIENT", "LIST", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClientPause(dur time.Duration) *BoolCmd {
-	cmd := NewBoolCmd("CLIENT", "PAUSE", formatMs(dur))
+	cmd := NewBoolCmd("CLIENT", "PAUSE", formatMs(dur), isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
@@ -1419,54 +1476,54 @@ func (c *commandable) ClientPause(dur time.Duration) *BoolCmd {
 
 // ClientSetName assigns a name to the one of many connections in the pool.
 func (c *commandable) ClientSetName(name string) *BoolCmd {
-	cmd := NewBoolCmd("CLIENT", "SETNAME", name)
+	cmd := NewBoolCmd("CLIENT", "SETNAME", name, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 // ClientGetName returns the name of the one of many connections in the pool.
 func (c *Client) ClientGetName() *StringCmd {
-	cmd := NewStringCmd("CLIENT", "GETNAME")
+	cmd := NewStringCmd("CLIENT", "GETNAME", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ConfigGet(parameter string) *SliceCmd {
-	cmd := NewSliceCmd("CONFIG", "GET", parameter)
+	cmd := NewSliceCmd("CONFIG", "GET", parameter, isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ConfigResetStat() *StatusCmd {
-	cmd := NewStatusCmd("CONFIG", "RESETSTAT")
+	cmd := NewStatusCmd("CONFIG", "RESETSTAT", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ConfigSet(parameter, value string) *StatusCmd {
-	cmd := NewStatusCmd("CONFIG", "SET", parameter, value)
+	cmd := NewStatusCmd("CONFIG", "SET", parameter, value, isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) DbSize() *IntCmd {
-	cmd := NewIntCmd("DBSIZE")
+	cmd := NewIntCmd("DBSIZE", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) FlushAll() *StatusCmd {
-	cmd := newKeylessStatusCmd("FLUSHALL")
+	cmd := newKeylessStatusCmd("FLUSHALL", isWriter)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) FlushDb() *StatusCmd {
-	cmd := newKeylessStatusCmd("FLUSHDB")
+	cmd := newKeylessStatusCmd("FLUSHDB", isWriter)
 	c.Process(cmd)
 	return cmd
 }
@@ -1476,20 +1533,21 @@ func (c *commandable) Info(section ...string) *StringCmd {
 	if len(section) > 0 {
 		args = append(args, section[0])
 	}
+	args = append(args, isReadOnly)
 	cmd := NewStringCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) LastSave() *IntCmd {
-	cmd := NewIntCmd("LASTSAVE")
+	cmd := NewIntCmd("LASTSAVE", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Save() *StatusCmd {
-	cmd := newKeylessStatusCmd("SAVE")
+	cmd := newKeylessStatusCmd("SAVE", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1497,9 +1555,9 @@ func (c *commandable) Save() *StatusCmd {
 func (c *commandable) shutdown(modifier string) *StatusCmd {
 	var args []interface{}
 	if modifier == "" {
-		args = []interface{}{"SHUTDOWN"}
+		args = []interface{}{"SHUTDOWN", isReadOnly}
 	} else {
-		args = []interface{}{"SHUTDOWN", modifier}
+		args = []interface{}{"SHUTDOWN", modifier, isReadOnly}
 	}
 	cmd := newKeylessStatusCmd(args...)
 	c.Process(cmd)
@@ -1529,7 +1587,7 @@ func (c *commandable) ShutdownNoSave() *StatusCmd {
 }
 
 func (c *commandable) SlaveOf(host, port string) *StatusCmd {
-	cmd := newKeylessStatusCmd("SLAVEOF", host, port)
+	cmd := newKeylessStatusCmd("SLAVEOF", host, port, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1543,7 +1601,7 @@ func (c *commandable) Sync() {
 }
 
 func (c *commandable) Time() *StringSliceCmd {
-	cmd := NewStringSliceCmd("TIME")
+	cmd := NewStringSliceCmd("TIME", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
@@ -1563,6 +1621,7 @@ func (c *commandable) Eval(script string, keys []string, args ...interface{}) *C
 	for i, arg := range args {
 		cmdArgs[pos+i] = arg
 	}
+	cmdArgs = append(cmdArgs, isWriter)
 	cmd := NewCmd(cmdArgs...)
 	if len(keys) > 0 {
 		cmd._clusterKeyPos = 3
@@ -1583,6 +1642,7 @@ func (c *commandable) EvalSha(sha1 string, keys []string, args ...interface{}) *
 	for i, arg := range args {
 		cmdArgs[pos+i] = arg
 	}
+	cmdArgs = append(cmdArgs, isWriter)
 	cmd := NewCmd(cmdArgs...)
 	if len(keys) > 0 {
 		cmd._clusterKeyPos = 3
@@ -1592,12 +1652,13 @@ func (c *commandable) EvalSha(sha1 string, keys []string, args ...interface{}) *
 }
 
 func (c *commandable) ScriptExists(scripts ...string) *BoolSliceCmd {
-	args := make([]interface{}, 2+len(scripts))
+	args := make([]interface{}, 3+len(scripts))
 	args[0] = "SCRIPT"
 	args[1] = "EXISTS"
 	for i, script := range scripts {
 		args[2+i] = script
 	}
+	args[len(scripts)+2] = isReadOnly
 	cmd := NewBoolSliceCmd(args...)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
@@ -1605,19 +1666,19 @@ func (c *commandable) ScriptExists(scripts ...string) *BoolSliceCmd {
 }
 
 func (c *commandable) ScriptFlush() *StatusCmd {
-	cmd := newKeylessStatusCmd("SCRIPT", "FLUSH")
+	cmd := newKeylessStatusCmd("SCRIPT", "FLUSH", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ScriptKill() *StatusCmd {
-	cmd := newKeylessStatusCmd("SCRIPT", "KILL")
+	cmd := newKeylessStatusCmd("SCRIPT", "KILL", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ScriptLoad(script string) *StringCmd {
-	cmd := NewStringCmd("SCRIPT", "LOAD", script)
+	cmd := NewStringCmd("SCRIPT", "LOAD", script, isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
@@ -1626,7 +1687,7 @@ func (c *commandable) ScriptLoad(script string) *StringCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) DebugObject(key string) *StringCmd {
-	cmd := NewStringCmd("DEBUG", "OBJECT", key)
+	cmd := NewStringCmd("DEBUG", "OBJECT", key, isWriter)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
 	return cmd
@@ -1639,6 +1700,7 @@ func (c *commandable) PubSubChannels(pattern string) *StringSliceCmd {
 	if pattern != "*" {
 		args = append(args, pattern)
 	}
+	args = append(args, isReadOnly)
 	cmd := NewStringSliceCmd(args...)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
@@ -1646,12 +1708,13 @@ func (c *commandable) PubSubChannels(pattern string) *StringSliceCmd {
 }
 
 func (c *commandable) PubSubNumSub(channels ...string) *StringIntMapCmd {
-	args := make([]interface{}, 2+len(channels))
+	args := make([]interface{}, 3+len(channels))
 	args[0] = "PUBSUB"
 	args[1] = "NUMSUB"
 	for i, channel := range channels {
 		args[2+i] = channel
 	}
+	args[len(channels)+2] = isReadOnly
 	cmd := NewStringIntMapCmd(args...)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
@@ -1659,7 +1722,7 @@ func (c *commandable) PubSubNumSub(channels ...string) *StringIntMapCmd {
 }
 
 func (c *commandable) PubSubNumPat() *IntCmd {
-	cmd := NewIntCmd("PUBSUB", "NUMPAT")
+	cmd := NewIntCmd("PUBSUB", "NUMPAT", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
@@ -1668,84 +1731,85 @@ func (c *commandable) PubSubNumPat() *IntCmd {
 //------------------------------------------------------------------------------
 
 func (c *commandable) ClusterSlots() *ClusterSlotsCmd {
-	cmd := NewClusterSlotsCmd("CLUSTER", "slots")
+	cmd := NewClusterSlotsCmd("CLUSTER", "slots", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterNodes() *StringCmd {
-	cmd := NewStringCmd("CLUSTER", "nodes")
+	cmd := NewStringCmd("CLUSTER", "nodes", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterMeet(host, port string) *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "meet", host, port)
+	cmd := newKeylessStatusCmd("CLUSTER", "meet", host, port, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterForget(nodeID string) *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "forget", nodeID)
+	cmd := newKeylessStatusCmd("CLUSTER", "forget", nodeID, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterReplicate(nodeID string) *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "replicate", nodeID)
+	cmd := newKeylessStatusCmd("CLUSTER", "replicate", nodeID, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterResetSoft() *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "reset", "soft")
+	cmd := newKeylessStatusCmd("CLUSTER", "reset", "soft", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterResetHard() *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "reset", "hard")
+	cmd := newKeylessStatusCmd("CLUSTER", "reset", "hard", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterInfo() *StringCmd {
-	cmd := NewStringCmd("CLUSTER", "info")
+	cmd := NewStringCmd("CLUSTER", "info", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterKeySlot(key string) *IntCmd {
-	cmd := NewIntCmd("CLUSTER", "keyslot", key)
+	cmd := NewIntCmd("CLUSTER", "keyslot", key, isReadOnly)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterCountFailureReports(nodeID string) *IntCmd {
-	cmd := NewIntCmd("CLUSTER", "count-failure-reports", nodeID)
+	cmd := NewIntCmd("CLUSTER", "count-failure-reports", nodeID, isReadOnly)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterCountKeysInSlot(slot int) *IntCmd {
-	cmd := NewIntCmd("CLUSTER", "countkeysinslot", slot)
+	cmd := NewIntCmd("CLUSTER", "countkeysinslot", slot, isReadOnly)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterDelSlots(slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]interface{}, 3+len(slots))
 	args[0] = "CLUSTER"
 	args[1] = "DELSLOTS"
 	for i, slot := range slots {
 		args[2+i] = slot
 	}
+	args[len(slots)+2] = isReadOnly
 	cmd := newKeylessStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1761,45 +1825,46 @@ func (c *commandable) ClusterDelSlotsRange(min, max int) *StatusCmd {
 }
 
 func (c *commandable) ClusterSaveConfig() *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "saveconfig")
+	cmd := newKeylessStatusCmd("CLUSTER", "saveconfig", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterSlaves(nodeID string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("CLUSTER", "SLAVES", nodeID)
+	cmd := NewStringSliceCmd("CLUSTER", "SLAVES", nodeID, isReadOnly)
 	cmd._clusterKeyPos = 2
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) Readonly() *StatusCmd {
-	cmd := newKeylessStatusCmd("READONLY")
+	cmd := newKeylessStatusCmd("READONLY", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ReadWrite() *StatusCmd {
-	cmd := newKeylessStatusCmd("READWRITE")
+	cmd := newKeylessStatusCmd("READWRITE", isReadOnly)
 	cmd._clusterKeyPos = 0
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterFailover() *StatusCmd {
-	cmd := newKeylessStatusCmd("CLUSTER", "failover")
+	cmd := newKeylessStatusCmd("CLUSTER", "failover", isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) ClusterAddSlots(slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]interface{}, 3+len(slots))
 	args[0] = "CLUSTER"
 	args[1] = "ADDSLOTS"
 	for i, num := range slots {
 		args[2+i] = strconv.Itoa(num)
 	}
+	args[len(slots)+2] = isReadOnly
 	cmd := newKeylessStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1825,19 +1890,20 @@ func (c *commandable) GeoAdd(key string, geoLocation ...*GeoLocation) *IntCmd {
 		args[2+3*i+1] = eachLoc.Latitude
 		args[2+3*i+2] = eachLoc.Name
 	}
+	args = append(args, isWriter)
 	cmd := NewIntCmd(args...)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GeoRadius(key string, longitude, latitude float64, query *GeoRadiusQuery) *GeoLocationCmd {
-	cmd := NewGeoLocationCmd(query, "GEORADIUS", key, longitude, latitude)
+	cmd := NewGeoLocationCmd(query, "GEORADIUS", key, longitude, latitude, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GeoRadiusByMember(key, member string, query *GeoRadiusQuery) *GeoLocationCmd {
-	cmd := NewGeoLocationCmd(query, "GEORADIUSBYMEMBER", key, member)
+	cmd := NewGeoLocationCmd(query, "GEORADIUSBYMEMBER", key, member, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
@@ -1846,18 +1912,19 @@ func (c *commandable) GeoDist(key string, member1, member2, unit string) *FloatC
 	if unit == "" {
 		unit = "km"
 	}
-	cmd := NewFloatCmd("GEODIST", key, member1, member2, unit)
+	cmd := NewFloatCmd("GEODIST", key, member1, member2, unit, isReadOnly)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GeoHash(key string, members ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]interface{}, 3+len(members))
 	args[0] = "GEOHASH"
 	args[1] = key
 	for i, member := range members {
 		args[2+i] = member
 	}
+	args[len(members)+2] = isReadOnly
 	cmd := NewStringSliceCmd(args...)
 	c.Process(cmd)
 	return cmd

--- a/commands.go
+++ b/commands.go
@@ -726,7 +726,7 @@ func (c *commandable) HMSet(key string, fields map[string]string) *StatusCmd {
 		args[i+1] = v
 		i += 2
 	}
-	args[len(fields)+2] = isWriter
+	args[len(fields)*2+2] = isWriter
 	cmd := NewStatusCmd(args...)
 	c.Process(cmd)
 	return cmd
@@ -1897,13 +1897,13 @@ func (c *commandable) GeoAdd(key string, geoLocation ...*GeoLocation) *IntCmd {
 }
 
 func (c *commandable) GeoRadius(key string, longitude, latitude float64, query *GeoRadiusQuery) *GeoLocationCmd {
-	cmd := NewGeoLocationCmd(query, "GEORADIUS", key, longitude, latitude, isReadOnly)
+	cmd := NewGeoLocationCmd(query, "GEORADIUS", key, longitude, latitude)
 	c.Process(cmd)
 	return cmd
 }
 
 func (c *commandable) GeoRadiusByMember(key, member string, query *GeoRadiusQuery) *GeoLocationCmd {
-	cmd := NewGeoLocationCmd(query, "GEORADIUSBYMEMBER", key, member, isReadOnly)
+	cmd := NewGeoLocationCmd(query, "GEORADIUSBYMEMBER", key, member)
 	c.Process(cmd)
 	return cmd
 }

--- a/options.go
+++ b/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	// The frequency of idle checks.
 	// Default is 1 minute.
 	IdleCheckFrequency time.Duration
+	ReadOnly           bool
 }
 
 func (opt *Options) getNetwork() string {

--- a/redis.go
+++ b/redis.go
@@ -35,6 +35,18 @@ func (c *baseClient) conn() (*pool.Conn, error) {
 			_ = c.connPool.Remove(cn, err)
 			return nil, err
 		}
+		// If readonly then send readonly command for the connection
+		if c.opt.ReadOnly {
+			cmd := newKeylessStatusCmd("READONLY", isReadOnly)
+			cmd._clusterKeyPos = 0
+			if err := writeCmd(cn, cmd); err != nil {
+				internal.Logf("writeCmd failed: %s (Set ReadOnly for new conn)", err)
+			} else {
+				if err = cmd.readReply(cn); err != nil {
+					internal.Logf("readReply failed: %s (Set ReadOnly for new conn)", err)
+				}
+			}
+		}
 	}
 	return cn, err
 }


### PR DESCRIPTION
Hi guys,

I ran into few latency issues when doing queries on a redis-cluster split across multiple datacenters. 
I find out the package was always calling the first master of the slot (Which was causing latencies as master wasn't always the closest node handling the slot)

I suggest the following:
- Calculate the latency to each node just after retrieving the slots configuration
- Sending every `read only` commands to the closest node (Slave or Master)

Please let me know what you think about that or if you think of another/nicer way to do it.
Thanks,