### PR TITLE
fix(xreadgroup): fix the problem that can not use the func XReadGroup()

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1460,6 +1460,7 @@ type XReadGroupArgs struct {
 	Count    int64
 	Block    time.Duration
 	NoAck    bool
+	ID       string
 }
 
 func (c cmdable) XReadGroup(a *XReadGroupArgs) *XStreamSliceCmd {
@@ -1478,6 +1479,8 @@ func (c cmdable) XReadGroup(a *XReadGroupArgs) *XStreamSliceCmd {
 	for _, s := range a.Streams {
 		args = append(args, s)
 	}
+
+	args = append(args, a.ID)
 
 	cmd := NewXStreamSliceCmd(args...)
 	if a.Block >= 0 {


### PR DESCRIPTION
I got a problem in the func XreadGroup; There is  an error message there: 'xreadgroup group group1 c1 count 1 block 0 noack streams test1: ERR Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified', actually we need to add a param (ID) at the end of that command so that redis consumer can get where it is and find message appointed. You can get more information about redis xreadgroup from the link https://redis.io/commands/xreadgroup. So, in my way, I add 'ID' in XReadGroupArgs which type is string, it would be at the end of command, it works. Thank you for your reading.