### PR TITLE
Add WrapProcess and WrapPipelineExecer to all clients for better instrument support

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -445,8 +445,8 @@ type ClusterClient struct {
 	cmdsInfoOnce internal.Once
 	cmdsInfo     map[string]*CommandInfo
 
-	process            func(Cmder) error
-	wrapPipelineExecer func(func([]Cmder) error) func([]Cmder) error
+	process             func(Cmder) error
+	wrapPipelineProcess func(func([]Cmder) error) func([]Cmder) error
 
 	// Reports whether slots reloading is in progress.
 	reloading uint32
@@ -922,14 +922,14 @@ func (c *ClusterClient) reaper(idleCheckFrequency time.Duration) {
 	}
 }
 
-func (c *ClusterClient) WrapPipelineExecer(fn func(func([]Cmder) error) func([]Cmder) error) {
-	c.wrapPipelineExecer = fn
+func (c *ClusterClient) WrapPipelineProcess(fn func(func([]Cmder) error) func([]Cmder) error) {
+	c.wrapPipelineProcess = fn
 }
 
 func (c *ClusterClient) Pipeline() Pipeliner {
 	pipelineExec := c.pipelineExec
-	if c.wrapPipelineExecer != nil {
-		pipelineExec = c.wrapPipelineExecer(pipelineExec)
+	if c.wrapPipelineProcess != nil {
+		pipelineExec = c.wrapPipelineProcess(pipelineExec)
 	}
 	pipe := Pipeline{
 		exec: pipelineExec,
@@ -1086,8 +1086,8 @@ func (c *ClusterClient) checkMovedErr(
 // TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
 func (c *ClusterClient) TxPipeline() Pipeliner {
 	txPipelineExec := c.txPipelineExec
-	if c.wrapPipelineExecer != nil {
-		txPipelineExec = c.wrapPipelineExecer(txPipelineExec)
+	if c.wrapPipelineProcess != nil {
+		txPipelineExec = c.wrapPipelineProcess(txPipelineExec)
 	}
 	pipe := Pipeline{
 		exec: txPipelineExec,

--- a/example_instrumentation_test.go
+++ b/example_instrumentation_test.go
@@ -63,7 +63,7 @@ func Example_Pipeline_instrumentation() {
 		Addr: ":6379",
 	})
 
-	client.WrapPipelineExecer(func(pe func([]redis.Cmder) error) func([]redis.Cmder) error {
+	client.WrapPipelineProcess(func(pe func([]redis.Cmder) error) func([]redis.Cmder) error {
 		return func(cmds []redis.Cmder) error {
 			fmt.Printf("pipeline starting process: %v", cmds)
 			err := pe(cmds)

--- a/example_instrumentation_test.go
+++ b/example_instrumentation_test.go
@@ -57,3 +57,23 @@ func wrapRedisProcess(client *redis.Client) {
 		}
 	})
 }
+
+func Example_Pipeline_instrumentation() {
+	client := redis.NewClient(&redis.Options{
+		Addr: ":6379",
+	})
+
+	client.WrapPipelineExecer(func(pe func([]redis.Cmder) error) func([]redis.Cmder) error {
+		return func(cmds []redis.Cmder) error {
+			fmt.Printf("pipeline starting process: %v", cmds)
+			err := pe(cmds)
+			fmt.Printf("pipeline finished process: %v", cmds)
+			return err
+		}
+	})
+
+	client.Pipelined(func(pipe redis.Pipeliner) error {
+		pipe.Ping()
+		pipe.Ping()
+	})
+}

--- a/example_instrumentation_test.go
+++ b/example_instrumentation_test.go
@@ -75,5 +75,6 @@ func Example_Pipeline_instrumentation() {
 	client.Pipelined(func(pipe redis.Pipeliner) error {
 		pipe.Ping()
 		pipe.Ping()
+		return nil
 	})
 }

--- a/redis.go
+++ b/redis.go
@@ -198,8 +198,8 @@ func (c *baseClient) getAddr() string {
 	return c.opt.Addr
 }
 
-func (c *baseClient) WrapPipelineExecer(fn func(func([]Cmder) error) func([]Cmder) error) {
-	c.wrapPipelineExecer = fn
+func (c *baseClient) WrapPipelineProcess(fn func(func([]Cmder) error) func([]Cmder) error) {
+	c.wrapPipelineProcess = fn
 }
 
 type pipelineProcessor func(*pool.Conn, []Cmder) (bool, error)
@@ -232,8 +232,8 @@ func (c *baseClient) pipelineExecer(p pipelineProcessor) pipelineExecer {
 		return firstCmdsErr(cmds)
 	}
 
-	if c.wrapPipelineExecer != nil {
-		return c.wrapPipelineExecer(defaultExecer)
+	if c.wrapPipelineProcess != nil {
+		return c.wrapPipelineProcess(defaultExecer)
 	}
 
 	return defaultExecer

--- a/redis_context.go
+++ b/redis_context.go
@@ -15,7 +15,7 @@ type baseClient struct {
 	process func(Cmder) error
 	onClose func() error // hook called when client is closed
 
-	wrapPipelineExecer func(func([]Cmder) error) func([]Cmder) error
+	wrapPipelineProcess func(func([]Cmder) error) func([]Cmder) error
 
 	ctx context.Context
 }

--- a/redis_context.go
+++ b/redis_context.go
@@ -15,6 +15,8 @@ type baseClient struct {
 	process func(Cmder) error
 	onClose func() error // hook called when client is closed
 
+	wrapPipelineExecer func(func([]Cmder) error) func([]Cmder) error
+
 	ctx context.Context
 }
 

--- a/ring.go
+++ b/ring.go
@@ -150,7 +150,7 @@ type Ring struct {
 	shards     map[string]*ringShard
 	shardsList []*ringShard
 
-	wrapPipelineExecer func(func([]Cmder) error) func([]Cmder) error
+	wrapPipelineProcess func(func([]Cmder) error) func([]Cmder) error
 
 	cmdsInfoOnce internal.Once
 	cmdsInfo     map[string]*CommandInfo
@@ -445,8 +445,8 @@ func (c *Ring) Close() error {
 
 func (c *Ring) Pipeline() Pipeliner {
 	pipelineExec := c.pipelineExec
-	if c.wrapPipelineExecer != nil {
-		pipelineExec = c.wrapPipelineExecer(pipelineExec)
+	if c.wrapPipelineProcess != nil {
+		pipelineExec = c.wrapPipelineProcess(pipelineExec)
 	}
 	pipe := Pipeline{
 		exec: pipelineExec,
@@ -459,8 +459,8 @@ func (c *Ring) Pipelined(fn func(Pipeliner) error) ([]Cmder, error) {
 	return c.Pipeline().Pipelined(fn)
 }
 
-func (c *Ring) WrapPipelineExecer(fn func(func([]Cmder) error) func([]Cmder) error) {
-	c.wrapPipelineExecer = fn
+func (c *Ring) WrapPipelineProcess(fn func(func([]Cmder) error) func([]Cmder) error) {
+	c.wrapPipelineProcess = fn
 }
 
 func (c *Ring) pipelineExec(cmds []Cmder) error {


### PR DESCRIPTION
Currently, there is only WrapProcess method in Client, not in other client. Besides, there is no method to instrument pipeline. This pull request implement WrapPipelineExecer method to instrument pipeline, and add WrapProcess and WrapPlinelineExecer to all clients