### PR TITLE
Use unsafe StringToBytes to speedup StringCmd.Bytes

### DIFF
--- a/command.go
+++ b/command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-redis/redis/internal"
 	"github.com/go-redis/redis/internal/proto"
+	"github.com/go-redis/redis/internal/util"
 )
 
 type Cmder interface {
@@ -617,7 +618,7 @@ func (cmd *StringCmd) Result() (string, error) {
 }
 
 func (cmd *StringCmd) Bytes() ([]byte, error) {
-	return []byte(cmd.val), cmd.err
+	return util.StringToBytes(cmd.val), cmd.err
 }
 
 func (cmd *StringCmd) Int() (int, error) {


### PR DESCRIPTION
Updates https://github.com/go-redis/redis/issues/472

Before

```
BenchmarkRedisSetGetBytes-4   	   41136	     28640 ns/op	   20777 B/op	      11 allocs/op
```

After

```
BenchmarkRedisSetGetBytes-4   	   43369	     26224 ns/op	   10537 B/op	      10 allocs/op
```