### PR TITLE
Use low-level Process method with SCAN commands

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -7,6 +7,17 @@ type Scanner struct {
 	*ScanCmd
 }
 
+// NewTestScanner creates a scanner whose internal process function is
+// hijacked by the provided processor.
+func NewScanner(cmd *ScanCmd, process func(cmd Cmder) error) Scanner {
+	return Scanner{
+		client: &cmdable{
+			process: process,
+		},
+		ScanCmd: cmd,
+	}
+}
+
 // Iterator creates a new ScanIterator.
 func (s Scanner) Iterator() *ScanIterator {
 	return &ScanIterator{


### PR DESCRIPTION
# Motivation

I am currently working on a project that requires to use the HSCAN redis command on a cluster.
I would like to use the low-level `Cmdable.Process(cmder)` method. 

With the current implementation, I cannot access the Scanner of a ScanCmd. I cannot do:

```go
cmd := redis.NewScanCmd("HSCAN", "x")
cluster.Process(cmd) // assuming cluster is set...
scanner := redis.Scanner{ScanCmd: cmd)

// iterator.Next() eventualy calls the scanner.client.process method, which triggers a nil pointer panic: there is no way to set the client attribute of a scanner.
for scanner.Iterator().Next() {
    // it.Val()
}
```

This PR provides a NewScanner function, that takes a cmd and a processor.

```go
// NewTestScanner creates a scanner whose internal process function is
// hijacked by the provided processor.
func NewScanner(cmd *ScanCmd, process func(cmd Cmder) error) Scanner {
	return Scanner{
		client: &cmdable{
			process: process,
		},
		ScanCmd: cmd,
	}
}
```
With this modification, we could achieve the previous goal by changing one line in the previous snippet:

```go
cmd := redis.NewScanCmd("HSCAN", "x")
cluster.Process(cmd) // assuming cluster is set...
scanner := redis.NewScanner(cmd, cluster.Process)

// The scanner.client is defined, and the process attribute is the cluster.Process method. The panic
is avoided. Beside, the process method can be changed for a mock, easier for tests.
for scanner.Iterator().Next() {
    // it.Val()
}
```