### PR TITLE
Set key to lowercase in cmdsInfoCache.Get()

### DIFF
--- a/command.go
+++ b/command.go
@@ -2006,6 +2006,12 @@ func (c *cmdsInfoCache) Get() (map[string]*CommandInfo, error) {
 		if err != nil {
 			return err
 		}
+		for key := range cmds {
+			lowerKey := internal.ToLower(key)
+			if key != lowerKey {
+				cmds[lowerKey] = cmds[key]
+			}
+		}
 		c.cmds = cmds
 		return nil
 	})


### PR DESCRIPTION
In function cmdInfo(name string), we use lower cmd name to find the cmdsInfo. 
```golang
//name is lower case
func (c *Ring) cmdInfo(name string) *CommandInfo {
	cmdsInfo, err := c.cmdsInfoCache.Get()
	if err != nil {
		return nil
	}
	info := cmdsInfo[name]
	if info == nil {
		internal.Logger.Printf("info for cmd=%s not found", name)
	}
	return info
}
```
But for extensions like bloom filter, the "command" returns names with uppercase. 

I think if we use lowercase name to find the cmdInfo, then we should turn cmd names to lower case when we fill the cmdsInfoCache.