### PR TITLE
Reload cluster data

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -601,6 +601,10 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	return c
 }
 
+func (c *ClusterClient) Reload() {
+	c.state.Load()
+}
+
 func (c *ClusterClient) Context() context.Context {
 	if c.ctx != nil {
 		return c.ctx

--- a/cluster.go
+++ b/cluster.go
@@ -277,6 +277,8 @@ func (c *clusterNodes) Addrs() ([]string, error) {
 }
 
 func (c *clusterNodes) NextGeneration() uint32 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.generation++
 	return c.generation
 }

--- a/cluster.go
+++ b/cluster.go
@@ -601,10 +601,6 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	return c
 }
 
-func (c *ClusterClient) Reload() {
-	c.state.Load()
-}
-
 func (c *ClusterClient) Context() context.Context {
 	if c.ctx != nil {
 		return c.ctx

--- a/cluster.go
+++ b/cluster.go
@@ -851,7 +851,7 @@ func (c *ClusterClient) defaultProcess(cmd Cmder) error {
 // ForEachMaster concurrently calls the fn on each master node in the cluster.
 // It returns the first error if any.
 func (c *ClusterClient) ForEachMaster(fn func(client *Client) error) error {
-	state, err := c.state.Get()
+	state, err := c.state.Load()
 	if err != nil {
 		return err
 	}
@@ -884,7 +884,7 @@ func (c *ClusterClient) ForEachMaster(fn func(client *Client) error) error {
 // ForEachSlave concurrently calls the fn on each slave node in the cluster.
 // It returns the first error if any.
 func (c *ClusterClient) ForEachSlave(fn func(client *Client) error) error {
-	state, err := c.state.Get()
+	state, err := c.state.Load()
 	if err != nil {
 		return err
 	}
@@ -917,7 +917,7 @@ func (c *ClusterClient) ForEachSlave(fn func(client *Client) error) error {
 // ForEachNode concurrently calls the fn on each known node in the cluster.
 // It returns the first error if any.
 func (c *ClusterClient) ForEachNode(fn func(client *Client) error) error {
-	state, err := c.state.Get()
+	state, err := c.state.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I initially found that running methods with `ForEachMaster` runs a command against all the nodes that _were_ masters when the client was created, but doesn't take into account failover while running. Rather than forcing a reload of cluster data at that point I added the ability to reload it whenever you want. It's possible it would be better to extend this to automatically update this information on a periodic basis of before all of the `ForEachX` methods.

There may be a _correct_ way of doing this, but I certainly couldn't find it.