### PR TITLE
Add SentinelClient Ping, Monitor, Remove and Set funcs

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -228,9 +228,7 @@ func (c *SentinelClient) CkQuorum(name string) *StringCmd {
 }
 
 // Monitor tells the Sentinel to start monitoring a new master with the specified
-// name, ip, port, and quorum. It is identical to the sentinel monitor configuration
-// directive in sentinel.conf configuration file, with the difference that you can't
-// use an hostname in as ip, but you need to provide an IPv4 or IPv6 address.
+// name, ip, port, and quorum.
 func (c *SentinelClient) Monitor(name, ip, port, quorum string) *StringCmd {
 	cmd := NewStringCmd("sentinel", "monitor", name, ip, port, quorum)
 	c.Process(cmd)
@@ -238,9 +236,6 @@ func (c *SentinelClient) Monitor(name, ip, port, quorum string) *StringCmd {
 }
 
 // Set is used in order to change configuration parameters of a specific master.
-// Multiple option / value pairs can be specified (or none at all). All the
-// configuration parameters that can be configured via sentinel.conf are also
-// configurable using the SET command.
 func (c *SentinelClient) Set(name, option, value string) *StringCmd {
 	cmd := NewStringCmd("sentinel", "set", name, option, value)
 	c.Process(cmd)
@@ -249,7 +244,7 @@ func (c *SentinelClient) Set(name, option, value string) *StringCmd {
 
 // Remove is used in order to remove the specified master: the master will no
 // longer be monitored, and will totally be removed from the internal state of
-// the Sentinel, so it will no longer listed by SENTINEL masters and so forth.
+// the Sentinel.
 func (c *SentinelClient) Remove(name string) *StringCmd {
 	cmd := NewStringCmd("sentinel", "remove", name)
 	c.Process(cmd)

--- a/sentinel.go
+++ b/sentinel.go
@@ -195,6 +195,30 @@ func (c *SentinelClient) Master(name string) *StringStringMapCmd {
 	return cmd
 }
 
+// Masters shows a list of monitored masters and their state.
+func (c *SentinelClient) Masters() *SliceCmd {
+	cmd := NewSliceCmd("sentinel", "masters")
+	c.Process(cmd)
+	return cmd
+}
+
+// Slaves shows a list of slaves for the specified master and their state.
+func (c *SentinelClient) Slaves(name string) *SliceCmd {
+	cmd := NewSliceCmd("sentinel", "slaves", name)
+	c.Process(cmd)
+	return cmd
+}
+
+// CkQuorum checks if the current Sentinel configuration is able to reach the
+// quorum needed to failover a master, and the majority needed to authorize the
+// failover. This command should be used in monitoring systems to check if a
+// Sentinel deployment is ok.
+func (c *SentinelClient) CkQuorum(name string) *StringCmd {
+	cmd := NewStringCmd("sentinel", "ckquorum", name)
+	c.Process(cmd)
+	return cmd
+}
+
 type sentinelFailover struct {
 	sentinelAddrs []string
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -130,6 +130,14 @@ func (c *SentinelClient) pubSub() *PubSub {
 	return pubsub
 }
 
+// Ping is used to test if a connection is still alive, or to
+// measure latency.
+func (c *SentinelClient) Ping() *StringCmd {
+	cmd := NewStringCmd("ping")
+	c.Process(cmd)
+	return cmd
+}
+
 // Subscribe subscribes the client to the specified channels.
 // Channels can be omitted to create empty subscription.
 func (c *SentinelClient) Subscribe(channels ...string) *PubSub {
@@ -215,6 +223,35 @@ func (c *SentinelClient) Slaves(name string) *SliceCmd {
 // Sentinel deployment is ok.
 func (c *SentinelClient) CkQuorum(name string) *StringCmd {
 	cmd := NewStringCmd("sentinel", "ckquorum", name)
+	c.Process(cmd)
+	return cmd
+}
+
+// Monitor tells the Sentinel to start monitoring a new master with the specified
+// name, ip, port, and quorum. It is identical to the sentinel monitor configuration
+// directive in sentinel.conf configuration file, with the difference that you can't
+// use an hostname in as ip, but you need to provide an IPv4 or IPv6 address.
+func (c *SentinelClient) Monitor(name, ip, port, quorum string) *StringCmd {
+	cmd := NewStringCmd("sentinel", "monitor", name, ip, port, quorum)
+	c.Process(cmd)
+	return cmd
+}
+
+// Set is used in order to change configuration parameters of a specific master.
+// Multiple option / value pairs can be specified (or none at all). All the 
+// configuration parameters that can be configured via sentinel.conf are also
+// configurable using the SET command.
+func (c *SentinelClient) Set(name, option, value string) *StringCmd {
+	cmd := NewStringCmd("sentinel", "set", name, option, value)
+	c.Process(cmd)
+	return cmd
+}
+
+// Remove is used in order to remove the specified master: the master will no
+// longer be monitored, and will totally be removed from the internal state of
+// the Sentinel, so it will no longer listed by SENTINEL masters and so forth.
+func (c *SentinelClient) Remove(name string) *StringCmd {
+	cmd := NewStringCmd("sentinel", "remove", name)
 	c.Process(cmd)
 	return cmd
 }


### PR DESCRIPTION
This PR adds the following missing Sentinel commands:
1. .Ping()
1. .Monitor()
1. .Remove()
1. .Set()

See: https://redis.io/topics/sentinel#sentinel-commands