### PR TITLE
add FailoverReadOnlyClient

### DIFF
--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Sentinel", func() {
+var _ = Describe("Sentinel Failover", func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
@@ -84,5 +84,73 @@ var _ = Describe("Sentinel", func() {
 		})
 		err := client.Ping().Err()
 		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("Sentinel Failover ReadOnly", func() {
+	var client *redis.ClusterClient
+
+	BeforeEach(func() {
+		client = redis.NewFailoverReadOnlyClient(&redis.FailoverReadOnlyOptions{
+			MasterName:    sentinelName,
+			SentinelAddrs: []string{":" + sentinelPort},
+		})
+		Expect(client.FlushDB().Err()).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(client.Close()).NotTo(HaveOccurred())
+	})
+
+	It("should facilitate failover", func() {
+		// Set value on master.
+		err := client.Set("foo", "master", 0).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify.
+		val, err := sentinelMaster.Get("foo").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(Equal("master"))
+
+		// Create subscription.
+		ch := client.Subscribe("foo").Channel()
+
+		// Wait until replicated.
+		Eventually(func() string {
+			return sentinelSlave1.Get("foo").Val()
+		}, "1s", "100ms").Should(Equal("master"))
+		Eventually(func() string {
+			return sentinelSlave2.Get("foo").Val()
+		}, "1s", "100ms").Should(Equal("master"))
+
+		// Wait until slaves are picked up by sentinel.
+		Eventually(func() string {
+			return sentinel.Info().Val()
+		}, "10s", "100ms").Should(ContainSubstring("slaves=2"))
+
+		// Kill master.
+		sentinelMaster.Shutdown()
+		Eventually(func() error {
+			return sentinelMaster.Ping().Err()
+		}, "5s", "100ms").Should(HaveOccurred())
+
+		// Wait for Redis sentinel to elect new master.
+		Eventually(func() string {
+			return sentinelSlave1.Info().Val() + sentinelSlave2.Info().Val()
+		}, "30s", "1s").Should(ContainSubstring("role:master"))
+
+		// Check that client picked up new master.
+		Eventually(func() error {
+			return client.Get("foo").Err()
+		}, "5s", "100ms").ShouldNot(HaveOccurred())
+
+		// Publish message to check if subscription is renewed.
+		err = client.Publish("foo", "hello").Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		var msg *redis.Message
+		Eventually(ch, "5s").Should(Receive(&msg))
+		Expect(msg.Channel).To(Equal("foo"))
+		Expect(msg.Payload).To(Equal("hello"))
 	})
 })

--- a/universal_test.go
+++ b/universal_test.go
@@ -24,6 +24,15 @@ var _ = Describe("UniversalClient", func() {
 		Expect(client.Ping().Err()).NotTo(HaveOccurred())
 	})
 
+	It("should connect to failover readonly servers", func() {
+		client = redis.NewUniversalClient(&redis.UniversalOptions{
+			MasterName: sentinelName,
+			Addrs:      []string{":" + sentinelPort},
+			ReadOnly:   true,
+		})
+		Expect(client.Ping().Err()).NotTo(HaveOccurred())
+	})
+
 	It("should connect to simple servers", func() {
 		client = redis.NewUniversalClient(&redis.UniversalOptions{
 			Addrs: []string{redisAddr},


### PR DESCRIPTION
This is related to https://github.com/go-redis/redis/issues/433 my was to make `UnversalClient` to route ReadOnly Commands to Slaves under sentinel mode if `ReadOnly` is `true` in options.
This was my expectation when I started using this library but after deployment I realized it's only using slaves for Failover regardless of the `ReadOnly` option.