### PR TITLE
Fix MOVED errors by not randomly selecting another node

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -822,8 +822,8 @@ func (c *ClusterClient) slotMasterNode(slot int) (*clusterNode, error) {
 	return c.nodes.Random()
 }
 
-func (c *ClusterClient) tryAnotherNode(cmdName string) *clusterNode {
-	cmdInfo := c.cmdInfo(cmdName)
+func (c *ClusterClient) tryAnotherNode(cmd Cmder) *clusterNode {
+	cmdInfo := c.cmdInfo(cmd.Name())
 	slot := c.cmdSlot(cmd)
 
 	state, err := c.state.Get()
@@ -1007,7 +1007,7 @@ func (c *ClusterClient) defaultProcess(cmd Cmder) error {
 			//
 			// If another node cannot be selected, the current node will be kept for the next
 			// attempts.
-			if otherNode := c.tryAnotherNode(cmd.Name()); otherNode == nil {
+			if otherNode := c.tryAnotherNode(cmd); otherNode == nil {
 				continue
 			} else {
 				node = otherNode


### PR DESCRIPTION
After some investigations we noticed a lot of MOVED errors that always seemed to happen when we received i/o timeouts. The original request selected the correct master node (for writes) and the correct master/slave for reads, however, if an i/o timeout or otherwise retryable error is received, a random node will be used after two attempts on the original node. This seems wrong as a random node will never be suitable to serve the request. Redis will most likely always send back MOVED errors as the random node is either not a master, not the right master, or not the right slave.

For writes, you cannot attempt on any other node than the currently selected master node. Best path here is probably around respecting the redirect configuration and keep retrying on that node.

For reads we can check if `ReadOnly` is set and retry on another slave. Otherwise we have to behave the same as writes.

Let me know if something along these lines would be acceptable and I can add some tests.