### PR TITLE
Fix: xreadgroup command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1450,12 +1450,13 @@ func (c *cmdable) XGroupDelConsumer(stream, group, consumer string) *IntCmd {
 }
 
 type XReadGroupArgs struct {
-	Group    string
-	Consumer string
-	Streams  map[string]string
-	Count    int64
-	Block    time.Duration
-	NoAck    bool
+	Group      string
+	Consumer   string
+	Streams    []string
+	MessageIDs []string
+	Count      int64
+	Block      time.Duration
+	NoAck      bool
 }
 
 func (c *cmdable) XReadGroup(a *XReadGroupArgs) *XStreamSliceCmd {
@@ -1472,12 +1473,13 @@ func (c *cmdable) XReadGroup(a *XReadGroupArgs) *XStreamSliceCmd {
 	}
 
 	args = append(args, "streams")
-	messageIds := make([]interface{}, 0, len(a.Streams))
-	for stream, id := range a.Streams {
-		args = append(args, stream)
-		messageIds = append(messageIds, id)
+
+	for _, s := range a.Streams {
+		args = append(args, s)
 	}
-	args = append(args, messageIds...)
+	for _, m := range a.MessageIDs {
+		args = append(args, m)
+	}
 
 	cmd := NewXStreamSliceCmd(args...)
 	if a.Block >= 0 {

--- a/commands.go
+++ b/commands.go
@@ -1452,7 +1452,7 @@ func (c *cmdable) XGroupDelConsumer(stream, group, consumer string) *IntCmd {
 type XReadGroupArgs struct {
 	Group    string
 	Consumer string
-	Streams  []string
+	Streams  map[string]string
 	Count    int64
 	Block    time.Duration
 	NoAck    bool
@@ -1470,10 +1470,14 @@ func (c *cmdable) XReadGroup(a *XReadGroupArgs) *XStreamSliceCmd {
 	if a.NoAck {
 		args = append(args, "noack")
 	}
+
 	args = append(args, "streams")
-	for _, s := range a.Streams {
-		args = append(args, s)
+	messageIds := make([]interface{}, 0, len(a.Streams))
+	for stream, id := range a.Streams {
+		args = append(args, stream)
+		messageIds = append(messageIds, id)
 	}
+	args = append(args, messageIds...)
 
 	cmd := NewXStreamSliceCmd(args...)
 	if a.Block >= 0 {

--- a/commands_test.go
+++ b/commands_test.go
@@ -3564,7 +3564,7 @@ var _ = Describe("Commands", func() {
 				res, err := client.XReadGroup(&redis.XReadGroupArgs{
 					Group:    "group",
 					Consumer: "consumer",
-					Streams:  []string{"stream", ">"},
+					Streams:  map[string]string{"stream": ">"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(Equal([]redis.XStream{{

--- a/commands_test.go
+++ b/commands_test.go
@@ -3564,7 +3564,7 @@ var _ = Describe("Commands", func() {
 				res, err := client.XReadGroup(&redis.XReadGroupArgs{
 					Group:    "group",
 					Consumer: "consumer",
-					Streams:  map[string]string{"stream": ">"},
+					Streams:  []string{"stream", ">"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(Equal([]redis.XStream{{


### PR DESCRIPTION
The current version does not accept message IDs in its input and subsequently does not write them out as part of the command - but that is a requirement for the `xreadgroup` command. 

It's still possible with the current API, but feels like more of a hack then a feature. You could pass in `[]string{ "streamA", "streamB", ">", ">" }` - but the field is "streams" so it seems odd to pass it IDs as well. Whereas a map for the streams field makes sense because it maps from the stream to the message ID.