### PR TITLE
Add godoc about Receive call after Subscribe

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -460,6 +460,30 @@ func (c *Client) pubSub() *PubSub {
 
 // Subscribe subscribes the client to the specified channels.
 // Channels can be omitted to create empty subscription.
+// Note that this method does not wait on a response from Redis, so the
+// subscription may not be active immediately. To force the connection to wait,
+// you may call the Receive() method on the returned *PubSub like so:
+//
+//    sub := client.Subscribe(queryResp)
+//    iface, err := sub.Receive()
+//    if err != nil {
+//        // handle error
+//    }
+//    
+//    // Should be *Subscription, but others are possible if other actions have been
+//    // taken on sub since it was created.
+//    switch iface.(type) {
+//    case *Subscription:
+//        // subscribe succeeded
+//    case *Message:
+//        // received first message
+//    case *Pong:
+//        // pong received
+//    default:
+//        // handle error
+//    }
+//
+//    ch := sub.Channel()
 func (c *Client) Subscribe(channels ...string) *PubSub {
 	pubsub := c.pubSub()
 	if len(channels) > 0 {


### PR DESCRIPTION
I had a race in my integration tests that ultimately boiled down to a subscription that wasn't always completing before the first publication. The debugging took a bit of spelunking and/or running across https://github.com/go-redis/redis/issues/575 to figure out. The behavior was surprising to me, but makes sense, so I figured a little documentation wouldn't hurt.

Haven't looked at the other client configuration Subscribe() methods. Would they benefit from a note as well?

Also, can it be expected that calling Receive() right after Subscribe() should always return a *Subscription?