### PR TITLE
reset cmdable.process when copying cluster client

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -650,7 +650,7 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	c.processPipeline = c.defaultProcessPipeline
 	c.processTxPipeline = c.defaultProcessTxPipeline
 
-	c.cmdable.setProcessor(c.Process)
+	c.init()
 
 	_, _ = c.state.Reload()
 	if opt.IdleCheckFrequency > 0 {
@@ -658,6 +658,10 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	}
 
 	return c
+}
+
+func (c *ClusterClient) init() {
+	c.cmdable.setProcessor(c.Process)
 }
 
 func (c *ClusterClient) Context() context.Context {
@@ -678,6 +682,7 @@ func (c *ClusterClient) WithContext(ctx context.Context) *ClusterClient {
 
 func (c *ClusterClient) copy() *ClusterClient {
 	cp := *c
+	cp.init()
 	return &cp
 }
 


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/773

The problem is `c.cmdable.setProcess(c.Process)` in the factory method. The reference to `c.Process` is specific to that instance. When we copy via `cp := *c`, the new client retains that reference, and thus methods invoked on the new client will end up calling `Process` on the old client.

To fix this, I took the same approach used in the non-cluster client: https://github.com/go-redis/redis/blob/master/redis.go#L361