### PR TITLE
Add Sentinel Password Option

### DIFF
--- a/options.go
+++ b/options.go
@@ -42,6 +42,10 @@ type Options struct {
 	// Optional password. Must match the password specified in the
 	// requirepass server configuration option.
 	Password string
+
+	// Optional sentinel password. Sentinel process can also be password protected.
+	SentinelPassword string
+
 	// Database to be selected after connecting to the server.
 	DB int
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -53,8 +53,9 @@ func (opt *FailoverOptions) options() *Options {
 
 		OnConnect: opt.OnConnect,
 
-		DB:       opt.DB,
-		Password: opt.Password,
+		DB:               opt.DB,
+		Password:         opt.Password,
+		SentinelPassword: opt.SentinelPassword,
 
 		MaxRetries: opt.MaxRetries,
 
@@ -258,6 +259,8 @@ func (c *sentinelFailover) masterAddr() (string, error) {
 			Addr: sentinelAddr,
 
 			MaxRetries: c.opt.MaxRetries,
+
+			Password: c.opt.SentinelPassword,
 
 			DialTimeout:  c.opt.DialTimeout,
 			ReadTimeout:  c.opt.ReadTimeout,


### PR DESCRIPTION
Add Sentinel Password Option

However, it can not support sentinels usage with different passwords, but I think this should not happen.

issue: https://github.com/go-redis/redis/issues/1020#issuecomment-494358866