### PR TITLE
Don't return an error when pipeline is empty

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/go-redis/redis/internal/pool"
@@ -80,7 +79,7 @@ func (c *Pipeline) Exec() ([]Cmder, error) {
 	}
 
 	if len(c.cmds) == 0 {
-		return nil, errors.New("redis: pipeline is empty")
+		return nil, nil
 	}
 
 	cmds := c.cmds

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -34,16 +34,17 @@ var _ = Describe("pipelining", func() {
 	})
 
 	assertPipeline := func() {
-		It("returns an error when there are no commands", func() {
+		It("returns no errors when there are no commands", func() {
 			_, err := pipe.Exec()
-			Expect(err).To(MatchError("redis: pipeline is empty"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("discards queued commands", func() {
 			pipe.Get("key")
 			pipe.Discard()
-			_, err := pipe.Exec()
-			Expect(err).To(MatchError("redis: pipeline is empty"))
+			cmds, err := pipe.Exec()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmds).To(BeNil())
 		})
 
 		It("handles val/err", func() {

--- a/redis_test.go
+++ b/redis_test.go
@@ -344,6 +344,7 @@ var _ = Describe("Client OnConnect", func() {
 
 	BeforeEach(func() {
 		opt := redisOptions()
+		opt.DB = 0
 		opt.OnConnect = func(cn *redis.Conn) error {
 			return cn.ClientSetName("on_connect").Err()
 		}

--- a/tx_test.go
+++ b/tx_test.go
@@ -86,12 +86,12 @@ var _ = Describe("Tx", func() {
 		Expect(get.Val()).To(Equal("hello2"))
 	})
 
-	It("returns an error when there are no commands", func() {
+	It("returns no error when there are no commands", func() {
 		err := client.Watch(func(tx *redis.Tx) error {
 			_, err := tx.Pipelined(func(redis.Pipeliner) error { return nil })
 			return err
 		})
-		Expect(err).To(MatchError("redis: pipeline is empty"))
+		Expect(err).NotTo(HaveOccurred())
 
 		v, err := client.Ping().Result()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/572