### PR TITLE
cluster: add support for context.Context to ClusterClient and Ring

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
@@ -438,6 +439,8 @@ func (c *clusterState) slotNodes(slot int) []*clusterNode {
 type ClusterClient struct {
 	cmdable
 
+	ctx context.Context
+
 	opt    *ClusterOptions
 	nodes  *clusterNodes
 	_state atomic.Value
@@ -568,6 +571,23 @@ func (c *ClusterClient) cmdSlotAndNode(state *clusterState, cmd Cmder) (int, *cl
 
 	node, err := state.slotMasterNode(slot)
 	return slot, node, err
+}
+
+func (c *ClusterClient) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+
+// WithContext changes the ClusterClient's context to ctx and returns
+// a reference to the ClusterClient.
+func (c *ClusterClient) WithContext(ctx context.Context) *ClusterClient {
+	if ctx == nil {
+		panic("nil context")
+	}
+	c.ctx = ctx
+	return c
 }
 
 func (c *ClusterClient) Watch(fn func(*Tx) error, keys ...string) error {

--- a/ring.go
+++ b/ring.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -142,6 +143,8 @@ func (shard *ringShard) Vote(up bool) bool {
 type Ring struct {
 	cmdable
 
+	ctx context.Context
+
 	opt       *RingOptions
 	nreplicas int
 
@@ -200,6 +203,23 @@ func (c *Ring) Options() *RingOptions {
 
 func (c *Ring) retryBackoff(attempt int) time.Duration {
 	return internal.RetryBackoff(attempt, c.opt.MinRetryBackoff, c.opt.MaxRetryBackoff)
+}
+
+func (c *Ring) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+
+// WithContext changes the Ring's context to ctx and returns
+// a reference to the Ring.
+func (c *Ring) WithContext(ctx context.Context) *Ring {
+	if ctx == nil {
+		panic("nil context")
+	}
+	c.ctx = ctx
+	return c
 }
 
 // PoolStats returns accumulated connection pool stats.


### PR DESCRIPTION
This change adds the `Context` and `WithContext` methods to
`ClusterClient` and `Ring`, as we have in the regular `Client`

In these two cases, `WithContext` returns the same instance of the client, and not a copy. Copying is tricky and difficult in this case because the two contain mutexes (in clusterNodes).

Fixes #700