### PR TITLE
add WrapProcess to allow users to alter command processing

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -245,6 +245,14 @@ type cmdable struct {
 	process func(cmd Cmder) error
 }
 
+// WrapProcess replaces the process func. It takes a function createWrapper
+// which is supplied by the user. createWrapper takes the old process func as
+// an input and returns the new wrapper process func. createWrapper should
+// use call the old process func within the new process func.
+func (c *cmdable) WrapProcess(createWrapper func(oldProcess func(cmd Cmder) error) func(cmd Cmder) error) {
+	c.process = createWrapper(c.process)
+}
+
 var _ Cmdable = (*cmdable)(nil)
 
 type statefulCmdable struct {


### PR DESCRIPTION
This could be used to update metrics or debug/logging (#259).

There are many ways this could be done. I chose a way that involves minimal changes.

Example usage:
```
	client = redis.NewClient(...)

	client.WrapProcess(func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
		return func(cmd redis.Cmder) error {
			before := time.Now()

			err := oldProcess(cmd)

			if err != nil {
				log.Println(`error running redis command "`, cmd, `": `, err)
			} else {
				log.Println(`running redis command "`, cmd, `" took `, time.Since(before))
			}

			return err
		}
	})
```