### PR TITLE
Supports new style syntax of client kill command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -220,6 +220,7 @@ type Cmdable interface {
 	BgRewriteAOF() *StatusCmd
 	BgSave() *StatusCmd
 	ClientKill(ipPort string) *StatusCmd
+	ClientKillByFilter(keys ...string) *IntCmd
 	ClientList() *StringCmd
 	ClientPause(dur time.Duration) *BoolCmd
 	ConfigGet(parameter string) *SliceCmd
@@ -1818,6 +1819,20 @@ func (c *cmdable) BgSave() *StatusCmd {
 
 func (c *cmdable) ClientKill(ipPort string) *StatusCmd {
 	cmd := NewStatusCmd("client", "kill", ipPort)
+	c.process(cmd)
+	return cmd
+}
+
+// ClientKillByFilter is new style synx, while the ClientKill is old
+// CLIENT KILL <option> [value] ... <option> [value]
+func (c *cmdable) ClientKillByFilter(keys ...string) *IntCmd {
+	args := make([]interface{}, 2+len(keys))
+	args[0] = "client"
+	args[1] = "kill"
+	for i, key := range keys {
+		args[2+i] = key
+	}
+	cmd := NewIntCmd(args...)
 	c.process(cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -115,6 +115,12 @@ var _ = Describe("Commands", func() {
 			Expect(r.Val()).To(Equal(""))
 		})
 
+		It("should ClientKillByFilter", func() {
+			r := client.ClientKillByFilter("TYPE", "test")
+			Expect(r.Err()).To(MatchError("ERR Unknown client type 'test'"))
+			Expect(r.Val()).To(Equal(int64(0)))
+		})
+
 		It("should ClientPause", func() {
 			err := client.ClientPause(time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
go-redis supports old-style syntax of client kill command, and new syntax wasn't supported. This pr add new style syntax without breaking the old API by adding a new function `ClientKillByOption`.

old style syntax:
```
CLIENT KILL ip:port
```
new style syntax:
```
CLIENT KILL <option> [value] ... <option> [value]
```