### PR TITLE
FailoverClient with read-only support

### DIFF
--- a/options.go
+++ b/options.go
@@ -104,6 +104,9 @@ type Options struct {
 	// Enables read only queries on slave nodes.
 	readOnly bool
 
+	// Enables read only queries on redis replicas in sentinel mode
+	sentinelReadOnly bool
+
 	// TLS Config to use. When set TLS will be negotiated.
 	TLSConfig *tls.Config
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"math/rand"
 	"net"
 	"strings"
 	"sync"
@@ -50,6 +51,9 @@ type FailoverOptions struct {
 	IdleCheckFrequency time.Duration
 
 	TLSConfig *tls.Config
+
+	// Enables read-only commands on slave nodes.
+	ReadOnly bool
 }
 
 func (opt *FailoverOptions) options() *Options {
@@ -79,6 +83,8 @@ func (opt *FailoverOptions) options() *Options {
 		MaxConnAge:         opt.MaxConnAge,
 
 		TLSConfig: opt.TLSConfig,
+
+		sentinelReadOnly: opt.ReadOnly,
 	}
 }
 
@@ -325,7 +331,15 @@ func (c *sentinelFailover) Pool() *pool.ConnPool {
 }
 
 func (c *sentinelFailover) dial(ctx context.Context, network, _ string) (net.Conn, error) {
-	addr, err := c.MasterAddr(ctx)
+	var addr string
+	var err error
+
+	if c.opt.sentinelReadOnly {
+		addr, err = c.RandomSlaveAddr()
+	} else {
+		addr, err = c.MasterAddr()
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -342,6 +356,17 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 	}
 	c.switchMaster(ctx, addr)
 	return addr, nil
+}
+
+func (c *sentinelFailover) RandomSlaveAddr() (string, error) {
+	addresses, err := c.slaveAddresses()
+	if err != nil {
+		return "", err
+	}
+	if len(addresses) < 1 {
+		return c.MasterAddr()
+	}
+	return addresses[rand.Intn(len(addresses))], nil
 }
 
 func (c *sentinelFailover) masterAddr(ctx context.Context) (string, error) {
@@ -408,6 +433,69 @@ func (c *sentinelFailover) masterAddr(ctx context.Context) (string, error) {
 	return "", errors.New("redis: all sentinels are unreachable")
 }
 
+func (c *sentinelFailover) slaveAddresses() ([]string, error) {
+	c.mu.RLock()
+	sentinel := c.sentinel
+	c.mu.RUnlock()
+
+	if sentinel != nil {
+		addrs := c.getSlaveAddrs(sentinel)
+		if len(addrs) > 0 {
+			return addrs, nil
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.sentinel != nil {
+		addrs := c.getSlaveAddrs(c.sentinel)
+		if len(addrs) > 0 {
+			return addrs, nil
+		}
+		_ = c.closeSentinel()
+	}
+
+	for i, sentinelAddr := range c.sentinelAddrs {
+		sentinel := NewSentinelClient(&Options{
+			Addr:   sentinelAddr,
+			Dialer: c.opt.Dialer,
+
+			Password: c.password,
+
+			MaxRetries: c.opt.MaxRetries,
+
+			DialTimeout:  c.opt.DialTimeout,
+			ReadTimeout:  c.opt.ReadTimeout,
+			WriteTimeout: c.opt.WriteTimeout,
+
+			PoolSize:           c.opt.PoolSize,
+			PoolTimeout:        c.opt.PoolTimeout,
+			IdleTimeout:        c.opt.IdleTimeout,
+			IdleCheckFrequency: c.opt.IdleCheckFrequency,
+
+			TLSConfig: c.opt.TLSConfig,
+		})
+
+		slaves, err := sentinel.Slaves(c.masterName).Result()
+		if err != nil {
+			internal.Logger.Printf("sentinel: Slaves master=%q failed: %s",
+				c.masterName, err)
+			_ = sentinel.Close()
+			continue
+		}
+
+		// Push working sentinel to the top.
+		c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
+		c.setSentinel(sentinel)
+
+		addrs := parseSlaveAddresses(slaves)
+		return addrs, nil
+	}
+
+	return []string{}, errors.New("redis: all sentinels are unreachable")
+}
+
 func (c *sentinelFailover) getMasterAddr(ctx context.Context, sentinel *SentinelClient) string {
 	addr, err := sentinel.GetMasterAddrByName(ctx, c.masterName).Result()
 	if err != nil {
@@ -416,6 +504,40 @@ func (c *sentinelFailover) getMasterAddr(ctx context.Context, sentinel *Sentinel
 		return ""
 	}
 	return net.JoinHostPort(addr[0], addr[1])
+}
+
+func (c *sentinelFailover) getSlaveAddrs(sentinel *SentinelClient) []string {
+	addrs, err := sentinel.Slaves(c.masterName).Result()
+	if err != nil {
+		internal.Logger.Printf("sentinel: Slaves name=%q failed: %s",
+			c.masterName, err)
+		return []string{}
+	}
+
+	return parseSlaveAddresses(addrs)
+}
+
+func parseSlaveAddresses(addrs []interface{}) []string {
+	nodes := []string{}
+
+	for _, node := range addrs {
+		ip := ""
+		port := ""
+		lastkey := ""
+
+		for _, key := range node.([]interface{}) {
+			switch lastkey {
+			case "ip":
+				ip = key.(string)
+			case "port":
+				port = key.(string)
+			}
+			lastkey = key.(string)
+		}
+		nodes = append(nodes, net.JoinHostPort(ip, port))
+	}
+
+	return nodes
 }
 
 func (c *sentinelFailover) switchMaster(ctx context.Context, addr string) {

--- a/sentinel.go
+++ b/sentinel.go
@@ -523,7 +523,9 @@ func parseSlaveAddresses(addrs []interface{}) []string {
 	for _, node := range addrs {
 		ip := ""
 		port := ""
+		flags := []string{}
 		lastkey := ""
+		isDown := false
 
 		for _, key := range node.([]interface{}) {
 			switch lastkey {
@@ -531,10 +533,20 @@ func parseSlaveAddresses(addrs []interface{}) []string {
 				ip = key.(string)
 			case "port":
 				port = key.(string)
+			case "flags":
+				flags = strings.Split(key.(string), ",")
 			}
 			lastkey = key.(string)
 		}
-		nodes = append(nodes, net.JoinHostPort(ip, port))
+		for _, flag := range flags {
+			switch flag {
+			case "s_down", "o_down", "disconnected":
+				isDown = true
+			}
+		}
+		if !isDown {
+			nodes = append(nodes, net.JoinHostPort(ip, port))
+		}
 	}
 
 	return nodes


### PR DESCRIPTION
Allow `FailoverClient` `ReadOnly` option. Client then connects to redis replicas (or master if no slave is available) for performing read-only queries. User is responsible for deciding which query can be run against it.

It aims to implement the same as #997 but without misusing ClusterClient which is not suitable for this.