### PR TITLE
properly point redisServerConf to redis.conf

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -257,7 +257,7 @@ func (p *redisProcess) Close() error {
 
 var (
 	redisServerBin, _  = filepath.Abs(filepath.Join("testdata", "redis", "src", "redis-server"))
-	redisServerConf, _ = filepath.Abs(filepath.Join("testdata", "redis.conf"))
+	redisServerConf, _ = filepath.Abs(filepath.Join("testdata", "redis", "redis.conf"))
 )
 
 func redisDir(port string) (string, error) {


### PR DESCRIPTION
I am working on a mac and I was having a number of issues running the tests. One of them being that the default redis config seemed to be in the wrong place. I am not sure if I the config was supposed to be placed at the existing `redisServerConf` by some script, but I needed to make this change to have it work properly. 

If I am doing something wrong and I should not need to make this update let me know. 