### PR TITLE
Change Makefile to use sed syntax that will work for both GNU and BSD sed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.rdb
 testdata/*/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.rdb
 testdata/*/
-.idea/

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ testdata/redis:
 	wget -qO- https://github.com/antirez/redis/archive/unstable.tar.gz | tar xvz --strip-components=1 -C $@
 
 testdata/redis/src/redis-server: testdata/redis
-	sed -i 's/libjemalloc.a/libjemalloc.a -lrt/g' $</src/Makefile
+	sed -i.bak 's/libjemalloc.a/libjemalloc.a -lrt/g' $</src/Makefile
 	cd $< && make all


### PR DESCRIPTION
I could not run `make testdeps` on a mac. The change I have made to the inline-editing option syntax will allow the sed command to work with both GNU sed and BSD sed.