### PR TITLE
Export Redis ring shards to be able to work with them directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.rdb
 testdata/*/
+
+# IntelliJ Idea files
+.idea
+redis.iml


### PR DESCRIPTION
As the PR about MGet/MSet commands for Redis ring support was declined ( https://github.com/go-redis/redis/pull/493 ), layers above `go-redis/redis` should have the possibility to understand, which shard is responsible for which set of keys.
The PR just makes the `Ring.Shards` field exportable.