### PR TITLE
Use RWMutex in pool

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -58,10 +58,10 @@ type ConnPool struct {
 
 	queue chan struct{}
 
-	connsMu sync.Mutex
+	connsMu sync.RWMutex
 	conns   []*Conn
 
-	freeConnsMu sync.Mutex
+	freeConnsMu sync.RWMutex
 	freeConns   []*Conn
 
 	stats Stats
@@ -238,17 +238,17 @@ func (p *ConnPool) remove(cn *Conn, reason error) {
 
 // Len returns total number of connections.
 func (p *ConnPool) Len() int {
-	p.connsMu.Lock()
+	p.connsMu.RLock()
 	l := len(p.conns)
-	p.connsMu.Unlock()
+	p.connsMu.RUnlock()
 	return l
 }
 
 // FreeLen returns number of free connections.
 func (p *ConnPool) FreeLen() int {
-	p.freeConnsMu.Lock()
+	p.freeConnsMu.RLock()
 	l := len(p.freeConns)
-	p.freeConnsMu.Unlock()
+	p.freeConnsMu.RUnlock()
 	return l
 }
 

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -11,7 +11,7 @@ type StickyConnPool struct {
 
 	cn     *Conn
 	closed bool
-	mx     sync.Mutex
+	mx     sync.RWMutex
 }
 
 var _ Pooler = (*StickyConnPool)(nil)
@@ -89,8 +89,8 @@ func (p *StickyConnPool) Remove(cn *Conn, reason error) error {
 }
 
 func (p *StickyConnPool) Len() int {
-	defer p.mx.Unlock()
-	p.mx.Lock()
+	defer p.mx.RUnlock()
+	p.mx.RLock()
 	if p.cn == nil {
 		return 0
 	}
@@ -98,8 +98,8 @@ func (p *StickyConnPool) Len() int {
 }
 
 func (p *StickyConnPool) FreeLen() int {
-	defer p.mx.Unlock()
-	p.mx.Lock()
+	defer p.mx.RUnlock()
+	p.mx.RLock()
 	if p.cn == nil {
 		return 1
 	}
@@ -130,8 +130,8 @@ func (p *StickyConnPool) Close() error {
 }
 
 func (p *StickyConnPool) Closed() bool {
-	p.mx.Lock()
+	p.mx.RLock()
 	closed := p.closed
-	p.mx.Unlock()
+	p.mx.RUnlock()
 	return closed
 }


### PR DESCRIPTION
Replace `Mutex` to `RWMutex`.
Use `RLock()` to spend waiting for locks with minimal time.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-redis/redis/404)
<!-- Reviewable:end -->
