### PR TITLE
Fix wrong usage of timer Reset(), causing service frozen during master switch.

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -95,12 +95,13 @@ func (p *ConnPool) NewConn() (*Conn, error) {
 
 func (p *ConnPool) PopFree() *Conn {
 	timer := timers.Get().(*time.Timer)
-	if !timer.Reset(p.poolTimeout) {
-		<-timer.C
-	}
+	timer.Reset(p.poolTimeout)
 
 	select {
 	case p.queue <- struct{}{}:
+		if !timer.Stop() {
+			<-timer.C
+		}
 		timers.Put(timer)
 	case <-timer.C:
 		timers.Put(timer)
@@ -138,12 +139,13 @@ func (p *ConnPool) Get() (*Conn, bool, error) {
 	atomic.AddUint32(&p.stats.Requests, 1)
 
 	timer := timers.Get().(*time.Timer)
-	if !timer.Reset(p.poolTimeout) {
-		<-timer.C
-	}
+	timer.Reset(p.poolTimeout)
 
 	select {
 	case p.queue <- struct{}{}:
+		if !timer.Stop() {
+			<-timer.C
+		}
 		timers.Put(timer)
 	case <-timer.C:
 		timers.Put(timer)


### PR DESCRIPTION
Fix for issue #521.