### PR TITLE
Remove Addr field from clusterNode

### DIFF
--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -8,7 +8,7 @@ import (
 func (c *ClusterClient) SlotAddrs(slot int) []string {
 	var addrs []string
 	for _, n := range c.slotNodes(slot) {
-		addrs = append(addrs, n.Addr)
+		addrs = append(addrs, n.Client.getAddr())
 	}
 	return addrs
 }
@@ -51,22 +51,22 @@ var _ = Describe("ClusterClient", func() {
 
 	It("should update slots cache", func() {
 		populate()
-		Expect(subject.slots[0][0].Addr).To(Equal("127.0.0.1:7000"))
-		Expect(subject.slots[0][1].Addr).To(Equal("127.0.0.1:7004"))
-		Expect(subject.slots[4095][0].Addr).To(Equal("127.0.0.1:7000"))
-		Expect(subject.slots[4095][1].Addr).To(Equal("127.0.0.1:7004"))
-		Expect(subject.slots[4096][0].Addr).To(Equal("127.0.0.1:7001"))
-		Expect(subject.slots[4096][1].Addr).To(Equal("127.0.0.1:7005"))
-		Expect(subject.slots[8191][0].Addr).To(Equal("127.0.0.1:7001"))
-		Expect(subject.slots[8191][1].Addr).To(Equal("127.0.0.1:7005"))
-		Expect(subject.slots[8192][0].Addr).To(Equal("127.0.0.1:7002"))
-		Expect(subject.slots[8192][1].Addr).To(Equal("127.0.0.1:7006"))
-		Expect(subject.slots[12287][0].Addr).To(Equal("127.0.0.1:7002"))
-		Expect(subject.slots[12287][1].Addr).To(Equal("127.0.0.1:7006"))
-		Expect(subject.slots[12288][0].Addr).To(Equal("127.0.0.1:7003"))
-		Expect(subject.slots[12288][1].Addr).To(Equal("127.0.0.1:7007"))
-		Expect(subject.slots[16383][0].Addr).To(Equal("127.0.0.1:7003"))
-		Expect(subject.slots[16383][1].Addr).To(Equal("127.0.0.1:7007"))
+		Expect(subject.slots[0][0].Client.getAddr()).To(Equal("127.0.0.1:7000"))
+		Expect(subject.slots[0][1].Client.getAddr()).To(Equal("127.0.0.1:7004"))
+		Expect(subject.slots[4095][0].Client.getAddr()).To(Equal("127.0.0.1:7000"))
+		Expect(subject.slots[4095][1].Client.getAddr()).To(Equal("127.0.0.1:7004"))
+		Expect(subject.slots[4096][0].Client.getAddr()).To(Equal("127.0.0.1:7001"))
+		Expect(subject.slots[4096][1].Client.getAddr()).To(Equal("127.0.0.1:7005"))
+		Expect(subject.slots[8191][0].Client.getAddr()).To(Equal("127.0.0.1:7001"))
+		Expect(subject.slots[8191][1].Client.getAddr()).To(Equal("127.0.0.1:7005"))
+		Expect(subject.slots[8192][0].Client.getAddr()).To(Equal("127.0.0.1:7002"))
+		Expect(subject.slots[8192][1].Client.getAddr()).To(Equal("127.0.0.1:7006"))
+		Expect(subject.slots[12287][0].Client.getAddr()).To(Equal("127.0.0.1:7002"))
+		Expect(subject.slots[12287][1].Client.getAddr()).To(Equal("127.0.0.1:7006"))
+		Expect(subject.slots[12288][0].Client.getAddr()).To(Equal("127.0.0.1:7003"))
+		Expect(subject.slots[12288][1].Client.getAddr()).To(Equal("127.0.0.1:7007"))
+		Expect(subject.slots[16383][0].Client.getAddr()).To(Equal("127.0.0.1:7003"))
+		Expect(subject.slots[16383][1].Client.getAddr()).To(Equal("127.0.0.1:7007"))
 		Expect(subject.addrs).To(Equal([]string{
 			"127.0.0.1:6379",
 			"127.0.0.1:7003",

--- a/redis.go
+++ b/redis.go
@@ -24,7 +24,7 @@ type baseClient struct {
 }
 
 func (c *baseClient) String() string {
-	return fmt.Sprintf("Redis<%s db:%d>", c.opt.Addr, c.opt.DB)
+	return fmt.Sprintf("Redis<%s db:%d>", c.getAddr(), c.opt.DB)
 }
 
 func (c *baseClient) conn() (*pool.Conn, bool, error) {
@@ -138,6 +138,10 @@ func (c *baseClient) Close() error {
 		retErr = err
 	}
 	return retErr
+}
+
+func (c *baseClient) getAddr() string {
+	return c.opt.Addr
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
To avoid a duplicate definition,
remove `Addr` field from `clusterNode`.

thanks!