### PR TITLE
Use DialContext by default

### DIFF
--- a/options.go
+++ b/options.go
@@ -112,7 +112,7 @@ func (opt *Options) init() {
 				KeepAlive: 5 * time.Minute,
 			}
 			if opt.TLSConfig == nil {
-				return netDialer.Dial(network, addr)
+				return netDialer.DialContext(ctx, network, addr)
 			}
 			return tls.DialWithDialer(netDialer, opt.Network, opt.Addr, opt.TLSConfig)
 		}

--- a/redis_test.go
+++ b/redis_test.go
@@ -51,7 +51,8 @@ var _ = Describe("Client", func() {
 			Network: "tcp",
 			Addr:    redisAddr,
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return net.Dial(network, addr)
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
 			},
 		})
 


### PR DESCRIPTION
Use net.Dialer DialContext by default because go-redis supports contexts.

Resolves #1101