### PR TITLE
add NewGeoPosCmdResult to make GeoPos mockable result

### DIFF
--- a/result.go
+++ b/result.go
@@ -139,6 +139,14 @@ func NewGeoLocationCmdResult(val []GeoLocation, err error) *GeoLocationCmd {
 	return &cmd
 }
 
+// NewGeoPosCmdResult returns a GeoPosCmd initialised with val and err for testing
+func NewGeoPosCmdResult(val []*GeoPos, err error) *GeoPosCmd {
+	var cmd GeoPosCmd
+	cmd.val = val
+	cmd.setErr(err)
+	return &cmd
+}
+
 // NewCommandsInfoCmdResult returns a CommandsInfoCmd initialised with val and err for testing
 func NewCommandsInfoCmdResult(val map[string]*CommandInfo, err error) *CommandsInfoCmd {
 	var cmd CommandsInfoCmd


### PR DESCRIPTION
GeoPosCmd cannot mock in unit test due to set result function is missing.