### PR TITLE
Remove static import

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,31 @@ Examples: http://godoc.org/gopkg.in/redis.v5#pkg-examples.
 
 Install:
 
-    go get gopkg.in/redis.v5
+```shell
+go get gopkg.in/redis.v5
+```
+
+Import:
+
+```go
+import "gopkg.in/redis.v5"
+```
+
+## Vendoring
+
+If you are using a vendoring tool with support for semantic versioning
+e.g. [glide](https://github.com/Masterminds/glide), you can import this
+package via its GitHub URL:
+
+```yaml
+- package: github.com/go-redis/redis
+  version: ^5.0.0
+```
+
+WARNING: please note that by importing `github.com/go-redis/redis`
+directly (without semantic versioning constrol) you are in danger of
+running in the breaking API changes. Use carefully and at your own
+risk!
 
 ## Quickstart
 

--- a/redis.go
+++ b/redis.go
@@ -1,4 +1,4 @@
-package redis // import "gopkg.in/redis.v5"
+package redis
 
 import (
 	"fmt"


### PR DESCRIPTION
Two reasons:

1. Most people use some sort of vendor tools these days and they support semver, e.g. https://github.com/Masterminds/glide. You are using tags already!
2. The gopkg.in servers are unfortunately not as stable and robust as I wish they were. We have experienced several failures on builds, CI runs, etc because of non-200 responses.

Replaces #395 