### PR TITLE
Add support for SPOP with a count argument

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -959,8 +959,16 @@ func (c *commandable) SMove(source, destination string, member interface{}) *Boo
 	return cmd
 }
 
+// Redis `SPOP key` command.
 func (c *commandable) SPop(key string) *StringCmd {
 	cmd := NewStringCmd("SPOP", key)
+	c.Process(cmd)
+	return cmd
+}
+
+// Redis `SPOP key count` command.
+func (c *commandable) SPopN(key string, count int64) *StringSliceCmd {
+	cmd := NewStringSliceCmd("SPOP", key, count)
 	c.Process(cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1819,6 +1819,34 @@ var _ = Describe("Commands", func() {
 			sMembers := client.SMembers("set")
 			Expect(sMembers.Err()).NotTo(HaveOccurred())
 			Expect(sMembers.Val()).To(HaveLen(2))
+
+		})
+
+		It("should SPopN", func() {
+			sAdd := client.SAdd("set", "one")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd("set", "two")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd("set", "three")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd("set", "four")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+
+			sPopN := client.SPopN("set", 1)
+			Expect(sPopN.Err()).NotTo(HaveOccurred())
+			Expect(sPopN.Val()).NotTo(Equal([]string{""}))
+
+			sMembers := client.SMembers("set")
+			Expect(sMembers.Err()).NotTo(HaveOccurred())
+			Expect(sMembers.Val()).To(HaveLen(3))
+
+			sPopN = client.SPopN("set", 4)
+			Expect(sPopN.Err()).NotTo(HaveOccurred())
+			Expect(sPopN.Val()).To(HaveLen(3))
+
+			sMembers = client.SMembers("set")
+			Expect(sMembers.Err()).NotTo(HaveOccurred())
+			Expect(sMembers.Val()).To(HaveLen(0))
 		})
 
 		It("should SRandMember and SRandMemberN", func() {


### PR DESCRIPTION
This PR adds support for the `count` part of `SPOP key [count]` that was introduced in REDIS 3.2. The implementation follows the implementation of `SRandMemberN`.