### PR TITLE
pool.go:close conn when remove conn

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -635,10 +635,10 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolSize:    opt.PoolSize,
-		PoolTimeout: opt.PoolTimeout,
-		IdleTimeout: opt.IdleTimeout,
-
+		PoolSize:           opt.PoolSize,
+		PoolTimeout:        opt.PoolTimeout,
+		IdleTimeout:        opt.IdleTimeout,
+		IdleCheckFrequency: opt.IdleCheckFrequency,
 		// IdleCheckFrequency is not copied to disable reaper
 	}
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -222,6 +222,7 @@ func (p *ConnPool) Remove(cn *Conn, reason error) error {
 	p.connsMu.Lock()
 	p.remove(cn, reason)
 	p.connsMu.Unlock()
+	cn.Close()
 	p.queue <- struct{}{}
 	return nil
 }
@@ -318,6 +319,7 @@ func (p *ConnPool) ReapStaleConns() (n int, err error) {
 		p.connsMu.Lock()
 		p.remove(cn, errConnStale)
 		p.connsMu.Unlock()
+		cn.Close()
 		n++
 	}
 	if idx > 0 {


### PR DESCRIPTION
hi editor:
     when origin code run some time, redis server has many client link, but redis client log show that the own link is few.
     I find when remove conn from pool, the conn has not been closed.
     So I suggest this pull request.
     wish editor to give feedback.   
                                                                                                                           from lijunfei