### PR TITLE
Remove static import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,5 @@ install:
   - go get gopkg.in/bsm/ratelimit.v1
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
-  - go get github.com/garyburd/redigo/redis
   - mkdir -p $HOME/gopath/src/gopkg.in
-  - mv $HOME/gopath/src/github.com/go-redis/redis $HOME/gopath/src/gopkg.in/redis.v4
-  - cd $HOME/gopath/src/gopkg.in/redis.v4
+  - mv `pwd` $HOME/gopath/src/gopkg.in/redis.v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v5
+
+ - *Important*. ClusterClient and Ring now chose random node/shard when command does not have any keys or command info is not fully available. Also clients use EVAL and EVALSHA keys to pick the right node.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,31 @@ Examples: http://godoc.org/gopkg.in/redis.v5#pkg-examples.
 
 Install:
 
-    go get gopkg.in/redis.v5
+```shell
+go get gopkg.in/redis.v5
+```
+
+Import:
+
+```go
+import "gopkg.in/redis.v5"
+```
+
+## Vendoring
+
+If you are using a vendoring tool with support for semantic versioning
+e.g. [glide](https://github.com/Masterminds/glide), you can import this
+package via its GitHub URL:
+
+```yaml
+- package: github.com/go-redis/redis
+  version: ^5.0.0
+```
+
+WARNING: please note that by importing `github.com/go-redis/redis`
+directly (without semantic versioning constrol) you are in danger of
+running in the breaking API changes. Use carefully and at your own
+risk!
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,26 @@
 Supports:
 
 - Redis 3 commands except QUIT, MONITOR, SLOWLOG and SYNC.
-- [Pub/Sub](http://godoc.org/gopkg.in/redis.v4#PubSub).
-- [Transactions](http://godoc.org/gopkg.in/redis.v4#Multi).
-- [Pipelining](http://godoc.org/gopkg.in/redis.v4#Client.Pipeline).
-- [Scripting](http://godoc.org/gopkg.in/redis.v4#Script).
-- [Timeouts](http://godoc.org/gopkg.in/redis.v4#Options).
-- [Redis Sentinel](http://godoc.org/gopkg.in/redis.v4#NewFailoverClient).
-- [Redis Cluster](http://godoc.org/gopkg.in/redis.v4#NewClusterClient).
-- [Ring](http://godoc.org/gopkg.in/redis.v4#NewRing).
+- [Pub/Sub](http://godoc.org/gopkg.in/redis.v5#PubSub).
+- [Transactions](http://godoc.org/gopkg.in/redis.v5#Multi).
+- [Pipelining](http://godoc.org/gopkg.in/redis.v5#Client.Pipeline).
+- [Scripting](http://godoc.org/gopkg.in/redis.v5#Script).
+- [Timeouts](http://godoc.org/gopkg.in/redis.v5#Options).
+- [Redis Sentinel](http://godoc.org/gopkg.in/redis.v5#NewFailoverClient).
+- [Redis Cluster](http://godoc.org/gopkg.in/redis.v5#NewClusterClient).
+- [Ring](http://godoc.org/gopkg.in/redis.v5#NewRing).
 - [Cache friendly](https://github.com/go-redis/cache).
 - [Rate limiting](https://github.com/go-redis/rate).
 - [Distributed Locks](https://github.com/bsm/redis-lock).
 
-API docs: http://godoc.org/gopkg.in/redis.v4.
-Examples: http://godoc.org/gopkg.in/redis.v4#pkg-examples.
+API docs: http://godoc.org/gopkg.in/redis.v5.
+Examples: http://godoc.org/gopkg.in/redis.v5#pkg-examples.
 
 ## Installation
 
 Install:
 
-    go get gopkg.in/redis.v4
+    go get gopkg.in/redis.v5
 
 ## Quickstart
 
@@ -66,7 +66,7 @@ func ExampleClient() {
 
 ## Howto
 
-Please go through [examples](http://godoc.org/gopkg.in/redis.v4#pkg-examples) to get an idea how to use this package.
+Please go through [examples](http://godoc.org/gopkg.in/redis.v5#pkg-examples) to get an idea how to use this package.
 
 ## Look and feel
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 	"time"
 
-	redigo "github.com/garyburd/redigo/redis"
-
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 func benchmarkRedisClient(poolSize int) *redis.Client {
@@ -71,7 +69,7 @@ func BenchmarkRedisGetNil(b *testing.B) {
 	})
 }
 
-func benchmarkSetGoRedis(b *testing.B, poolSize, payloadSize int) {
+func benchmarkSetRedis(b *testing.B, poolSize, payloadSize int) {
 	client := benchmarkRedisClient(poolSize)
 	defer client.Close()
 
@@ -88,93 +86,36 @@ func benchmarkSetGoRedis(b *testing.B, poolSize, payloadSize int) {
 	})
 }
 
-func BenchmarkSetGoRedis10Conns64Bytes(b *testing.B) {
-	benchmarkSetGoRedis(b, 10, 64)
+func BenchmarkSetRedis10Conns64Bytes(b *testing.B) {
+	benchmarkSetRedis(b, 10, 64)
 }
 
-func BenchmarkSetGoRedis100Conns64Bytes(b *testing.B) {
-	benchmarkSetGoRedis(b, 100, 64)
+func BenchmarkSetRedis100Conns64Bytes(b *testing.B) {
+	benchmarkSetRedis(b, 100, 64)
 }
 
-func BenchmarkSetGoRedis10Conns1KB(b *testing.B) {
-	benchmarkSetGoRedis(b, 10, 1024)
+func BenchmarkSetRedis10Conns1KB(b *testing.B) {
+	benchmarkSetRedis(b, 10, 1024)
 }
 
-func BenchmarkSetGoRedis100Conns1KB(b *testing.B) {
-	benchmarkSetGoRedis(b, 100, 1024)
+func BenchmarkSetRedis100Conns1KB(b *testing.B) {
+	benchmarkSetRedis(b, 100, 1024)
 }
 
-func BenchmarkSetGoRedis10Conns10KB(b *testing.B) {
-	benchmarkSetGoRedis(b, 10, 10*1024)
+func BenchmarkSetRedis10Conns10KB(b *testing.B) {
+	benchmarkSetRedis(b, 10, 10*1024)
 }
 
-func BenchmarkSetGoRedis100Conns10KB(b *testing.B) {
-	benchmarkSetGoRedis(b, 100, 10*1024)
+func BenchmarkSetRedis100Conns10KB(b *testing.B) {
+	benchmarkSetRedis(b, 100, 10*1024)
 }
 
-func BenchmarkSetGoRedis10Conns1MB(b *testing.B) {
-	benchmarkSetGoRedis(b, 10, 1024*1024)
+func BenchmarkSetRedis10Conns1MB(b *testing.B) {
+	benchmarkSetRedis(b, 10, 1024*1024)
 }
 
-func BenchmarkSetGoRedis100Conns1MB(b *testing.B) {
-	benchmarkSetGoRedis(b, 100, 1024*1024)
-}
-
-func benchmarkSetRedigo(b *testing.B, poolSize, payloadSize int) {
-	pool := &redigo.Pool{
-		Dial: func() (redigo.Conn, error) {
-			return redigo.DialTimeout("tcp", ":6379", time.Second, time.Second, time.Second)
-		},
-		MaxActive: poolSize,
-		MaxIdle:   poolSize,
-	}
-	defer pool.Close()
-
-	value := string(bytes.Repeat([]byte{'1'}, payloadSize))
-
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			conn := pool.Get()
-			if _, err := conn.Do("SET", "key", value); err != nil {
-				b.Fatal(err)
-			}
-			conn.Close()
-		}
-	})
-}
-
-func BenchmarkSetRedigo10Conns64Bytes(b *testing.B) {
-	benchmarkSetRedigo(b, 10, 64)
-}
-
-func BenchmarkSetRedigo100Conns64Bytes(b *testing.B) {
-	benchmarkSetRedigo(b, 100, 64)
-}
-
-func BenchmarkSetRedigo10Conns1KB(b *testing.B) {
-	benchmarkSetRedigo(b, 10, 1024)
-}
-
-func BenchmarkSetRedigo100Conns1KB(b *testing.B) {
-	benchmarkSetRedigo(b, 100, 1024)
-}
-
-func BenchmarkSetRedigo10Conns10KB(b *testing.B) {
-	benchmarkSetRedigo(b, 10, 10*1024)
-}
-
-func BenchmarkSetRedigo100Conns10KB(b *testing.B) {
-	benchmarkSetRedigo(b, 100, 10*1024)
-}
-
-func BenchmarkSetRedigo10Conns1MB(b *testing.B) {
-	benchmarkSetRedigo(b, 10, 1024*1024)
-}
-
-func BenchmarkSetRedigo100Conns1MB(b *testing.B) {
-	benchmarkSetRedigo(b, 100, 1024*1024)
+func BenchmarkSetRedis100Conns1MB(b *testing.B) {
+	benchmarkSetRedis(b, 100, 1024*1024)
 }
 
 func BenchmarkRedisSetGetBytes(b *testing.B) {

--- a/cluster.go
+++ b/cluster.go
@@ -300,6 +300,17 @@ func (c *ClusterClient) Process(cmd Cmder) error {
 			return nil
 		}
 
+		// If slave is loading, read from master
+		if errors.IsLoading(cmd.Err()) && c.opt.ReadOnly {
+			trynode, err := c.slotMasterNode(slot)
+			if err == nil && trynode != node {
+				node = trynode
+				continue
+			} else {
+				break
+			}
+		}
+
 		// On network errors try random node.
 		if errors.IsRetryable(err) {
 			node, err = c.randomNode()

--- a/cluster.go
+++ b/cluster.go
@@ -6,10 +6,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/errors"
-	"gopkg.in/redis.v4/internal/hashtag"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal/hashtag"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 // ClusterOptions are used to configure a cluster client and should be

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -301,6 +301,37 @@ var _ = Describe("ClusterClient", func() {
 			Expect(client.Close()).NotTo(HaveOccurred())
 		})
 
+		It("distributes keys", func() {
+			for i := 0; i < 100; i++ {
+				err := client.Set(fmt.Sprintf("key%d", i), "value", 0).Err()
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			wanted := []string{"keys=31", "keys=29", "keys=40"}
+			for i, master := range cluster.masters() {
+				Expect(master.Info().Val()).To(ContainSubstring(wanted[i]))
+			}
+		})
+
+		It("distributes keys when using EVAL", func() {
+			script := redis.NewScript(`
+				local r = redis.call('SET', KEYS[1], ARGV[1])
+				return r
+			`)
+
+			var key string
+			for i := 0; i < 100; i++ {
+				key = fmt.Sprintf("key%d", i)
+				err := script.Run(client, []string{key}, "value").Err()
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			wanted := []string{"keys=31", "keys=29", "keys=40"}
+			for i, master := range cluster.masters() {
+				Expect(master.Info().Val()).To(ContainSubstring(wanted[i]))
+			}
+		})
+
 		It("supports Watch", func() {
 			var incr func(string) error
 
@@ -342,60 +373,62 @@ var _ = Describe("ClusterClient", func() {
 			Expect(n).To(Equal(int64(100)))
 		})
 
-		It("supports pipeline", func() {
-			slot := hashtag.Slot("A")
-			Expect(client.SwapSlotNodes(slot)).To(Equal([]string{"127.0.0.1:8224", "127.0.0.1:8221"}))
+		Describe("pipeline", func() {
+			It("follows redirects", func() {
+				slot := hashtag.Slot("A")
+				Expect(client.SwapSlotNodes(slot)).To(Equal([]string{"127.0.0.1:8224", "127.0.0.1:8221"}))
 
-			pipe := client.Pipeline()
-			defer pipe.Close()
+				pipe := client.Pipeline()
+				defer pipe.Close()
 
-			keys := []string{"A", "B", "C", "D", "E", "F", "G"}
+				keys := []string{"A", "B", "C", "D", "E", "F", "G"}
 
-			for i, key := range keys {
-				pipe.Set(key, key+"_value", 0)
-				pipe.Expire(key, time.Duration(i+1)*time.Hour)
-			}
-			cmds, err := pipe.Exec()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cmds).To(HaveLen(14))
+				for i, key := range keys {
+					pipe.Set(key, key+"_value", 0)
+					pipe.Expire(key, time.Duration(i+1)*time.Hour)
+				}
+				cmds, err := pipe.Exec()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmds).To(HaveLen(14))
 
-			for _, key := range keys {
-				pipe.Get(key)
-				pipe.TTL(key)
-			}
-			cmds, err = pipe.Exec()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cmds).To(HaveLen(14))
-			Expect(cmds[0].(*redis.StringCmd).Val()).To(Equal("A_value"))
-			Expect(cmds[1].(*redis.DurationCmd).Val()).To(BeNumerically("~", 1*time.Hour, time.Second))
-			Expect(cmds[6].(*redis.StringCmd).Val()).To(Equal("D_value"))
-			Expect(cmds[7].(*redis.DurationCmd).Val()).To(BeNumerically("~", 4*time.Hour, time.Second))
-			Expect(cmds[12].(*redis.StringCmd).Val()).To(Equal("G_value"))
-			Expect(cmds[13].(*redis.DurationCmd).Val()).To(BeNumerically("~", 7*time.Hour, time.Second))
-		})
-
-		It("supports pipeline with missing keys", func() {
-			Expect(client.Set("A", "A_value", 0).Err()).NotTo(HaveOccurred())
-			Expect(client.Set("C", "C_value", 0).Err()).NotTo(HaveOccurred())
-
-			var a, b, c *redis.StringCmd
-			cmds, err := client.Pipelined(func(pipe *redis.Pipeline) error {
-				a = pipe.Get("A")
-				b = pipe.Get("B")
-				c = pipe.Get("C")
-				return nil
+				for _, key := range keys {
+					pipe.Get(key)
+					pipe.TTL(key)
+				}
+				cmds, err = pipe.Exec()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmds).To(HaveLen(14))
+				Expect(cmds[0].(*redis.StringCmd).Val()).To(Equal("A_value"))
+				Expect(cmds[1].(*redis.DurationCmd).Val()).To(BeNumerically("~", 1*time.Hour, time.Second))
+				Expect(cmds[6].(*redis.StringCmd).Val()).To(Equal("D_value"))
+				Expect(cmds[7].(*redis.DurationCmd).Val()).To(BeNumerically("~", 4*time.Hour, time.Second))
+				Expect(cmds[12].(*redis.StringCmd).Val()).To(Equal("G_value"))
+				Expect(cmds[13].(*redis.DurationCmd).Val()).To(BeNumerically("~", 7*time.Hour, time.Second))
 			})
-			Expect(err).To(Equal(redis.Nil))
-			Expect(cmds).To(HaveLen(3))
 
-			Expect(a.Err()).NotTo(HaveOccurred())
-			Expect(a.Val()).To(Equal("A_value"))
+			It("works with missing keys", func() {
+				Expect(client.Set("A", "A_value", 0).Err()).NotTo(HaveOccurred())
+				Expect(client.Set("C", "C_value", 0).Err()).NotTo(HaveOccurred())
 
-			Expect(b.Err()).To(Equal(redis.Nil))
-			Expect(b.Val()).To(Equal(""))
+				var a, b, c *redis.StringCmd
+				cmds, err := client.Pipelined(func(pipe *redis.Pipeline) error {
+					a = pipe.Get("A")
+					b = pipe.Get("B")
+					c = pipe.Get("C")
+					return nil
+				})
+				Expect(err).To(Equal(redis.Nil))
+				Expect(cmds).To(HaveLen(3))
 
-			Expect(c.Err()).NotTo(HaveOccurred())
-			Expect(c.Val()).To(Equal("C_value"))
+				Expect(a.Err()).NotTo(HaveOccurred())
+				Expect(a.Val()).To(Equal("A_value"))
+
+				Expect(b.Err()).To(Equal(redis.Nil))
+				Expect(b.Val()).To(Equal(""))
+
+				Expect(c.Err()).NotTo(HaveOccurred())
+				Expect(c.Val()).To(Equal("C_value"))
+			})
 		})
 
 		It("calls fn for every master node", func() {
@@ -451,6 +484,25 @@ var _ = Describe("ClusterClient", func() {
 		describeClusterClient()
 	})
 
+	Describe("ClusterClient without nodes", func() {
+		BeforeEach(func() {
+			client = redis.NewClusterClient(&redis.ClusterOptions{})
+		})
+
+		It("returns an error", func() {
+			err := client.Ping().Err()
+			Expect(err).To(MatchError("redis: cluster has no nodes"))
+		})
+
+		It("pipeline returns an error", func() {
+			_, err := client.Pipelined(func(pipe *redis.Pipeline) error {
+				pipe.Ping()
+				return nil
+			})
+			Expect(err).To(MatchError("redis: cluster has no nodes"))
+		})
+	})
+
 	Describe("ClusterClient without valid nodes", func() {
 		BeforeEach(func() {
 			client = redis.NewClusterClient(&redis.ClusterOptions{
@@ -460,6 +512,14 @@ var _ = Describe("ClusterClient", func() {
 
 		It("returns an error", func() {
 			err := client.Ping().Err()
+			Expect(err).To(MatchError("ERR This instance has cluster support disabled"))
+		})
+
+		It("pipeline returns an error", func() {
+			_, err := client.Pipelined(func(pipe *redis.Pipeline) error {
+				pipe.Ping()
+				return nil
+			})
 			Expect(err).To(MatchError("ERR This instance has cluster support disabled"))
 		})
 	})

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
-	"gopkg.in/redis.v4/internal/hashtag"
+	"gopkg.in/redis.v5"
+	"gopkg.in/redis.v5/internal/hashtag"
 )
 
 type clusterScenario struct {

--- a/command.go
+++ b/command.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis/internal"
-
-	"gopkg.in/redis.v4/internal/pool"
-	"gopkg.in/redis.v4/internal/proto"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/pool"
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 var (

--- a/command_test.go
+++ b/command_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Cmd", func() {

--- a/commands.go
+++ b/commands.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"gopkg.in/redis.v5/internal"
-	"gopkg.in/redis.v5/internal/errors"
 )
 
 func readTimeout(timeout time.Duration) time.Duration {
@@ -1710,7 +1709,7 @@ func (c *cmdable) shutdown(modifier string) *StatusCmd {
 		}
 	} else {
 		// Server did not quit. String reply contains the reason.
-		cmd.err = errors.RedisError(cmd.val)
+		cmd.err = internal.RedisError(cmd.val)
 		cmd.val = ""
 	}
 	return cmd

--- a/commands.go
+++ b/commands.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/errors"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/errors"
 )
 
 func readTimeout(timeout time.Duration) time.Duration {

--- a/commands_test.go
+++ b/commands_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Commands", func() {

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var client *redis.Client

--- a/export_test.go
+++ b/export_test.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"time"
 
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 func (c *baseClient) Pool() pool.Pooler {

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,4 +1,4 @@
-package errors
+package internal
 
 import (
 	"io"
@@ -12,16 +12,16 @@ type RedisError string
 
 func (e RedisError) Error() string { return string(e) }
 
-func IsRetryable(err error) bool {
-	return IsNetwork(err)
+func IsRetryableError(err error) bool {
+	return IsNetworkError(err)
 }
 
-func IsInternal(err error) bool {
+func IsInternalError(err error) bool {
 	_, ok := err.(RedisError)
 	return ok
 }
 
-func IsNetwork(err error) bool {
+func IsNetworkError(err error) bool {
 	if err == io.EOF {
 		return true
 	}
@@ -33,7 +33,7 @@ func IsBadConn(err error, allowTimeout bool) bool {
 	if err == nil {
 		return false
 	}
-	if IsInternal(err) {
+	if IsInternalError(err) {
 		return false
 	}
 	if allowTimeout {
@@ -44,8 +44,8 @@ func IsBadConn(err error, allowTimeout bool) bool {
 	return true
 }
 
-func IsMoved(err error) (moved bool, ask bool, addr string) {
-	if !IsInternal(err) {
+func IsMovedError(err error) (moved bool, ask bool, addr string) {
+	if !IsInternalError(err) {
 		return
 	}
 
@@ -66,6 +66,6 @@ func IsMoved(err error) (moved bool, ask bool, addr string) {
 	return
 }
 
-func IsLoading(err error) bool {
+func IsLoadingError(err error) bool {
 	return strings.HasPrefix(err.Error(), "LOADING")
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -10,6 +10,8 @@ const Nil = RedisError("redis: nil")
 
 type RedisError string
 
+var LoadingError RedisError = "LOADING Redis is loading the dataset in memory"
+
 func (e RedisError) Error() string { return string(e) }
 
 func IsRetryable(err error) bool {
@@ -64,4 +66,8 @@ func IsMoved(err error) (moved bool, ask bool, addr string) {
 	}
 	addr = s[ind+1:]
 	return
+}
+
+func IsLoading(err error) bool {
+	return err.Error() == string(LoadingError)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -10,8 +10,6 @@ const Nil = RedisError("redis: nil")
 
 type RedisError string
 
-var LoadingError RedisError = "LOADING Redis is loading the dataset in memory"
-
 func (e RedisError) Error() string { return string(e) }
 
 func IsRetryable(err error) bool {
@@ -69,5 +67,5 @@ func IsMoved(err error) (moved bool, ask bool, addr string) {
 }
 
 func IsLoading(err error) bool {
-	return err.Error() == string(LoadingError)
+	return strings.HasPrefix(err.Error(), "LOADING")
 }

--- a/internal/pool/bench_test.go
+++ b/internal/pool/bench_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 func benchmarkPoolGetPut(b *testing.B, poolSize int) {

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	"gopkg.in/redis.v4/internal/proto"
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 const defaultBufSize = 4096

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -10,7 +10,7 @@ import (
 
 	"gopkg.in/bsm/ratelimit.v1"
 
-	"gopkg.in/redis.v4/internal"
+	"gopkg.in/redis.v5/internal"
 )
 
 var (

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 var _ = Describe("ConnPool", func() {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/redis.v4/internal/errors"
+	"gopkg.in/redis.v5/internal/errors"
 )
 
 const (

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 
 const defaultBufSize = 4096
 
-var errScanNil = errors.RedisError("redis: Scan(nil)")
+const errScanNil = internal.RedisError("redis: Scan(nil)")
 
 func Scan(b []byte, val interface{}) error {
 	switch v := val.(type) {

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strconv"
 
-	ierrors "gopkg.in/redis.v4/internal/errors"
+	ierrors "gopkg.in/redis.v5/internal/errors"
 )
 
 type MultiBulkParse func(*Reader, int64) (interface{}, error)

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -2,17 +2,16 @@ package proto
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
 
-	ierrors "gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal"
 )
 
-type MultiBulkParse func(*Reader, int64) (interface{}, error)
+const errEmptyReply = internal.RedisError("redis: reply is empty")
 
-var errEmptyReply = errors.New("redis: reply is empty")
+type MultiBulkParse func(*Reader, int64) (interface{}, error)
 
 type Reader struct {
 	src *bufio.Reader
@@ -59,7 +58,7 @@ func (p *Reader) ReadLine() ([]byte, error) {
 		return nil, errEmptyReply
 	}
 	if isNilReply(line) {
-		return nil, ierrors.Nil
+		return nil, internal.Nil
 	}
 	return line, nil
 }
@@ -209,7 +208,7 @@ func (p *Reader) ReadScanReply() ([]string, uint64, error) {
 
 func (p *Reader) parseBytesValue(line []byte) ([]byte, error) {
 	if isNilReply(line) {
-		return nil, ierrors.Nil
+		return nil, internal.Nil
 	}
 
 	replyLen, err := strconv.Atoi(string(line[1:]))
@@ -245,7 +244,7 @@ func isNilReply(b []byte) bool {
 }
 
 func parseErrorValue(line []byte) error {
-	return ierrors.RedisError(string(line[1:]))
+	return internal.RedisError(string(line[1:]))
 }
 
 func parseStatusValue(line []byte) ([]byte, error) {
@@ -258,7 +257,7 @@ func parseIntValue(line []byte) (int64, error) {
 
 func parseArrayLen(line []byte) (int64, error) {
 	if isNilReply(line) {
-		return 0, ierrors.Nil
+		return 0, internal.Nil
 	}
 	return parseIntValue(line)
 }

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -7,7 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/redis.v4/internal/proto"
+
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 var _ = Describe("Reader", func() {

--- a/internal/proto/writebuffer_test.go
+++ b/internal/proto/writebuffer_test.go
@@ -6,7 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/redis.v4/internal/proto"
+
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 var _ = Describe("WriteBuffer", func() {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("ScanIterator", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 const (
@@ -94,7 +94,7 @@ var _ = AfterSuite(func() {
 
 func TestGinkgoSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "gopkg.in/redis.v4")
+	RunSpecs(t, "gopkg.in/redis.v5")
 }
 
 //------------------------------------------------------------------------------

--- a/main_test.go
+++ b/main_test.go
@@ -138,6 +138,7 @@ func redisRingOptions() *redis.RingOptions {
 		PoolTimeout:        30 * time.Second,
 		IdleTimeout:        500 * time.Millisecond,
 		IdleCheckFrequency: 500 * time.Millisecond,
+		RouteByEvalKeys:    true,
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -138,7 +138,6 @@ func redisRingOptions() *redis.RingOptions {
 		PoolTimeout:        30 * time.Second,
 		IdleTimeout:        500 * time.Millisecond,
 		IdleCheckFrequency: 500 * time.Millisecond,
-		RouteByEvalKeys:    true,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 type Options struct {

--- a/parser.go
+++ b/parser.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strconv"
 
-	"gopkg.in/redis.v4/internal/proto"
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 // Implements proto.MultiBulkParse

--- a/pipeline.go
+++ b/pipeline.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"gopkg.in/redis.v4/internal/errors"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 // Pipeline implements pipelining as described in

--- a/pipeline.go
+++ b/pipeline.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal"
 	"gopkg.in/redis.v5/internal/pool"
 )
 
@@ -100,7 +100,7 @@ func execCmds(cn *pool.Conn, cmds []Cmder) ([]Cmder, error) {
 		if firstCmdErr == nil {
 			firstCmdErr = err
 		}
-		if errors.IsRetryable(err) {
+		if internal.IsRetryableError(err) {
 			failedCmds = append(failedCmds, cmd)
 		}
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Pipelining", func() {

--- a/pool_test.go
+++ b/pool_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 var _ = Describe("pool", func() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -5,9 +5,9 @@ import (
 	"net"
 	"time"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/errors"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 // PubSub implements Pub/Sub commands as described in

--- a/pubsub.go
+++ b/pubsub.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"gopkg.in/redis.v5/internal"
-	"gopkg.in/redis.v5/internal/errors"
 	"gopkg.in/redis.v5/internal/pool"
 )
 
@@ -212,7 +211,7 @@ func (c *PubSub) receiveMessage(timeout time.Duration) (*Message, error) {
 	for {
 		msgi, err := c.ReceiveTimeout(timeout)
 		if err != nil {
-			if !errors.IsNetwork(err) {
+			if !internal.IsNetworkError(err) {
 				return nil, err
 			}
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("PubSub", func() {

--- a/race_test.go
+++ b/race_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 var _ = Describe("races", func() {

--- a/redis.go
+++ b/redis.go
@@ -1,12 +1,12 @@
-package redis // import "gopkg.in/redis.v4"
+package redis // import "gopkg.in/redis.v5"
 
 import (
 	"fmt"
 	"log"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/errors"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 // Redis nil reply, .e.g. when key does not exist.

--- a/redis.go
+++ b/redis.go
@@ -1,4 +1,4 @@
-package redis // import "gopkg.in/redis.v5"
+package redis
 
 import (
 	"fmt"

--- a/redis_test.go
+++ b/redis_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Client", func() {

--- a/ring.go
+++ b/ring.go
@@ -9,10 +9,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/consistenthash"
-	"gopkg.in/redis.v4/internal/hashtag"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/consistenthash"
+	"gopkg.in/redis.v5/internal/hashtag"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 var errRingShardsDown = errors.New("redis: all ring shards are down")

--- a/ring.go
+++ b/ring.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"errors"
 	"fmt"
+	"math/rand"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,9 +42,6 @@ type RingOptions struct {
 	PoolTimeout        time.Duration
 	IdleTimeout        time.Duration
 	IdleCheckFrequency time.Duration
-
-	// RouteByEvalKeys flag to enable eval and evalsha key position parsing for sharding
-	RouteByEvalKeys bool
 }
 
 func (opt *RingOptions) init() {
@@ -131,12 +130,10 @@ type Ring struct {
 	hash   *consistenthash.Map
 	shards map[string]*ringShard
 
-	cmdsInfo     map[string]*CommandInfo
 	cmdsInfoOnce *sync.Once
+	cmdsInfo     map[string]*CommandInfo
 
 	closed bool
-
-	routeByEvalKeys bool
 }
 
 var _ Cmdable = (*Ring)(nil)
@@ -159,7 +156,6 @@ func NewRing(opt *RingOptions) *Ring {
 		clopt.Addr = addr
 		ring.addClient(name, NewClient(clopt))
 	}
-	ring.routeByEvalKeys = opt.RouteByEvalKeys
 	go ring.heartbeat()
 	return ring
 }
@@ -227,30 +223,6 @@ func (c *Ring) cmdInfo(name string) *CommandInfo {
 	return c.cmdsInfo[name]
 }
 
-func (c *Ring) getEvalFirstKey(cmd Cmder) string {
-	if c.routeByEvalKeys && cmd.arg(2) != "0" {
-		return cmd.arg(3)
-	} else {
-		return cmd.arg(0)
-	}
-}
-
-func (c *Ring) cmdFirstKey(cmd Cmder) string {
-	switch cmd.arg(0) {
-	case "eval":
-		return c.getEvalFirstKey(cmd)
-	case "evalsha":
-		return c.getEvalFirstKey(cmd)
-	}
-
-	cmdInfo := c.cmdInfo(cmd.arg(0))
-	if cmdInfo == nil {
-		internal.Logf("info for cmd=%s not found", cmd.arg(0))
-		return ""
-	}
-	return cmd.arg(int(cmdInfo.FirstKeyPos))
-}
-
 func (c *Ring) addClient(name string, cl *Client) {
 	c.mu.Lock()
 	c.hash.Add(name)
@@ -258,14 +230,17 @@ func (c *Ring) addClient(name string, cl *Client) {
 	c.mu.Unlock()
 }
 
-func (c *Ring) getClient(key string) (*Client, error) {
+func (c *Ring) shardByKey(key string) (*Client, error) {
+	key = hashtag.Key(key)
+
 	c.mu.RLock()
 
 	if c.closed {
+		c.mu.RUnlock()
 		return nil, pool.ErrClosed
 	}
 
-	name := c.hash.Get(hashtag.Key(key))
+	name := c.hash.Get(key)
 	if name == "" {
 		c.mu.RUnlock()
 		return nil, errRingShardsDown
@@ -276,8 +251,32 @@ func (c *Ring) getClient(key string) (*Client, error) {
 	return cl, nil
 }
 
+func (c *Ring) randomShard() (*Client, error) {
+	return c.shardByKey(strconv.Itoa(rand.Int()))
+}
+
+func (c *Ring) shardByName(name string) (*Client, error) {
+	if name == "" {
+		return c.randomShard()
+	}
+
+	c.mu.RLock()
+	cl := c.shards[name].Client
+	c.mu.RUnlock()
+	return cl, nil
+}
+
+func (c *Ring) cmdShard(cmd Cmder) (*Client, error) {
+	cmdInfo := c.cmdInfo(cmd.arg(0))
+	firstKey := cmd.arg(cmdFirstKeyPos(cmd, cmdInfo))
+	if firstKey == "" {
+		return c.randomShard()
+	}
+	return c.shardByKey(firstKey)
+}
+
 func (c *Ring) Process(cmd Cmder) error {
-	cl, err := c.getClient(c.cmdFirstKey(cmd))
+	cl, err := c.cmdShard(cmd)
 	if err != nil {
 		cmd.setErr(err)
 		return err
@@ -285,17 +284,18 @@ func (c *Ring) Process(cmd Cmder) error {
 	return cl.baseClient.Process(cmd)
 }
 
-// rebalance removes dead shards from the c.
+// rebalance removes dead shards from the Ring.
 func (c *Ring) rebalance() {
-	defer c.mu.Unlock()
-	c.mu.Lock()
-
-	c.hash = consistenthash.New(c.nreplicas, nil)
+	hash := consistenthash.New(c.nreplicas, nil)
 	for name, shard := range c.shards {
 		if shard.IsUp() {
-			c.hash.Add(name)
+			hash.Add(name)
 		}
 	}
+
+	c.mu.Lock()
+	c.hash = hash
+	c.mu.Unlock()
 }
 
 // heartbeat monitors state of each shard in the ring.
@@ -370,13 +370,10 @@ func (c *Ring) pipelineExec(cmds []Cmder) error {
 
 	cmdsMap := make(map[string][]Cmder)
 	for _, cmd := range cmds {
-		name := c.hash.Get(hashtag.Key(c.cmdFirstKey(cmd)))
-		if name == "" {
-			cmd.setErr(errRingShardsDown)
-			if retErr == nil {
-				retErr = errRingShardsDown
-			}
-			continue
+		cmdInfo := c.cmdInfo(cmd.arg(0))
+		name := cmd.arg(cmdFirstKeyPos(cmd, cmdInfo))
+		if name != "" {
+			name = c.hash.Get(hashtag.Key(name))
 		}
 		cmdsMap[name] = append(cmdsMap[name], cmd)
 	}
@@ -385,7 +382,15 @@ func (c *Ring) pipelineExec(cmds []Cmder) error {
 		failedCmdsMap := make(map[string][]Cmder)
 
 		for name, cmds := range cmdsMap {
-			client := c.shards[name].Client
+			client, err := c.shardByName(name)
+			if err != nil {
+				setCmdsErr(cmds, err)
+				if retErr == nil {
+					retErr = err
+				}
+				continue
+			}
+
 			cn, _, err := client.conn()
 			if err != nil {
 				setCmdsErr(cmds, err)

--- a/ring_test.go
+++ b/ring_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Redis Ring", func() {

--- a/ring_test.go
+++ b/ring_test.go
@@ -38,10 +38,27 @@ var _ = Describe("Redis Ring", func() {
 		Expect(ring.Close()).NotTo(HaveOccurred())
 	})
 
-	It("uses both shards", func() {
+	It("distributes keys", func() {
 		setRingKeys()
 
 		// Both shards should have some keys now.
+		Expect(ringShard1.Info().Val()).To(ContainSubstring("keys=57"))
+		Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=43"))
+	})
+
+	It("distributes keys when using EVAL", func() {
+		script := redis.NewScript(`
+			local r = redis.call('SET', KEYS[1], ARGV[1])
+			return r
+		`)
+
+		var key string
+		for i := 0; i < 100; i++ {
+			key = fmt.Sprintf("key%d", i)
+			err := script.Run(ring, []string{key}, "value").Err()
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		Expect(ringShard1.Info().Val()).To(ContainSubstring("keys=57"))
 		Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=43"))
 	})
@@ -89,34 +106,8 @@ var _ = Describe("Redis Ring", func() {
 		Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=100"))
 	})
 
-	It("supports eval key search", func() {
-		script := redis.NewScript(`
-			local r = redis.call('SET', KEYS[1], ARGV[1])
-			return r
-		`)
-
-		var key string
-		for i := 0; i < 100; i++ {
-			key = fmt.Sprintf("key{%d}", i)
-			err := script.Run(ring, []string{key}, "value").Err()
-			Expect(err).NotTo(HaveOccurred())
-		}
-
-		Expect(ringShard1.Info().Val()).To(ContainSubstring("keys=52"))
-		Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=48"))
-	})
-
-	Describe("pipelining", func() {
-		It("returns an error when all shards are down", func() {
-			ring := redis.NewRing(&redis.RingOptions{})
-			_, err := ring.Pipelined(func(pipe *redis.Pipeline) error {
-				pipe.Ping()
-				return nil
-			})
-			Expect(err).To(MatchError("redis: all ring shards are down"))
-		})
-
-		It("uses both shards", func() {
+	Describe("pipeline", func() {
+		It("distributes keys", func() {
 			pipe := ring.Pipeline()
 			for i := 0; i < 100; i++ {
 				err := pipe.Set(fmt.Sprintf("key%d", i), "value", 0).Err()
@@ -173,5 +164,30 @@ var _ = Describe("Redis Ring", func() {
 			Expect(ringShard1.Info().Val()).ToNot(ContainSubstring("keys="))
 			Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=100"))
 		})
+	})
+})
+
+var _ = Describe("empty Redis Ring", func() {
+	var ring *redis.Ring
+
+	BeforeEach(func() {
+		ring = redis.NewRing(&redis.RingOptions{})
+	})
+
+	AfterEach(func() {
+		Expect(ring.Close()).NotTo(HaveOccurred())
+	})
+
+	It("returns an error", func() {
+		err := ring.Ping().Err()
+		Expect(err).To(MatchError("redis: all ring shards are down"))
+	})
+
+	It("pipeline returns an error", func() {
+		_, err := ring.Pipelined(func(pipe *redis.Pipeline) error {
+			pipe.Ping()
+			return nil
+		})
+		Expect(err).To(MatchError("redis: all ring shards are down"))
 	})
 })

--- a/sentinel.go
+++ b/sentinel.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/redis.v4/internal"
-	"gopkg.in/redis.v4/internal/pool"
+	"gopkg.in/redis.v5/internal"
+	"gopkg.in/redis.v5/internal/pool"
 )
 
 //------------------------------------------------------------------------------

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Sentinel", func() {

--- a/tx.go
+++ b/tx.go
@@ -1,19 +1,17 @@
 package redis
 
 import (
-	"errors"
 	"fmt"
 
 	"gopkg.in/redis.v5/internal"
-	ierrors "gopkg.in/redis.v5/internal/errors"
 	"gopkg.in/redis.v5/internal/pool"
 	"gopkg.in/redis.v5/internal/proto"
 )
 
 // Redis transaction failed.
-const TxFailedErr = ierrors.RedisError("redis: transaction failed")
+const TxFailedErr = internal.RedisError("redis: transaction failed")
 
-var errDiscard = errors.New("redis: Discard can be used only inside Exec")
+var errDiscard = internal.RedisError("redis: Discard can be used only inside Exec")
 
 // Tx implements Redis transactions as described in
 // http://redis.io/topics/transactions. It's NOT safe for concurrent use

--- a/tx.go
+++ b/tx.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/redis.v4/internal"
-	ierrors "gopkg.in/redis.v4/internal/errors"
-	"gopkg.in/redis.v4/internal/pool"
-	"gopkg.in/redis.v4/internal/proto"
+	"gopkg.in/redis.v5/internal"
+	ierrors "gopkg.in/redis.v5/internal/errors"
+	"gopkg.in/redis.v5/internal/pool"
+	"gopkg.in/redis.v5/internal/proto"
 )
 
 // Redis transaction failed.

--- a/tx_test.go
+++ b/tx_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gopkg.in/redis.v4"
+	"gopkg.in/redis.v5"
 )
 
 var _ = Describe("Tx", func() {


### PR DESCRIPTION
Two reasons:

1. Most people use some sort of vendor tools these days and they support semver, e.g. https://github.com/Masterminds/glide. You are using tags already!
2. The gopkg.in servers are unfortunately not as stable and robust as I wish they were. We have experienced several failures on builds, CI runs, etc because of non-200 responses.

Replaces #395 