### PR TITLE
Added WrapProcessPipeline to UniversalClient, wrap c.processTxPipelin…

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1198,6 +1198,7 @@ func (c *ClusterClient) WrapProcessPipeline(
 	fn func(oldProcess func([]Cmder) error) func([]Cmder) error,
 ) {
 	c.processPipeline = fn(c.processPipeline)
+	c.processTxPipeline = fn(c.processTxPipeline)
 }
 
 func (c *ClusterClient) defaultProcessPipeline(cmds []Cmder) error {

--- a/universal.go
+++ b/universal.go
@@ -155,6 +155,7 @@ type UniversalClient interface {
 	Watch(fn func(*Tx) error, keys ...string) error
 	Process(cmd Cmder) error
 	WrapProcess(fn func(oldProcess func(cmd Cmder) error) func(cmd Cmder) error)
+	WrapProcessPipeline(fn func(oldProcess func([]Cmder) error) func([]Cmder) error)
 	Subscribe(channels ...string) *PubSub
 	PSubscribe(channels ...string) *PubSub
 	Close() error


### PR DESCRIPTION
…e in cluster client

I'm not sure why those two implementations were missing and if there is any ratio for that. Not having had yet an answer on #1004 I decided to just push some of them.

Feel free to reject if I missed any requirement why these should not be implemented