### PR TITLE
add option for sentinel password

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -27,8 +27,9 @@ type FailoverOptions struct {
 
 	OnConnect func(*Conn) error
 
-	Password string
-	DB       int
+	Password         string
+	SentinelPassword string
+	DB               int
 
 	MaxRetries      int
 	MinRetryBackoff time.Duration
@@ -82,6 +83,7 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 	failover := &sentinelFailover{
 		masterName:    failoverOpt.MasterName,
 		sentinelAddrs: failoverOpt.SentinelAddrs,
+		password:      failoverOpt.SentinelPassword,
 
 		opt: opt,
 	}
@@ -275,7 +277,8 @@ func (c *SentinelClient) Remove(name string) *StringCmd {
 type sentinelFailover struct {
 	sentinelAddrs []string
 
-	opt *Options
+	opt      *Options
+	password string
 
 	pool     *pool.ConnPool
 	poolOnce sync.Once
@@ -333,6 +336,8 @@ func (c *sentinelFailover) masterAddr() (string, error) {
 	for i, sentinelAddr := range c.sentinelAddrs {
 		sentinel := NewSentinelClient(&Options{
 			Addr: sentinelAddr,
+
+			Password: c.password,
 
 			MaxRetries: c.opt.MaxRetries,
 


### PR DESCRIPTION
Last version of sentinel support password (AUTH)

From: https://redis.io/topics/sentinel
> You can also configure the Sentinel instance itself in order to require client authentication via the AUTH command, however this feature is only available starting with Redis 5.0.1.

> Before using this configuration make sure your client library is able to send the AUTH command to Sentinel instances.

I add a new option in failover options that is PasswordSentinel that can be different from Redis Database.

Tested and working.

