### PR TITLE
if readonly is open, read from master when slave is loading data

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -300,6 +300,17 @@ func (c *ClusterClient) Process(cmd Cmder) error {
 			return nil
 		}
 
+		// If slave is loading, read from master
+		if errors.IsLoading(cmd.Err()) && c.opt.ReadOnly {
+			trynode, err := c.slotMasterNode(slot)
+			if err == nil && trynode != node {
+				node = trynode
+				continue
+			} else {
+				break
+			}
+		}
+
 		// On network errors try random node.
 		if errors.IsRetryable(err) {
 			node, err = c.randomNode()

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -10,6 +10,8 @@ const Nil = RedisError("redis: nil")
 
 type RedisError string
 
+var LoadingError RedisError = "LOADING Redis is loading the dataset in memory"
+
 func (e RedisError) Error() string { return string(e) }
 
 func IsRetryable(err error) bool {
@@ -64,4 +66,8 @@ func IsMoved(err error) (moved bool, ask bool, addr string) {
 	}
 	addr = s[ind+1:]
 	return
+}
+
+func IsLoading(err error) bool {
+	return err.Error() == string(LastIndexoadingError)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,5 +69,5 @@ func IsMoved(err error) (moved bool, ask bool, addr string) {
 }
 
 func IsLoading(err error) bool {
-	return err.Error() == string(LastIndexoadingError)
+	return err.Error() == string(LoadingError)
 }


### PR DESCRIPTION
I meet a problem in cluster; When slave failover, other slave will resync data from new master, if readonly is open, service can't get data in some minute. So I suggest to get data from new master in the sync duration.   