### PR TITLE
Handling of isPrefix in Reader.ReadLine.

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -65,12 +65,15 @@ func (r *Reader) ReadN(n int) ([]byte, error) {
 }
 
 func (r *Reader) ReadLine() ([]byte, error) {
-	line, isPrefix, err := r.src.ReadLine()
-	if err != nil {
-		return nil, err
-	}
-	if isPrefix {
-		return nil, bufio.ErrBufferFull
+	line := make([]byte, 0)
+	for isPrefix := true; isPrefix; {
+		var lineSegment []byte
+		var err error
+		lineSegment, isPrefix, err = r.src.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		line = append(line, lineSegment...)
 	}
 	if len(line) == 0 {
 		return nil, fmt.Errorf("redis: reply is empty")

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -36,6 +36,14 @@ var _ = Describe("Reader", func() {
 		Expect(string(data)).To(Equal("hello"))
 	})
 
+	It("should read very long lines", func() {
+		p := proto.NewReader(strings.NewReader(strings.Repeat("x", 4097) + "\r\n"))
+
+		data, err := p.ReadLine()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(strings.Repeat("x", 4097))) // + "\r\n"))
+	})
+
 })
 
 func BenchmarkReader_ParseReply_Status(b *testing.B) {

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Reader", func() {
 
 		data, err := p.ReadLine()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(data)).To(Equal(strings.Repeat("x", 4097))) // + "\r\n"))
+		Expect(string(data)).To(Equal(strings.Repeat("x", 4097)))
 	})
 
 })


### PR DESCRIPTION
I've added a commit to resolve an issue where data greater than 4096 bytes could not be read without generating an error.