### PR TITLE
Support default redis address

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -24,9 +24,9 @@ func init() {
 
 func ExampleNewClient() {
 	redisdb := redis.NewClient(&redis.Options{
-		Addr:     "localhost:6379",
-		Password: "", // no password set
-		DB:       0,  // use default DB
+		Addr:     "localhost:6379", // use default Addr
+		Password: "",               // no password set
+		DB:       0,                // use default DB
 	})
 
 	pong, err := redisdb.Ping().Result()

--- a/options.go
+++ b/options.go
@@ -101,6 +101,9 @@ func (opt *Options) init() {
 	if opt.Network == "" {
 		opt.Network = "tcp"
 	}
+	if opt.Addr == "" {
+		opt.Addr = "localhost:6379"
+	}
 	if opt.Dialer == nil {
 		opt.Dialer = func() (net.Conn, error) {
 			netDialer := &net.Dialer{


### PR DESCRIPTION
If the Addr value is not passed, use default host (`localhost`) and port (`6379`).