### PR TITLE
Update example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ import "github.com/go-redis/redis"
 
 ```go
 func ExampleNewClient() {
-	client := redis.NewClient(&redis.Options{
-		Addr:     "localhost:6379",
+	client := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs:     []string{"localhost:6379"},
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	})


### PR DESCRIPTION
Let me know if this should be the default. It seems like a reasonable choice since running a redis sentinel cluster locally for testing is not that straightforward. 