### PR TITLE
Add ForEachMaster API.

### DIFF
--- a/command.go
+++ b/command.go
@@ -31,6 +31,7 @@ var (
 type Cmder interface {
 	args() []interface{}
 	arg(int) string
+
 	readReply(*pool.Conn) error
 	setErr(error)
 	reset()
@@ -142,7 +143,9 @@ type Cmd struct {
 }
 
 func NewCmd(args ...interface{}) *Cmd {
-	return &Cmd{baseCmd: newBaseCmd(args)}
+	return &Cmd{
+		baseCmd: newBaseCmd(args),
+	}
 }
 
 func (cmd *Cmd) reset() {

--- a/commands.go
+++ b/commands.go
@@ -52,11 +52,11 @@ func formatSec(dur time.Duration) string {
 }
 
 type cmdable struct {
-	process func(cmd Cmder)
+	process func(cmd Cmder) error
 }
 
 type statefulCmdable struct {
-	process func(cmd Cmder)
+	process func(cmd Cmder) error
 }
 
 //------------------------------------------------------------------------------

--- a/pipeline.go
+++ b/pipeline.go
@@ -22,10 +22,11 @@ type Pipeline struct {
 	closed int32
 }
 
-func (pipe *Pipeline) Process(cmd Cmder) {
+func (pipe *Pipeline) Process(cmd Cmder) error {
 	pipe.mu.Lock()
 	pipe.cmds = append(pipe.cmds, cmd)
 	pipe.mu.Unlock()
+	return nil
 }
 
 // Close closes the pipeline, releasing any open resources.

--- a/redis.go
+++ b/redis.go
@@ -74,7 +74,7 @@ func (c *baseClient) initConn(cn *pool.Conn) error {
 	return err
 }
 
-func (c *baseClient) Process(cmd Cmder) {
+func (c *baseClient) Process(cmd Cmder) error {
 	for i := 0; i <= c.opt.MaxRetries; i++ {
 		if i > 0 {
 			cmd.reset()
@@ -83,7 +83,7 @@ func (c *baseClient) Process(cmd Cmder) {
 		cn, err := c.conn()
 		if err != nil {
 			cmd.setErr(err)
-			return
+			return err
 		}
 
 		readTimeout := cmd.readTimeout()
@@ -100,7 +100,7 @@ func (c *baseClient) Process(cmd Cmder) {
 			if err != nil && shouldRetry(err) {
 				continue
 			}
-			return
+			return err
 		}
 
 		err = cmd.readReply(cn)
@@ -109,8 +109,10 @@ func (c *baseClient) Process(cmd Cmder) {
 			continue
 		}
 
-		return
+		return err
 	}
+
+	return cmd.Err()
 }
 
 func (c *baseClient) closed() bool {

--- a/ring.go
+++ b/ring.go
@@ -199,13 +199,13 @@ func (ring *Ring) getClient(key string) (*Client, error) {
 	return cl, nil
 }
 
-func (ring *Ring) Process(cmd Cmder) {
+func (ring *Ring) Process(cmd Cmder) error {
 	cl, err := ring.getClient(ring.cmdFirstKey(cmd))
 	if err != nil {
 		cmd.setErr(err)
-		return
+		return err
 	}
-	cl.baseClient.Process(cmd)
+	return cl.baseClient.Process(cmd)
 }
 
 // rebalance removes dead shards from the ring.

--- a/tx.go
+++ b/tx.go
@@ -50,12 +50,12 @@ func (c *Client) Watch(fn func(*Tx) error, keys ...string) error {
 	return retErr
 }
 
-func (tx *Tx) Process(cmd Cmder) {
+func (tx *Tx) Process(cmd Cmder) error {
 	if tx.cmds == nil {
-		tx.baseClient.Process(cmd)
-	} else {
-		tx.cmds = append(tx.cmds, cmd)
+		return tx.baseClient.Process(cmd)
 	}
+	tx.cmds = append(tx.cmds, cmd)
+	return nil
 }
 
 // close closes the transaction, releasing any open resources.


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/240. Example:

```
err := client.ForEachMaster(func(master *redis.Client) error {
	keys, err := master.Keys("*")
	if err != nil {
		return err
	}
	log.Println(keys)
})
```