### PR TITLE
Add GETKEYSINSLOT API call for Clustered Redis

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -637,6 +637,12 @@ var _ = Describe("ClusterClient", func() {
 			Expect(hashSlot).To(Equal(int64(hashtag.Slot("somekey"))))
 		})
 
+		It("should CLUSTER GETKEYSINSLOT", func() {
+			keys, err := client.ClusterGetKeysInSlot(hashtag.Slot("somekey"), 1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(keys)).To(Equal(0))
+		})
+
 		It("should CLUSTER COUNT-FAILURE-REPORTS", func() {
 			n, err := client.ClusterCountFailureReports(cluster.nodeIds[0]).Result()
 			Expect(err).NotTo(HaveOccurred())

--- a/commands.go
+++ b/commands.go
@@ -270,6 +270,7 @@ type Cmdable interface {
 	ClusterResetHard() *StatusCmd
 	ClusterInfo() *StringCmd
 	ClusterKeySlot(key string) *IntCmd
+	ClusterGetKeysInSlot(slot int, count int) *StringSliceCmd
 	ClusterCountFailureReports(nodeID string) *IntCmd
 	ClusterCountKeysInSlot(slot int) *IntCmd
 	ClusterDelSlots(slots ...int) *StatusCmd
@@ -2398,6 +2399,12 @@ func (c *cmdable) ClusterInfo() *StringCmd {
 
 func (c *cmdable) ClusterKeySlot(key string) *IntCmd {
 	cmd := NewIntCmd("cluster", "keyslot", key)
+	c.process(cmd)
+	return cmd
+}
+
+func (c *cmdable) ClusterGetKeysInSlot(slot int, count int) *StringSliceCmd {
+	cmd := NewStringSliceCmd("cluster", "getkeysinslot", slot, count)
 	c.process(cmd)
 	return cmd
 }


### PR DESCRIPTION
[API Reference](https://redis.io/commands/cluster-getkeysinslot)

This change adds the `GETKEYSINSLOT` API, which fetches a list keys for a given key slot, given a max count of keys to fetch.