### PR TITLE
Disable idle checks for cluster connection

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -627,6 +627,8 @@ func (opt *ClusterOptions) init() {
 }
 
 func (opt *ClusterOptions) clientOptions() *Options {
+	const disableIdleCheck = -1
+
 	return &Options{
 		Password: opt.Password,
 		ReadOnly: opt.ReadOnly,
@@ -640,5 +642,6 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		IdleTimeout: opt.IdleTimeout,
 
 		// IdleCheckFrequency is not copied to disable reaper
+		IdleCheckFrequency: disableIdleCheck,
 	}
 }

--- a/options.go
+++ b/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	IdleTimeout time.Duration
 	// Frequency of idle checks.
 	// Default is 1 minute.
+	// When minus value is set, then idle check is disabled.
 	IdleCheckFrequency time.Duration
 
 	// Enables read only queries on slave nodes.


### PR DESCRIPTION
This PR disables reap connection for cluster.

`ClusterOptions.clientOptions()` does not copy `IdleCheckFrequency` field, but `Options.init()` sets default parameter (1min).
So `ConnPool.reaper()` is enabled in `NewConnPool()`.

I'm not sure the concept to disable idle check for cluster connection is right decision but I follow the comment in `ClusterOptions.clientOptions()`

```go
    // IdleCheckFrequency is not copied to disable reaper
```

If not, I'll create another PR to reflect IdleCheckFrequency from cluster options.