### PR TITLE
fix unsafe.go 

### DIFF
--- a/internal/unsafe.go
+++ b/internal/unsafe.go
@@ -3,25 +3,20 @@
 package internal
 
 import (
-	"reflect"
 	"unsafe"
 )
 
+// BytesToString converts byte slice to string.
 func BytesToString(b []byte) string {
-	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	strHeader := reflect.StringHeader{
-		Data: bytesHeader.Data,
-		Len:  bytesHeader.Len,
-	}
-	return *(*string)(unsafe.Pointer(&strHeader))
+	return *(*string)(unsafe.Pointer(&b))
 }
 
+// StringToBytes converts string to byte slice.
 func StringToBytes(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	return *(*[]byte)(unsafe.Pointer(
+		&struct {
+		string
+		Cap int
+		}{s,len(s)},
+	))
 }


### PR DESCRIPTION
there is a problem of converts by reflect.see example:
```go
package main

import (
	"fmt"
	"reflect"
	"unsafe"
)

func main() {
	fmt.Println(GetString())
}

// BytesToString converts byte slice to string.
func BytesToString(b []byte) string {
	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
	strHeader := reflect.StringHeader{
		Data: bytesHeader.Data,
		Len:  bytesHeader.Len,
	}
	return *(*string)(unsafe.Pointer(&strHeader))
}

// StringToBytes converts string to byte slice.
func StringToBytes(s string) []byte {
	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
	bh := reflect.SliceHeader{
		Data: sh.Data,
		Len:  sh.Len,
		Cap:  sh.Len,
	}
	return *(*[]byte)(unsafe.Pointer(&bh))
}

func GetString() string {
	b := make([]byte, 8)
	return BytesToString(b)
}
```
i use cmd：
```go
go build -gcflags="-m"
```
output:
```go
.\main.go:14:6: can inline BytesToString
.\main.go:34:6: can inline GetString
.\main.go:36:22: inlining call to BytesToString
.\main.go:10:23: inlining call to GetString
.\main.go:10:23: inlining call to BytesToString
.\main.go:24:6: can inline StringToBytes
.\main.go:10:23: GetString() escapes to heap
.\main.go:10:23: main make([]byte, 8) does not escape
.\main.go:10:23: main &b does not escape
.\main.go:10:23: main &strHeader does not escape
.\main.go:10:13: main ... argument does not escape
.\main.go:14:30: BytesToString b does not escape
.\main.go:15:55: BytesToString &b does not escape
.\main.go:20:35: BytesToString &strHeader does not escape
.\main.go:24:32: StringToBytes s does not escape
.\main.go:25:47: StringToBytes &s does not escape
.\main.go:31:35: StringToBytes &bh does not escape
.\main.go:35:11: GetString make([]byte, 8) does not escape
.\main.go:36:22: GetString &b does not escape
.\main.go:36:22: GetString &strHeader does not escape
```
***.\main.go:35:11: GetString make([]byte, 8) does not escape*** so GetString got a unknown str
so i fix them