### PR TITLE
Cluster commands respecting keyslots from command input

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -775,6 +775,11 @@ func cmdSlot(cmd Cmder, pos int) int {
 }
 
 func (c *ClusterClient) cmdSlot(cmd Cmder) int {
+	args := cmd.Args()
+	if args[0] == "cluster" && args[1] == "getkeysinslot" {
+		return args[2].(int)
+	}
+
 	cmdInfo := c.cmdInfo(cmd.Name())
 	return cmdSlot(cmd, cmdFirstKeyPos(cmd, cmdInfo))
 }

--- a/cluster.go
+++ b/cluster.go
@@ -767,8 +767,11 @@ func cmdSlot(cmd Cmder, pos int) int {
 	if pos == 0 {
 		return hashtag.RandomSlot()
 	}
-	firstKey := cmd.stringArg(pos)
-	return hashtag.Slot(firstKey)
+	val, ok := cmd.Args()[pos].(int)
+	if ok {
+		return val
+	}
+	return hashtag.Slot(cmd.stringArg(pos))
 }
 
 func (c *ClusterClient) cmdSlot(cmd Cmder) int {

--- a/cluster.go
+++ b/cluster.go
@@ -767,11 +767,8 @@ func cmdSlot(cmd Cmder, pos int) int {
 	if pos == 0 {
 		return hashtag.RandomSlot()
 	}
-	val, ok := cmd.Args()[pos].(int)
-	if ok {
-		return val
-	}
-	return hashtag.Slot(cmd.stringArg(pos))
+	firstKey := cmd.stringArg(pos)
+	return hashtag.Slot(firstKey)
 }
 
 func (c *ClusterClient) cmdSlot(cmd Cmder) int {
@@ -791,7 +788,7 @@ func (c *ClusterClient) cmdSlotAndNode(cmd Cmder) (int, *clusterNode, error) {
 	}
 
 	cmdInfo := c.cmdInfo(cmd.Name())
-	slot := cmdSlot(cmd, cmdFirstKeyPos(cmd, cmdInfo))
+	slot := c.cmdSlot(cmd)
 
 	if c.opt.ReadOnly && cmdInfo != nil && cmdInfo.ReadOnly {
 		if c.opt.RouteByLatency {

--- a/command.go
+++ b/command.go
@@ -74,6 +74,11 @@ func cmdString(cmd Cmder, val interface{}) string {
 
 func cmdFirstKeyPos(cmd Cmder, info *CommandInfo) int {
 	switch cmd.Name() {
+	case "cluster":
+		switch cmd.stringArg(1) {
+		case "getkeysinslot":
+			return 2
+		}
 	case "eval", "evalsha":
 		if cmd.stringArg(2) != "0" {
 			return 3

--- a/command.go
+++ b/command.go
@@ -74,11 +74,6 @@ func cmdString(cmd Cmder, val interface{}) string {
 
 func cmdFirstKeyPos(cmd Cmder, info *CommandInfo) int {
 	switch cmd.Name() {
-	case "cluster":
-		switch cmd.stringArg(1) {
-		case "getkeysinslot":
-			return 2
-		}
 	case "eval", "evalsha":
 		if cmd.stringArg(2) != "0" {
 			return 3


### PR DESCRIPTION
Currently, the cluster command "GETKEYSINSLOT" passes in a keyslot as a parameter. This parameter needs to be recognized as the slot to use when executing the command. Currently, it ignores it and picks a random node. This PR fixes this issue.