### PR TITLE
the timeout of WAIT command is in milliseconds.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -275,7 +275,7 @@ func (c *cmdable) Ping() *StatusCmd {
 
 func (c *cmdable) Wait(numSlaves int, timeout time.Duration) *IntCmd {
 
-	cmd := NewIntCmd("wait", numSlaves, int(timeout/time.Second))
+	cmd := NewIntCmd("wait", numSlaves, int(timeout/time.Millisecond))
 	c.process(cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -52,9 +52,11 @@ var _ = Describe("Commands", func() {
 
 		It("should Wait", func() {
 			// assume testing on single redis instance
-			wait := client.Wait(0, time.Minute)
+			start := time.Now()
+			wait := client.Wait(1, time.Second)
 			Expect(wait.Err()).NotTo(HaveOccurred())
 			Expect(wait.Val()).To(Equal(int64(0)))
+			Expect(time.Now()).To(BeTemporally("~", start.Add(time.Second), 800*time.Millisecond))
 		})
 
 		It("should Select", func() {


### PR DESCRIPTION
I found that the timeout of WAIT command is too short.

[The document](https://redis.io/commands/wait) says that the timeout is in milliseconds,

> If the timeout, specified in milliseconds, is reached, the command returns even if the specified number of slaves were not yet reached.

but go-redis treats it as seconds.

``` go
cmd := NewIntCmd("wait", numSlaves, int(timeout/time.Second))
```

I tried WAIT command actually(in redis 3.2.8).
`wait 1 1000` timed out in 1000ms = 1s.

``` plain
127.0.0.1:6379> role
1) "master"
2) (integer) 0
3) (empty list or set)
127.0.0.1:6379> wait 1 1000
(integer) 0
(1.07s)
```
