### PR TITLE
fix: FailoverOptions to Options

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -60,6 +60,8 @@ func (opt *FailoverOptions) options() *Options {
 		Password: opt.Password,
 
 		MaxRetries: opt.MaxRetries,
+		MinRetryBackoff: opt.MinRetryBackoff,
+		MaxRetryBackoff: opt.MaxRetryBackoff,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,
@@ -69,6 +71,8 @@ func (opt *FailoverOptions) options() *Options {
 		PoolTimeout:        opt.PoolTimeout,
 		IdleTimeout:        opt.IdleTimeout,
 		IdleCheckFrequency: opt.IdleCheckFrequency,
+		MinIdleConns:       opt.MinIdleConns,
+		MaxConnAge:         opt.MaxConnAge,
 
 		TLSConfig: opt.TLSConfig,
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -59,7 +59,7 @@ func (opt *FailoverOptions) options() *Options {
 		DB:       opt.DB,
 		Password: opt.Password,
 
-		MaxRetries: opt.MaxRetries,
+		MaxRetries:      opt.MaxRetries,
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
 


### PR DESCRIPTION
why FailoverOptions like MinIdleConns not trans to Options?