### PR TITLE
Inc StaleConns in ReapStaleConns call.

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -465,7 +465,7 @@ func (p *ConnPool) reaper(frequency time.Duration) {
 		if p.closed() {
 			break
 		}
-		n, err := p.ReapStaleConns()
+		_, err := p.ReapStaleConns()
 		if err != nil {
 			internal.Logf("ReapStaleConns failed: %s", err)
 			continue

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -453,6 +453,7 @@ func (p *ConnPool) ReapStaleConns() (int, error) {
 			break
 		}
 	}
+	atomic.AddUint32(&p.stats.StaleConns, uint32(n))
 	return n, nil
 }
 
@@ -469,7 +470,6 @@ func (p *ConnPool) reaper(frequency time.Duration) {
 			internal.Logf("ReapStaleConns failed: %s", err)
 			continue
 		}
-		atomic.AddUint32(&p.stats.StaleConns, uint32(n))
 	}
 }
 


### PR DESCRIPTION
The current implementation does not increment the reaped
connection counter if ReapStaleConns is called
inside func (c *ClusterClient) reaper(idleCheckFrequency time.Duration)