### PR TITLE
simplify if condition

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -653,7 +653,9 @@ func (c *ClusterClient) execClusterCmds(
 			cmd.reset()
 			failedCmds[nil] = append(failedCmds[nil], cmds[i:]...)
 			break
-		} else if moved, ask, addr := internal.IsMovedError(err); moved {
+		}
+		moved, ask, addr := internal.IsMovedError(err)
+		if moved {
 			c.lazyReloadSlots()
 			cmd.reset()
 			node, err := c.nodeByAddr(addr)


### PR DESCRIPTION
refactor `cluster.go`

Reduce elseif statements and distinguish between `errors.IsNetwork` and `errors.IsMoved`

```go
		if errors.IsNetwork(err) {
			...
			break
		}
		moved, ask, addr := internal.IsMovedError(err)
		if moved {
			...
		} else if ask {
			...
		} else {
			...
		}

```

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-redis/redis/400)
<!-- Reviewable:end -->
