### PR TITLE
add WrapProcess to UniversalClient interface

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -114,6 +114,7 @@ func (o *UniversalOptions) simple() *Options {
 type UniversalClient interface {
 	Cmdable
 	Process(cmd Cmder) error
+	WrapProcess(fn func(oldProcess func(cmd Cmder) error) func(cmd Cmder) error)
 	Subscribe(channels ...string) *PubSub
 	PSubscribe(channels ...string) *PubSub
 	Close() error


### PR DESCRIPTION
At the moment, instrumentation of `UniversalClient` is not possible without extra type conversion.

Could you add `WrapProcess` to the `UniversalClient` interface?