### PR TITLE
fix accuracy problems when float32 convert to flaot64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ matrix:
 install:
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
-  - go get github.com/spf13/cast

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ matrix:
 install:
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
+  - go get github.com/spf13/cast

--- a/command_test.go
+++ b/command_test.go
@@ -58,13 +58,26 @@ var _ = Describe("Cmd", func() {
 	})
 
 	It("safe float32 convert to float64", func() {
-		var f float32 = 66.97
+		var f float32
+		f = 66.97
+
 		set := client.Set("float_key", f, 0)
 		Expect(set.Err()).NotTo(HaveOccurred())
 
 		val, err := client.Get("float_key").Float64()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(Equal(float64(66.97)))
+
+		member := "sam123"
+		mycmd := []interface{}{"Zadd", "zset_float_key", f, member}
+		cmd := redis.NewStatusCmd(mycmd...)
+
+		client.Process(cmd)
+		Expect(cmd.Err()).NotTo(HaveOccurred())
+
+		fscore := client.ZScore("zset_float_key", member)
+		Expect(fscore.Err()).NotTo(HaveOccurred())
+		Expect(fscore.Val()).To(Equal(float64(66.97)))
 	})
 
 })

--- a/command_test.go
+++ b/command_test.go
@@ -57,4 +57,14 @@ var _ = Describe("Cmd", func() {
 		Expect(f).To(Equal(float64(10)))
 	})
 
+	It("safe float32 convert to float64", func() {
+		var f float32 = 66.97
+		set := client.Set("float_key", f, 0)
+		Expect(set.Err()).NotTo(HaveOccurred())
+
+		val, err := client.Get("float_key").Float64()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(Equal(float64(66.97)))
+	})
+
 })

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/go-redis/redis/internal/util"
+	"github.com/spf13/cast"
 )
 
 type Writer struct {
@@ -83,7 +84,7 @@ func (w *Writer) writeArg(v interface{}) error {
 	case uint64:
 		return w.uint(v)
 	case float32:
-		return w.float(float64(v))
+		return w.float(cast.ToFloat64(cast.ToString(v)))
 	case float64:
 		return w.float(v)
 	case bool:

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -83,16 +83,9 @@ func (w *Writer) writeArg(v interface{}) error {
 	case uint64:
 		return w.uint(v)
 	case float32:
-		float32String := strconv.FormatFloat(float64(v), 'E', -1, 32)
-		toFloat64, err := strconv.ParseFloat(float32String, 64)
-		if err != nil{
-			return fmt.Errorf(
-				"redis: can't convert the type of [ %v ] from float32 to float64, err: %s", v, err.Error())
-		}
-
-		return w.float(toFloat64)
+		return w.float32(v)
 	case float64:
-		return w.float(v)
+		return w.float64(v)
 	case bool:
 		if v {
 			return w.int(1)
@@ -144,7 +137,18 @@ func (w *Writer) int(n int64) error {
 	return w.bytes(w.numBuf)
 }
 
-func (w *Writer) float(f float64) error {
+func (w *Writer) float32(f float32) error {
+	float32String := strconv.FormatFloat(float64(f), 'E', -1, 32)
+	toFloat64, err := strconv.ParseFloat(float32String, 64)
+	if err != nil{
+		return fmt.Errorf(
+			"redis: can't convert the type of [ %v ] from float32 to float64, err: %s", f, err.Error())
+	}
+
+	return w.float64(toFloat64)
+}
+
+func (w *Writer) float64(f float64) error {
 	w.numBuf = strconv.AppendFloat(w.numBuf[:0], f, 'f', -1, 64)
 	return w.bytes(w.numBuf)
 }

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/go-redis/redis/internal/util"
-	"github.com/spf13/cast"
 )
 
 type Writer struct {
@@ -84,7 +83,14 @@ func (w *Writer) writeArg(v interface{}) error {
 	case uint64:
 		return w.uint(v)
 	case float32:
-		return w.float(cast.ToFloat64(cast.ToString(v)))
+		float32String := strconv.FormatFloat(float64(v), 'E', -1, 32)
+		toFloat64, err := strconv.ParseFloat(float32String, 64)
+		if err != nil{
+			return fmt.Errorf(
+				"redis: can't convert the type of [ %v ] from float32 to float64, err: %s", v, err.Error())
+		}
+
+		return w.float(toFloat64)
 	case float64:
 		return w.float(v)
 	case bool:


### PR DESCRIPTION
**my problem:**
------------------------------------
    var score float32
    myscore = 66.7

	formatScore := cast.ToFloat32(fmt.Sprintf("%0.2f", myscore))
	member := "sam123"
	mycmd := []interface{}{"Zadd", "testzsetkey", formatScore, member}
	cmd := redis.NewCmd(mycmd...)

	client := redis.NewClient(&redis.Options{
		Addr:        "127.0.0.1",
		Password:    "", // no password set
		DB:          0,       // use default DB
		PoolSize:    1,
		IdleTimeout: 500,
	})
	
	client.Process(cmd)
	//.... blabla
-----------------------------
"formatScore"  which its type will be convert to float64, then the data stored in Redis is not accurate! 
like this:
![QQ截图20190409171103](https://user-images.githubusercontent.com/13757425/55790640-5c13dd00-5aef-11e9-8fde-ee7052fb1129.png)

**Result：**
then get the score of "sam123" from redis, it value is : 66.669998168945312,  
**_but my expected result is: 66.7_**
