### PR TITLE
sentinel support proxy, such as socks5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-redis/redis
+module github.com/Jasonix/redis
 
 require (
 	github.com/onsi/ginkgo v1.8.0

--- a/options.go
+++ b/options.go
@@ -37,6 +37,9 @@ type Options struct {
 	// Network and Addr options.
 	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 
+	// For sentinel proxy
+	DumpDialer func(ctx context.Context, network, addr string) (net.Conn, error)
+
 	// Hook that is called when new connection is established.
 	OnConnect func(*Conn) error
 


### PR DESCRIPTION
current the redis client can access server over proxy, but the sentinel client can't
