### PR TITLE
Client TxPipeline method should also return a Pipeliner

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -71,7 +71,7 @@ var _ = Describe("pipelining", func() {
 
 	Describe("TxPipeline", func() {
 		BeforeEach(func() {
-			pipe = client.TxPipeline()
+			pipe = client.TxPipeline().(*redis.Pipeline)
 		})
 
 		assertPipeline()

--- a/redis.go
+++ b/redis.go
@@ -342,7 +342,7 @@ func (c *Client) TxPipelined(fn func(Pipeliner) error) ([]Cmder, error) {
 }
 
 // TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
-func (c *Client) TxPipeline() *Pipeline {
+func (c *Client) TxPipeline() Pipeliner {
 	pipe := Pipeline{
 		exec: c.pipelineExecer(c.txPipelineProcessCmds),
 	}


### PR DESCRIPTION
@vmihailenco Sorry, I've left one method returning the struct instead of the new interface, my bad...
Can you merge this and retag?

Thanks!