### PR TITLE
Limit Readonly Option to cluster client only

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -88,7 +88,7 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
 		Password:        opt.Password,
-		ReadOnly:        opt.ReadOnly,
+		readOnly:        opt.ReadOnly,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,

--- a/options.go
+++ b/options.go
@@ -73,7 +73,7 @@ type Options struct {
 	IdleCheckFrequency time.Duration
 
 	// Enables read only queries on slave nodes.
-	ReadOnly bool
+	readOnly bool
 
 	// TLS Config to use. When set TLS will be negotiated.
 	TLSConfig *tls.Config

--- a/redis.go
+++ b/redis.go
@@ -68,7 +68,7 @@ func (c *baseClient) initConn(cn *pool.Conn) error {
 
 	if c.opt.Password == "" &&
 		c.opt.DB == 0 &&
-		!c.opt.ReadOnly &&
+		!c.opt.readOnly &&
 		c.opt.OnConnect == nil {
 		return nil
 	}
@@ -91,7 +91,7 @@ func (c *baseClient) initConn(cn *pool.Conn) error {
 			pipe.Select(c.opt.DB)
 		}
 
-		if c.opt.ReadOnly {
+		if c.opt.readOnly {
 			pipe.ReadOnly()
 		}
 

--- a/universal.go
+++ b/universal.go
@@ -17,11 +17,10 @@ type UniversalOptions struct {
 	// Only single-node and failover clients.
 	DB int
 
-	// Enables read only queries on slave nodes.
-	// Only cluster and single-node clients.
-	ReadOnly bool
-
 	// Only cluster clients.
+
+	// Enables read only queries on slave nodes.
+	ReadOnly bool
 
 	MaxRedirects   int
 	RouteByLatency bool
@@ -93,7 +92,6 @@ func (o *UniversalOptions) simple() *Options {
 	return &Options{
 		Addr:     addr,
 		DB:       o.DB,
-		ReadOnly: o.ReadOnly,
 
 		MaxRetries:         o.MaxRetries,
 		Password:           o.Password,


### PR DESCRIPTION
As described in https://github.com/go-redis/redis/issues/603, this PR rename `ReadOnly` to `readOnly` so that it can only be used by a cluster client.