### PR TITLE
Add NewZWithKeyCmdResult to initialize ZWithKeyCmd for testing

### DIFF
--- a/result.go
+++ b/result.go
@@ -106,6 +106,14 @@ func NewZSliceCmdResult(val []Z, err error) *ZSliceCmd {
 	return &cmd
 }
 
+// NewZWithKeyCmdResult returns a NewZWithKeyCmd initialised with val and err for testing
+func NewZWithKeyCmdResult(val *ZWithKey, err error) *ZWithKeyCmd {
+	var cmd ZWithKeyCmd
+	cmd.val = val
+	cmd.setErr(err)
+	return &cmd
+}
+
 // NewScanCmdResult returns a ScanCmd initialised with val and err for testing
 func NewScanCmdResult(keys []string, cursor uint64, err error) *ScanCmd {
 	var cmd ScanCmd


### PR DESCRIPTION
Needed to create ZWithKeyCmd  while testing ZPOPMIN opertaions, found it missing in results.go