### PR TITLE
Fix "redis: discarding bad PubSub connection" stuck state

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -467,8 +467,8 @@ func (c *PubSub) initPing() {
 						pingErr = errPingTimeout
 					}
 					c.mu.Lock()
-					healthy = true
 					c.reconnect(pingErr)
+					healthy = true
 					c.mu.Unlock()
 				}
 			case <-c.exit:

--- a/pubsub.go
+++ b/pubsub.go
@@ -467,6 +467,7 @@ func (c *PubSub) initPing() {
 						pingErr = errPingTimeout
 					}
 					c.mu.Lock()
+					healthy = true
 					c.reconnect(pingErr)
 					c.mu.Unlock()
 				}


### PR DESCRIPTION
This addresses the issue where the client is stuck in a loop of "redis: discarding bad PubSub connection" while failing to receive subscription messages. 

The following sequence causes this stuck state:
healthy is initialized to true.
Timer event fires, a new Ping command is issued, and healthy = false.
Another timer event fires before the ping response, a new Ping command is issued but the connection is dropped by c.reconnect before a response can be received.

The client will remain in this reconnect loop since there is no way to set healthy = true. This PR sets healthy = true after the reconnect, which allows the next timer event's Ping response to arrive before another reconnect.