### PR TITLE
Add new parameter to the RingOptions to override CommandInfo first key

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -138,6 +138,7 @@ func redisRingOptions() *redis.RingOptions {
 		PoolTimeout:        30 * time.Second,
 		IdleTimeout:        500 * time.Millisecond,
 		IdleCheckFrequency: 500 * time.Millisecond,
+		RouteByEvalKeys:    true,
 	}
 }
 


### PR DESCRIPTION
There is problem with `eval` and `evalsha` commands.
`COMMAND INFO eval` returns first key position `0`.
After that, redis ring chooses `eval` as a value for sharding.
Then, if you try to delete created value, ring may choose another shard
and delete won't work.
    
Eval command should be parsed, to be sharded properly, according to
redis specs: http://redis.io/commands/command .
    
I've introduced a new flag in the `RingOptions`, which will enable new
behavior: `RouteByEvalKeys `.
    
If it is enabled, `cmdFirstKey` will check if function is  `eval` or
`evalsha` commands and will check if number of params -- `cmd.arg(2) != "0"`.
If it has parameters, it will return `3`, otherwise it will return `0`.