### PR TITLE
ensure wait.done to avoid deadlock in test

### DIFF
--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -347,11 +347,11 @@ var _ = Describe("PubSub", func() {
 			defer GinkgoRecover()
 
 			wg.Done()
-
+			defer wg.Done()
+			
 			_, err := pubsub.ReceiveMessage()
 			Expect(err).To(MatchError("redis: client is closed"))
 
-			wg.Done()
 		}()
 
 		wg.Wait()


### PR DESCRIPTION
Seems like in Go 1.4 sometimes the error returned from pubsub.ReceiveMessage is "use of closed network connection" error instead of "redis: client is closed". 
This cause the go routine to fail before it marks the waitGroup which causes the test to wait forever 
This commit doesn't fix the test but at least the build will fail sooner. 