### PR TITLE
Use cmdSlotAndNode() to route ClusterClient pipeline commands

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -857,6 +857,7 @@ var _ = Describe("ClusterClient timeout", func() {
 			opt.WriteTimeout = 300 * time.Millisecond
 			opt.MaxRedirects = 1
 			client = cluster.clusterClient(opt)
+			client.Ping() // Load cmdsInfoCache before issuing client pause
 
 			err := client.ForEachNode(func(client *redis.Client) error {
 				return client.ClientPause(pause).Err()


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/775
Non-pipeline cluster client commands are routed using cmdSlotAndNode().
This changes pipeline cluster client commands to use that as well rather than always routing to master nodes.