### PR TITLE
Re-order atomic field to please race detector

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -491,13 +491,14 @@ func (c *clusterState) slotNodes(slot int) []*clusterNode {
 //------------------------------------------------------------------------------
 
 type clusterStateHolder struct {
-	load      func() (*clusterState, error)
-	reloading uint32 // atomic
+	load func() (*clusterState, error)
 
 	state atomic.Value
 
 	lastErrMu sync.RWMutex
 	lastErr   error
+
+	reloading uint32 // atomic
 }
 
 func newClusterStateHolder(fn func() (*clusterState, error)) *clusterStateHolder {


### PR DESCRIPTION
The race looks like this and I don't understand what is happening

```
WARNING: DATA RACE
Write at 0x00c420c7f958 by goroutine 98:
  sync/atomic.StoreInt32()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/runtime/race_amd64.s:229 +0xb
  github.com/go-redis/redis.(*clusterStateHolder).LazyReload.func1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:532 +0x7b
Previous write at 0x00c420c7f958 by goroutine 59:
  ??()
      -:0 +0xffffffffffffffff
  net.(*netFD).incref()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/net/fd_mutex.go:200 +0x3e
  net.setDeadlineImpl()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/net/fd_poll_runtime.go:135 +0xad
  net.(*netFD).setReadDeadline()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/net/fd_poll_runtime.go:117 +0x61
  net.(*conn).SetReadDeadline()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/net/net.go:248 +0x88
  net.(*TCPConn).SetReadDeadline()
      <autogenerated>:78 +0x70
  github.com/go-redis/redis/internal/pool.(*Conn).SetReadTimeout()
      /home/travis/gopath/src/github.com/go-redis/redis/internal/pool/conn.go:54 +0x115
  github.com/go-redis/redis.(*baseClient).txPipelineProcessCmds()
      /home/travis/gopath/src/github.com/go-redis/redis/redis.go:288 +0x113
  github.com/go-redis/redis.(*baseClient).(github.com/go-redis/redis.txPipelineProcessCmds)-fm()
      /home/travis/gopath/src/github.com/go-redis/redis/redis.go:226 +0x70
  github.com/go-redis/redis.(*baseClient).generalProcessPipeline()
      /home/travis/gopath/src/github.com/go-redis/redis/redis.go:243 +0x100
  github.com/go-redis/redis.(*baseClient).defaultProcessTxPipeline()
      /home/travis/gopath/src/github.com/go-redis/redis/redis.go:226 +0xa6
  github.com/go-redis/redis.(*baseClient).(github.com/go-redis/redis.defaultProcessTxPipeline)-fm()
      /home/travis/gopath/src/github.com/go-redis/redis/redis.go:40 +0x63
  github.com/go-redis/redis.(*Pipeline).Exec()
      /home/travis/gopath/src/github.com/go-redis/redis/pipeline.go:86 +0x19a
  github.com/go-redis/redis.(*Pipeline).pipelined()
      /home/travis/gopath/src/github.com/go-redis/redis/pipeline.go:93 +0xc4
  github.com/go-redis/redis.(*Pipeline).Pipelined()
      /home/travis/gopath/src/github.com/go-redis/redis/pipeline.go:99 +0x46
  github.com/go-redis/redis.(*Tx).Pipelined()
      /home/travis/gopath/src/github.com/go-redis/redis/tx.go:95 +0x5d
  github.com/go-redis/redis_test.glob..func1.1.5.1.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:302 +0x1f8
  github.com/go-redis/redis.(*Client).Watch()
      /home/travis/gopath/src/github.com/go-redis/redis/tx.go:41 +0x61
  github.com/go-redis/redis.(*ClusterClient).Watch()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:703 +0x258
  github.com/go-redis/redis_test.glob..func1.1.5.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:304 +0x149
  github.com/go-redis/redis_test.glob..func1.1.5.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:306 +0x25e
  github.com/go-redis/redis_test.glob..func1.1.5.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:306 +0x25e
  github.com/go-redis/redis_test.glob..func1.1.5.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:306 +0x25e
  github.com/go-redis/redis_test.glob..func1.1.5.2()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:318 +0xaa
Goroutine 98 (running) created at:
  github.com/go-redis/redis.(*clusterStateHolder).LazyReload()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:532 +0x7c
  github.com/go-redis/redis.(*ClusterClient).checkMovedErr()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:1152 +0x493
  github.com/go-redis/redis.(*ClusterClient).pipelineReadCmds()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:1133 +0xf5
  github.com/go-redis/redis.(*ClusterClient).pipelineProcessCmds()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:1121 +0x279
  github.com/go-redis/redis.(*ClusterClient).defaultProcessPipeline()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:1058 +0x454
  github.com/go-redis/redis.(*ClusterClient).(github.com/go-redis/redis.defaultProcessPipeline)-fm()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster.go:582 +0x63
  github.com/go-redis/redis.(*Pipeline).Exec()
      /home/travis/gopath/src/github.com/go-redis/redis/pipeline.go:86 +0x19a
  github.com/go-redis/redis_test.glob..func1.1.6.1.1()
      /home/travis/gopath/src/github.com/go-redis/redis/cluster_test.go:345 +0x371
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/leafnodes/runner.go:110 +0xbb
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).run()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x141
  github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/leafnodes/it_node.go:26 +0x88
  github.com/onsi/ginkgo/internal/spec.(*Spec).runSample()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/spec/spec.go:203 +0x753
  github.com/onsi/ginkgo/internal/spec.(*Spec).Run()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0x13f
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:198 +0x169
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:168 +0x4a9
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:64 +0x103
  github.com/onsi/ginkgo/internal/suite.(*Suite).Run()
      /home/travis/gopath/src/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x3dc
  github.com/onsi/ginkgo.RunSpecsWithCustomReporters()
      /home/travis/gopath/src/github.com/onsi/ginkgo/ginkgo_dsl.go:220 +0x32f
  github.com/onsi/ginkgo.RunSpecs()
      /home/travis/gopath/src/github.com/onsi/ginkgo/ginkgo_dsl.go:201 +0x366
  github.com/go-redis/redis_test.TestGinkgoSuite()
      /home/travis/gopath/src/github.com/go-redis/redis/main_test.go:98 +0x88
  testing.tRunner()
      /home/travis/.gimme/versions/go1.8.7.linux.amd64/src/testing/testing.go:657 +0x107
```