### PR TITLE
cluster: make ForEachNode iterate through each node

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -816,11 +816,7 @@ func (c *ClusterClient) ForEachNode(fn func(client *Client) error) error {
 		}
 	}
 
-	for _, node := range state.masters {
-		wg.Add(1)
-		go worker(node)
-	}
-	for _, node := range state.slaves {
+	for _, node := range state.nodes.nodes {
 		wg.Add(1)
 		go worker(node)
 	}


### PR DESCRIPTION
ForEachNode was iterating through the `masters` and `slaves` fields,
which are the result of the addresses advertised by the cluster, but do
not contain the addresses used to create the cluster (in
ClusterOptions). This was problematic in some situations. This PR
addresses that issue.

This might make more sense because it is the `nodes` property that is used
when selecting nodes, not `masters` and `slaves`. (see [here](https://github.com/gbbr/redis/blob/a0ddd1ed404fdf248caf6abd8caf55459713c123/cluster.go#L412)).

This addresses #701. If you decide against making this change, please
feel free to close the PR.