### PR TITLE
Remove reaper function in cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -436,35 +436,6 @@ func (c *ClusterClient) setNodesLatency() {
 	}
 }
 
-// reaper closes idle connections to the cluster.
-func (c *ClusterClient) reaper(frequency time.Duration) {
-	ticker := time.NewTicker(frequency)
-	defer ticker.Stop()
-
-	for _ = range ticker.C {
-		nodes := c.getNodes()
-		if nodes == nil {
-			break
-		}
-
-		var n int
-		for _, node := range nodes {
-			nn, err := node.Client.connPool.(*pool.ConnPool).ReapStaleConns()
-			if err != nil {
-				internal.Logf("ReapStaleConns failed: %s", err)
-			} else {
-				n += nn
-			}
-		}
-
-		s := c.PoolStats()
-		internal.Logf(
-			"reaper: removed %d stale conns (TotalConns=%d FreeConns=%d Requests=%d Hits=%d Timeouts=%d)",
-			n, s.TotalConns, s.FreeConns, s.Requests, s.Hits, s.Timeouts,
-		)
-	}
-}
-
 func (c *ClusterClient) Pipeline() *Pipeline {
 	pipe := Pipeline{
 		exec: c.pipelineExec,


### PR DESCRIPTION
After [this P-R](https://github.com/go-redis/redis/pull/285/files#diff-5012ac478fddb03fa409c41a16a72b0dL44) was merged, `ClusterClient.reaper` is not called from anywhere.
(or Is this unintentional ?)

```
$ git grep -n reaper ./
cluster.go:613:         // IdleCheckFrequency is not copied to disable reaper
internal/pool/pool.go:88:               go p.reaper(idleCheckFrequency)
internal/pool/pool.go:339:func (p *ConnPool) reaper(frequency time.Duration) {
internal/pool/pool.go:354:                      "reaper: removed %d stale conns (TotalConns=%d FreeConns=%d Requests=%d Hits=%d Timeouts=%d)",
internal/pool/pool_test.go:95:var _ = Describe("conns reaper", func() {
```

Thanks!