### PR TITLE
Use node address instead of relying on loopback reported by redis

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -2888,12 +2888,12 @@ var _ = Describe("Commands", func() {
 		It("returns map of commands", func() {
 			cmds, err := client.Command().Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(cmds)).To(BeNumerically("~", 173, 5))
+			Expect(len(cmds)).To(BeNumerically("~", 180, 10))
 
 			cmd := cmds["mget"]
 			Expect(cmd.Name).To(Equal("mget"))
 			Expect(cmd.Arity).To(Equal(int8(-2)))
-			Expect(cmd.Flags).To(Equal([]string{"readonly"}))
+			Expect(cmd.Flags).To(ContainElement("readonly"))
 			Expect(cmd.FirstKeyPos).To(Equal(int8(1)))
 			Expect(cmd.LastKeyPos).To(Equal(int8(-1)))
 			Expect(cmd.StepCount).To(Equal(int8(1)))


### PR DESCRIPTION
Not sure if this is a redis bug or a feature, but we have recently noticed `CLUSTER SLOTS` suddenly reporting:

```
1) 1) (integer) 12290
   2) (integer) 12697
   3) 1) "10.0.0.120"
      2) (integer) 6379
      3) "906ad7f61c9173cc86a793e7bdfc9d204153476f"
   4) 1) "127.0.0.1"
      2) (integer) 6379
      3) "e8e136bf028b88f4c7d5d64e73f134ed9b89dab6"
```

A similar issue was reported [here](https://github.com/luin/ioredis/issues/365)