### PR TITLE
Mention SETEX in the documentation.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -734,6 +734,7 @@ func (c *cmdable) MSetNX(pairs ...interface{}) *BoolCmd {
 
 // Redis `SET key value [expiration]` command.
 //
+// Use expiration for `SETEX`-like behavior.
 // Zero expiration means the key has no expiration time.
 func (c *cmdable) Set(key string, value interface{}, expiration time.Duration) *StatusCmd {
 	args := make([]interface{}, 3, 4)


### PR DESCRIPTION
To help people looking for it specifically.

(I just had a brief moment of madness: "Why was SETEX removed!?", until I found the [PR](https://github.com/go-redis/redis/pull/107), but I don't think everyone will use the GitHub search in such a desperation moment.)