### PR TITLE
Internalise rate-limiter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
     - go: tip
 
 install:
-  - go get gopkg.in/bsm/ratelimit.v1
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
   - go get github.com/garyburd/redigo/redis

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -8,9 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/bsm/ratelimit.v1"
-
 	"gopkg.in/redis.v4/internal"
+	"gopkg.in/redis.v4/internal/ratelimit"
 )
 
 var (

--- a/internal/ratelimit/LICENCE
+++ b/internal/ratelimit/LICENCE
@@ -1,0 +1,20 @@
+Copyright (c) 2015 Black Square Media
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,96 @@
+/*
+Simple, thread-safe Go rate-limiter.
+Inspired by Antti Huima's algorithm on http://stackoverflow.com/a/668327
+
+Example:
+
+  // Create a new rate-limiter, allowing up-to 10 calls
+  // per second
+  rl := ratelimit.New(10, time.Second)
+
+  for i:=0; i<20; i++ {
+    if rl.Limit() {
+      fmt.Println("DOH! Over limit!")
+    } else {
+      fmt.Println("OK")
+    }
+  }
+*/
+package ratelimit
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// RateLimiter instances are thread-safe.
+type RateLimiter struct {
+	rate, allowance, max, unit, lastCheck uint64
+}
+
+// New creates a new rate limiter instance
+func New(rate int, per time.Duration) *RateLimiter {
+	nano := uint64(per)
+	if nano < 1 {
+		nano = uint64(time.Second)
+	}
+	if rate < 1 {
+		rate = 1
+	}
+
+	return &RateLimiter{
+		rate:      uint64(rate),        // store the rate
+		allowance: uint64(rate) * nano, // set our allowance to max in the beginning
+		max:       uint64(rate) * nano, // remember our maximum allowance
+		unit:      nano,                // remember our unit size
+
+		lastCheck: unixNano(),
+	}
+}
+
+// UpdateRate allows to update the allowed rate
+func (rl *RateLimiter) UpdateRate(rate int) {
+	atomic.StoreUint64(&rl.rate, uint64(rate))
+	atomic.StoreUint64(&rl.max, uint64(rate)*rl.unit)
+}
+
+// Limit returns true if rate was exceeded
+func (rl *RateLimiter) Limit() bool {
+	// Calculate the number of ns that have passed since our last call
+	now := unixNano()
+	passed := now - atomic.SwapUint64(&rl.lastCheck, now)
+
+	// Add them to our allowance
+	rate := atomic.LoadUint64(&rl.rate)
+	current := atomic.AddUint64(&rl.allowance, passed*rate)
+
+	// Ensure our allowance is not over maximum
+	if max := atomic.LoadUint64(&rl.max); current > max {
+		atomic.AddUint64(&rl.allowance, max-current)
+		current = max
+	}
+
+	// If our allowance is less than one unit, rate-limit!
+	if current < rl.unit {
+		return true
+	}
+
+	// Not limited, subtract a unit
+	atomic.AddUint64(&rl.allowance, -rl.unit)
+	return false
+}
+
+// Undo reverts the last Limit() call, returning consumed allowance
+func (rl *RateLimiter) Undo() {
+	current := atomic.AddUint64(&rl.allowance, rl.unit)
+
+	// Ensure our allowance is not over maximum
+	if max := atomic.LoadUint64(&rl.max); current > max {
+		atomic.AddUint64(&rl.allowance, max-current)
+	}
+}
+
+// now as unix nanoseconds
+func unixNano() uint64 {
+	return uint64(time.Now().UnixNano())
+}

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,134 @@
+package ratelimit
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RateLimiter", func() {
+
+	It("should accurately rate-limit at small rates", func() {
+		var count int
+		rl := New(10, time.Minute)
+		for !rl.Limit() {
+			count++
+		}
+		Expect(count).To(Equal(10))
+	})
+
+	It("should accurately rate-limit at large rates", func() {
+		var count int
+		rl := New(100000, time.Hour)
+		for !rl.Limit() {
+			count++
+		}
+		Expect(count).To(BeNumerically("~", 100000, 10))
+	})
+
+	It("should accurately rate-limit at large intervals", func() {
+		var count int
+		rl := New(100, 360*24*time.Hour)
+		for !rl.Limit() {
+			count++
+		}
+		Expect(count).To(Equal(100))
+	})
+
+	It("should correctly increase allowance", func() {
+		n := 25
+		rl := New(n, 50*time.Millisecond)
+		for i := 0; i < n; i++ {
+			Expect(rl.Limit()).To(BeFalse(), "on cycle %d", i)
+		}
+		Expect(rl.Limit()).To(BeTrue())
+		Eventually(rl.Limit, "60ms", "10ms").Should(BeFalse())
+	})
+
+	It("should correctly spread allowance", func() {
+		var count int
+		rl := New(5, 10*time.Millisecond)
+		start := time.Now()
+		for time.Now().Sub(start) < 100*time.Millisecond {
+			if !rl.Limit() {
+				count++
+			}
+		}
+		Expect(count).To(BeNumerically("~", 54, 1))
+	})
+
+	It("should undo", func() {
+		rl := New(5, time.Minute)
+
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeTrue())
+
+		rl.Undo()
+		Expect(rl.Limit()).To(BeFalse())
+		Expect(rl.Limit()).To(BeTrue())
+	})
+
+	It("should be thread-safe", func() {
+		c := 100
+		n := 100
+		wg := sync.WaitGroup{}
+		rl := New(c*n, time.Hour)
+		for i := 0; i < c; i++ {
+			wg.Add(1)
+
+			go func(thread int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				for j := 0; j < n; j++ {
+					Expect(rl.Limit()).To(BeFalse(), "thread %d, cycle %d", thread, j)
+				}
+			}(i)
+		}
+		wg.Wait()
+		Expect(rl.Limit()).To(BeTrue())
+	})
+
+	It("should allow to upate rate", func() {
+		var count int
+		rl := New(5, 50*time.Millisecond)
+		for !rl.Limit() {
+			count++
+		}
+		Expect(count).To(Equal(5))
+
+		rl.UpdateRate(10)
+		time.Sleep(50 * time.Millisecond)
+
+		for !rl.Limit() {
+			count++
+		}
+		Expect(count).To(Equal(15))
+	})
+
+})
+
+// --------------------------------------------------------------------
+
+func BenchmarkLimit(b *testing.B) {
+	rl := New(1000, time.Second)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Limit()
+	}
+}
+
+// --------------------------------------------------------------------
+
+func TestGinkgoSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ratelimit")
+}


### PR DESCRIPTION
Given that this lib is widely used, it's probably worth avoiding external dependencies, especially since it's only a few LOC.
