### PR TITLE
Add support for individual passwords for ring shards

### DIFF
--- a/ring_test.go
+++ b/ring_test.go
@@ -172,6 +172,29 @@ var _ = Describe("Redis Ring", func() {
 			Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=100"))
 		})
 	})
+
+	Describe("shard passwords", func() {
+		It("can be initialized with a single password, used for all shards", func() {
+			opts := redisRingOptions()
+			opts.Password = "password"
+			ring = redis.NewRing(opts)
+
+			err := ring.Ping().Err()
+			Expect(err).To(MatchError("ERR Client sent AUTH, but no password is set"))
+		})
+
+		It("can be initialized with a passwords map, one for each shard", func() {
+			opts := redisRingOptions()
+			opts.Passwords = map[string]string{
+				"ringShardOne": "password1",
+				"ringShardTwo": "password2",
+			}
+			ring = redis.NewRing(opts)
+
+			err := ring.Ping().Err()
+			Expect(err).To(MatchError("ERR Client sent AUTH, but no password is set"))
+		})
+	})
 })
 
 var _ = Describe("empty Redis Ring", func() {


### PR DESCRIPTION
This PR enhances the `Ring` client by adding a new `Passwords` field to it so that each shard can have its own password. This change doesn't introduce a breaking change since the existing `Password` field has precedence over the new one and applications already using the `Ring` client with a single password won't stop working.