### PR TITLE
fix when go-redis connect to ssdb server error

### DIFF
--- a/command.go
+++ b/command.go
@@ -252,8 +252,18 @@ func (cmd *StatusCmd) String() string {
 }
 
 func (cmd *StatusCmd) readReply(cn *pool.Conn) error {
-	cmd.val, cmd.err = cn.Rd.ReadStringReply()
-	return cmd.err
+	//fix connect to ssdb
+	//cmd.val, cmd.err = cn.Rd.ReadStringReply()
+	//return cmd.err
+	val, err := cn.Rd.ReadReply(sliceParser)
+	if err != nil {
+		return err
+	}
+	if b, ok := val.([]byte); ok {
+		// Bytes must be copied, because underlying memory is reused.
+		cmd.val = string(b)
+	}
+	return nil
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
ssdb server link: https://github.com/ideawu/ssdb

when go-redis connect to ssdb server, and then do ping cmd, then ssdb server will reply *1(ArrayReply  = '*'), but this code cannot not parse this reply, 
```
cmd.val, cmd.err = cn.Rd.ReadStringReply()
return cmd.err
```
so i fix it by add below code:

```
val, err := cn.Rd.ReadReply(sliceParser)
	if err != nil {
		return err
	}
	if b, ok := val.([]byte); ok {
		// Bytes must be copied, because underlying memory is reused.
		cmd.val = string(b)
	}
	return nil
```