### PR TITLE
Close single conn connection pool

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -2,12 +2,15 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strings"
 
 	"github.com/go-redis/redis/internal/proto"
 )
+
+var ErrSingleConnPoolClosed = errors.New("redis: SingleConnPool is closed")
 
 func IsRetryableError(err error, retryTimeout bool) bool {
 	switch err {
@@ -22,6 +25,10 @@ func IsRetryableError(err error, retryTimeout bool) bool {
 		}
 		return true
 	}
+	if err == ErrSingleConnPoolClosed {
+		return true
+	}
+
 	s := err.Error()
 	if s == "ERR max number of clients reached" {
 		return true


### PR DESCRIPTION
This is a bugfix for issue #1113.

This is intended to solve the issue while making as few other changes as possible. Since `SingleConnPool` is not used in any other context, this seemed reasonable.

I'm completely open to alternative ways to solve this, but the essence is that `SingleConnPool.Remove` _must_ flag the pool as no longer able to return a valid connection.