### PR TITLE
Add support for parsing redis:// and rediss:// URLs

### DIFF
--- a/options.go
+++ b/options.go
@@ -154,7 +154,7 @@ func ParseURL(redisURL string) (*Options, error) {
 	}
 
 	if u.Scheme == "rediss" {
-		o.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		o.TLSConfig = &tls.Config{ServerName: h}
 	}
 	return o, nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,92 @@
+package redis
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	cases := []struct {
+		u      string
+		addr   string
+		db     int
+		dialer bool
+		err    error
+	}{
+		{
+			"redis://localhost:123/1",
+			"localhost:123",
+			1, false, nil,
+		},
+		{
+			"redis://localhost:123",
+			"localhost:123",
+			0, false, nil,
+		},
+		{
+			"redis://localhost/1",
+			"localhost:6379",
+			1, false, nil,
+		},
+		{
+			"redis://12345",
+			"12345:6379",
+			0, false, nil,
+		},
+		{
+			"rediss://localhost:123",
+			"localhost:123",
+			0, true, nil,
+		},
+		{
+			"redis://localhost/?abc=123",
+			"",
+			0, false, errors.New("no options supported"),
+		},
+		{
+			"http://google.com",
+			"",
+			0, false, errors.New("invalid redis URL scheme: http"),
+		},
+		{
+			"redis://localhost/1/2/3/4",
+			"",
+			0, false, errors.New("invalid redis URL path: /1/2/3/4"),
+		},
+		{
+			"12345",
+			"",
+			0, false, errors.New("invalid redis URL scheme: "),
+		},
+		{
+			"redis://localhost/iamadatabase",
+			"",
+			0, false, errors.New("Invalid redis database number: strconv.ParseInt: parsing \"iamadatabase\": invalid syntax"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.u, func(t *testing.T) {
+			o, err := ParseURL(c.u)
+			if c.err == nil && err != nil {
+				t.Fatalf("Expected err to be nil, but got: '%q'", err)
+				return
+			}
+			if c.err != nil && err != nil {
+				if c.err.Error() != err.Error() {
+					t.Fatalf("Expected err to be '%q', but got '%q'", c.err, err)
+				}
+				return
+			}
+			if o.Addr != c.addr {
+				t.Errorf("Expected Addr to be '%s', but got '%s'", c.addr, o.Addr)
+			}
+			if o.DB != c.db {
+				t.Errorf("Expecdted DB to be '%d', but got '%d'", c.db, o.DB)
+			}
+			if c.dialer && o.Dialer == nil {
+				t.Errorf("Expected a Dialer to be set, but isn't")
+			}
+		})
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestParseURL(t *testing.T) {
 	cases := []struct {
-		u      string
-		addr   string
-		db     int
-		dialer bool
-		err    error
+		u    string
+		addr string
+		db   int
+		tls  bool
+		err  error
 	}{
 		{
 			"redis://localhost:123/1",
@@ -63,7 +63,7 @@ func TestParseURL(t *testing.T) {
 		{
 			"redis://localhost/iamadatabase",
 			"",
-			0, false, errors.New("Invalid redis database number: strconv.ParseInt: parsing \"iamadatabase\": invalid syntax"),
+			0, false, errors.New("invalid redis database number: strconv.ParseInt: parsing \"iamadatabase\": invalid syntax"),
 		},
 	}
 
@@ -71,23 +71,23 @@ func TestParseURL(t *testing.T) {
 		t.Run(c.u, func(t *testing.T) {
 			o, err := ParseURL(c.u)
 			if c.err == nil && err != nil {
-				t.Fatalf("Expected err to be nil, but got: '%q'", err)
+				t.Fatalf("unexpected error: '%q'", err)
 				return
 			}
 			if c.err != nil && err != nil {
 				if c.err.Error() != err.Error() {
-					t.Fatalf("Expected err to be '%q', but got '%q'", c.err, err)
+					t.Fatalf("got %q, expected %q", err, c.err)
 				}
 				return
 			}
 			if o.Addr != c.addr {
-				t.Errorf("Expected Addr to be '%s', but got '%s'", c.addr, o.Addr)
+				t.Errorf("got %q, want %q", o.Addr, c.addr)
 			}
 			if o.DB != c.db {
-				t.Errorf("Expecdted DB to be '%d', but got '%d'", c.db, o.DB)
+				t.Errorf("got %q, expected %q", o.DB, c.db)
 			}
-			if c.dialer && o.Dialer == nil {
-				t.Errorf("Expected a Dialer to be set, but isn't")
+			if c.tls && o.TLSConfig == nil {
+				t.Errorf("got nil TLSConfig, expected a TLSConfig")
 			}
 		})
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package redis
 
 import (


### PR DESCRIPTION
This includes setting up a default dialer that handles the ssl
handshake.

We (Heroku) would like to move secure redis connections forward, but
have this chicken and egg problem with some drivers. Drivers for other
languages already support rediss://