### PR TITLE
Add "ScanSlice" to StringSliceCmd to allow scan into custom slice.

### DIFF
--- a/command.go
+++ b/command.go
@@ -526,6 +526,10 @@ func (cmd *StringSliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
+func (cmd *StringSliceCmd) ScanSlice(container interface{}) error {
+	return proto.ScanSlice(cmd.Val(), container)
+}
+
 func (cmd *StringSliceCmd) readReply(cn *pool.Conn) error {
 	var v interface{}
 	v, cmd.err = cn.Rd.ReadArrayReply(stringSliceParser)

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -4,7 +4,8 @@ import (
 	"encoding"
 	"fmt"
 	"strconv"
-
+	"reflect"
+	
 	"gopkg.in/redis.v5/internal"
 )
 
@@ -106,3 +107,63 @@ func Scan(s string, v interface{}) error {
 			"redis: can't unmarshal %T (consider implementing BinaryUnmarshaler)", v)
 	}
 }
+
+
+// Scan a string slice into a custom container
+// Example:
+// var container []YourStruct; ScanSlice([]string{""},&container)
+// var container []*YourStruct; ScanSlice([]string{""},&container)
+func ScanSlice(sSlice []string, container interface{}) error {
+	val := reflect.ValueOf(container)
+	ind := reflect.Indirect(val)
+	elemType := ind.Type().Elem()
+
+	// Check the if the container is pointer to slice
+	errTyp := true
+	isElemPtr := true
+	if val.Kind() == reflect.Ptr {
+		if ind.Kind() == reflect.Slice {
+			errTyp = false
+			isElemPtr = elemType.Kind() == reflect.Ptr
+		}
+	}
+	if errTyp {
+		return fmt.Errorf("wrong object type `%s` for rows scan, need *[]*Type or *[]Type", val.Type())
+	}
+
+	slice := ind
+	if isElemPtr {
+		for index, s := range sSlice {
+			elem := reflect.New(elemType)
+			mind := reflect.Indirect(elem)
+
+			if err := Scan(s, mind.Addr().Interface()); err != nil {
+				return fmt.Errorf("scan slice failed at index of %d: %s", index, err.Error())
+			}
+			// If elem is ptr, append with addr
+			slice = reflect.Append(slice, mind.Addr())
+		}
+	} else {
+		for index, s := range sSlice {
+			elem := reflect.New(elemType)
+			mind := reflect.Indirect(elem)
+
+			if err := Scan(s, mind.Addr().Interface()); err != nil {
+				return fmt.Errorf("scan slice failed at index of %d: %s", index, err.Error())
+			}
+			// If elem is ptr, append with value
+			slice = reflect.Append(slice, mind)
+		}
+	}
+	if slice.Len() > 0 {
+		ind.Set(slice)
+	} else {
+		// when a result is empty and container is nil
+		// to set a empty container
+		if ind.IsNil() {
+			ind.Set(reflect.MakeSlice(ind.Type(), 0, 0))
+		}
+	}
+	return nil
+}
+


### PR DESCRIPTION
It can help StringSliceCmd using in Set\ZSet and so on to quickly turn string response into custom slice.

Not only struct but also normal built-in value like "[]string", "[]int",... can work well ( []chan may not work well ).

Example: 
```golang
//FeedComment is a simple struct implement "encoding.BinaryMarshaler" and "encoding.BinaryUnmarshaler"

redisClient := ...

key := "TestStringSliceScan"
intCmd := redisClient.SAdd(key, &FeedComment{ID: 1}, &FeedComment{ID: 2}, &FeedComment{ID: 3})

stringSliceCmd := redisClient.SMembers(key)
var container []FeedComment
if err := stringSliceCmd.ScanSlice(&container); err == nil {
        fmt.Printf("%v", container)
} else {
        fmt.Printf("%v", err)
}
```

The container can be []YourStruct or []*YourStruct, but don't use []interface{}.