### PR TITLE
cluster: add support for context.Context to ClusterClient and Ring

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -557,6 +558,8 @@ func (c *clusterStateHolder) Get() (*clusterState, error) {
 type ClusterClient struct {
 	cmdable
 
+	ctx context.Context
+
 	opt           *ClusterOptions
 	nodes         *clusterNodes
 	state         *clusterStateHolder
@@ -591,6 +594,22 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	}
 
 	return c
+}
+
+func (c *ClusterClient) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+
+func (c *ClusterClient) WithContext(ctx context.Context) *ClusterClient {
+	if ctx == nil {
+		panic("nil context")
+	}
+	c2 := c.copy()
+	c2.ctx = ctx
+	return c2
 }
 
 func (c *ClusterClient) copy() *ClusterClient {

--- a/ring.go
+++ b/ring.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -289,6 +290,9 @@ func (c *ringShards) Close() error {
 // Otherwise you should use Redis Cluster.
 type Ring struct {
 	cmdable
+
+	ctx context.Context
+
 	opt           *RingOptions
 	shards        *ringShards
 	cmdsInfoCache *cmdsInfoCache
@@ -316,6 +320,22 @@ func NewRing(opt *RingOptions) *Ring {
 	go ring.shards.Heartbeat(opt.HeartbeatFrequency)
 
 	return ring
+}
+
+func (c *Ring) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+
+func (c *Ring) WithContext(ctx context.Context) *Ring {
+	if ctx == nil {
+		panic("nil context")
+	}
+	c2 := c.copy()
+	c2.ctx = ctx
+	return c2
 }
 
 func (c *Ring) copy() *Ring {


### PR DESCRIPTION
This change adds the Context and WithContext methods to
ClusterClient and Ring, as we have in the regular Client

In these two cases, WithContext returns the same instance of the client, and not a copy. Copying is tricky and difficult in this case because the two contain mutexes (in clusterNodes).

Fixes #700