### PR TITLE
fix pubsub panic on redis reload

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1551,6 +1551,8 @@ func (c *ClusterClient) pubSub() *PubSub {
 
 			cn, err := node.Client.newConn()
 			if err != nil {
+				node = nil
+
 				return nil, err
 			}
 


### PR DESCRIPTION
On reload redis cluster, pubSub do panic.
```
			cn, err := node.Client.newConn()
			if err != nil {
				// in this case cn still nil, but node not nil, 
				// and next call newConn (from pubsub._conn) do panic
				// we need set node to nil before return
				node = nil

				return nil, err
			}
```