### PR TITLE
Pop idle connections from the front of the pool

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -301,9 +301,9 @@ func (p *ConnPool) popIdle() *Conn {
 		return nil
 	}
 
-	idx := len(p.idleConns) - 1
-	cn := p.idleConns[idx]
-	p.idleConns = p.idleConns[:idx]
+	// Take idle conn from front
+	cn := p.idleConns[0]
+	p.idleConns = p.idleConns[1:]
 	p.idleConnsLen--
 	p.checkMinIdleConns()
 	return cn


### PR DESCRIPTION
Version: 0cf98f921

Pop idle connections from the front so the pool behaves like a queue instead of a stack. go-redis performance is significantly better when the Redis cluster is under memory pressure (evicting data due to LRU). Most of the errors were read timeout errors from net.Conn.Read with a 1s deadline set, and they go away with this change. My theory is that conns are more uniformly used and the Redis server likes this better

# Testing Setup

AWS ElastiCache Redis Cluster setup:
* Engine 3.2.10 (Reproduces on 5.0.3 too)
* 3 shards
* 3 nodes per shard
* cache.r4.xlarge node type

Redis cluster client configuration:

```go
dialer := net.Dialer{
  Timeout:   1 * time.Second,
  KeepAlive: 30 * time.Second,
}

client := redis.NewClusterClient(&redis.ClusterOptions{
  Addrs:        []string{"addr"},
  MaxRedirects: 1,
  ReadOnly:     true,
  DialTimeout:  1 * time.Second,
  ReadTimeout:  1 * time.Second,
  WriteTimeout: 1 * time.Second,
  PoolSize:     30,
  Dialer: func(ctx context.Context, network string, addr string) (net.Conn, error) {
    return dialer.DialContext(ctx, network, addr)
  },
  IdleTimeout:        -1,
  IdleCheckFrequency: -1,
})
```

There are 30 Go application processes running with the above client, and cumulatively generating 80K GET/s and 15K SETNX/s. When Redis starts evicting data due to memory pressure, I see read timeouts and higher latency.

At 0:57 in the graph below is the switch to use this change
<img width="1810" alt="goredis_patch" src="https://user-images.githubusercontent.com/85360/62811768-cfd2f000-bab7-11e9-86ea-6595fedb50af.png">
