### PR TITLE
Correctly parse EVAL response containing customized error

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -2,7 +2,6 @@ package redis_test
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -11,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/internal"
 )
 
 var _ = Describe("Commands", func() {
@@ -2976,7 +2976,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{12, errors.New("error"), "abc"}))
+			Expect(vals).To(BeEquivalentTo([]interface{}{12, internal.RedisError("error"), "abc"}))
 		})
 
 	})

--- a/commands_test.go
+++ b/commands_test.go
@@ -2976,7 +2976,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(BeEquivalentTo([]interface{}{12, internal.RedisError("error"), "abc"}))
+			Expect(vals).To(Equal([]interface{}{int64(12), internal.RedisError("error"), "abc"}))
 		})
 
 	})

--- a/commands_test.go
+++ b/commands_test.go
@@ -2976,7 +2976,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{12, errors.New("hello"), "abc"}))
+			Expect(vals).To(Equal([]interface{}{12, errors.New("error"), "abc"}))
 		})
 
 	})

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,6 +2,7 @@ package redis_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -2967,6 +2968,15 @@ var _ = Describe("Commands", func() {
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]interface{}{"key", "hello"}))
+		})
+
+		It("returns all values after an error", func() {
+			vals, err := client.Eval(
+				`return {12, {err="error"}, "abc"}`,
+				nil,
+			).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vals).To(Equal([]interface{}{12, errors.New("hello"), "abc"}))
 		})
 
 	})

--- a/parser.go
+++ b/parser.go
@@ -17,7 +17,7 @@ func sliceParser(rd *proto.Reader, n int64) (interface{}, error) {
 		if err == Nil {
 			vals = append(vals, nil)
 		} else if err != nil {
-			return nil, err
+			vals = append(vals, err)
 		} else {
 			switch vv := v.(type) {
 			case []byte:


### PR DESCRIPTION
When EVAL response contains a customized error, current parser will stop at this error and drop all remaining bytes.

Sample command.

    eval 'return {12, {err="error"}, 34}' 0

In this sample, result of `client.Eval` doesn't include `34`.