### PR TITLE
protect pollSize and idleConnsLen with mutex

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -92,9 +92,7 @@ func NewConnPool(opt *Options) *ConnPool {
 		idleConns: make([]*Conn, 0, opt.PoolSize),
 	}
 
-	for i := 0; i < opt.MinIdleConns; i++ {
-		p.checkMinIdleConns()
-	}
+	p.checkMinIdleConns()
 
 	if opt.IdleTimeout > 0 && opt.IdleCheckFrequency > 0 {
 		go p.reaper(opt.IdleCheckFrequency)
@@ -107,10 +105,13 @@ func (p *ConnPool) checkMinIdleConns() {
 	if p.opt.MinIdleConns == 0 {
 		return
 	}
-	if p.poolSize < p.opt.PoolSize && p.idleConnsLen < p.opt.MinIdleConns {
-		p.poolSize++
-		p.idleConnsLen++
-		go p.addIdleConn()
+	if p.poolSize < p.opt.PoolSize {
+		balanceLen := p.opt.MinIdleConns - p.idleConnsLen
+		for i := 0; i < balanceLen; i++ {
+			p.poolSize++
+			p.idleConnsLen++
+			go p.addIdleConn()
+		}
 	}
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -108,6 +108,8 @@ func (p *ConnPool) checkMinIdleConns() {
 		return
 	}
 	if p.poolSize < p.opt.PoolSize && p.idleConnsLen < p.opt.MinIdleConns {
+		p.poolSize++
+		p.idleConnsLen++
 		go p.addIdleConn()
 	}
 }
@@ -115,14 +117,14 @@ func (p *ConnPool) checkMinIdleConns() {
 func (p *ConnPool) addIdleConn() {
 	cn, err := p.newConn(context.TODO(), true)
 	if err != nil {
+		p.poolSize--
+		p.idleConnsLen--
 		return
 	}
 
 	p.connsMu.Lock()
 	p.conns = append(p.conns, cn)
-	p.poolSize++
 	p.idleConns = append(p.idleConns, cn)
-	p.idleConnsLen++
 	p.connsMu.Unlock()
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -108,8 +108,6 @@ func (p *ConnPool) checkMinIdleConns() {
 		return
 	}
 	if p.poolSize < p.opt.PoolSize && p.idleConnsLen < p.opt.MinIdleConns {
-		p.poolSize++
-		p.idleConnsLen++
 		go p.addIdleConn()
 	}
 }
@@ -122,7 +120,9 @@ func (p *ConnPool) addIdleConn() {
 
 	p.connsMu.Lock()
 	p.conns = append(p.conns, cn)
+	p.poolSize++
 	p.idleConns = append(p.idleConns, cn)
+	p.idleConnsLen++
 	p.connsMu.Unlock()
 }
 


### PR DESCRIPTION
If addIdleConn() stopped due to the error, poolSize and idleConnsLen will be confusing.