### PR TITLE
Establishing TLS connections respect DialTimeout

### DIFF
--- a/options.go
+++ b/options.go
@@ -85,12 +85,12 @@ func (opt *Options) init() {
 	}
 	if opt.Dialer == nil {
 		opt.Dialer = func() (net.Conn, error) {
-			conn, err := net.DialTimeout(opt.Network, opt.Addr, opt.DialTimeout)
-			if opt.TLSConfig == nil || err != nil {
-				return conn, err
+			netDialer := &net.Dialer{Timeout: opt.DialTimeout}
+			if opt.TLSConfig == nil {
+				return netDialer.Dial(opt.Network, opt.Addr)
+			} else {
+				return tls.DialWithDialer(netDialer, opt.Network, opt.Addr, opt.TLSConfig)
 			}
-			t := tls.Client(conn, opt.TLSConfig)
-			return t, t.Handshake()
 		}
 	}
 	if opt.PoolSize == 0 {


### PR DESCRIPTION
see the issue: https://github.com/go-redis/redis/issues/799

Currently when redis.Options.TLSConfig is set, the redis.Options.Dialer function can hang indefinitely!

This change causes connection negotiation + tls handshaking to together be governed by the redis.Options.DialTimeout.

This seems to be the expected behavior, per the go standard library.  See for example:
https://golang.org/pkg/crypto/tls/#DialWithDialer
