### PR TITLE
FIX: the BLPOP/BRPOP command may reach socket timeout when no message…

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1010,7 +1010,7 @@ func (c cmdable) BLPop(timeout time.Duration, keys ...string) *StringSliceCmd {
 	}
 	args[len(args)-1] = formatSec(timeout)
 	cmd := NewStringSliceCmd(args...)
-	cmd.setReadTimeout(timeout)
+	cmd.setReadTimeout(timeout + time.Second)
 	_ = c(cmd)
 	return cmd
 }
@@ -1023,7 +1023,7 @@ func (c cmdable) BRPop(timeout time.Duration, keys ...string) *StringSliceCmd {
 	}
 	args[len(keys)+1] = formatSec(timeout)
 	cmd := NewStringSliceCmd(args...)
-	cmd.setReadTimeout(timeout)
+	cmd.setReadTimeout(timeout + time.Second)
 	_ = c(cmd)
 	return cmd
 }
@@ -1035,7 +1035,7 @@ func (c cmdable) BRPopLPush(source, destination string, timeout time.Duration) *
 		destination,
 		formatSec(timeout),
 	)
-	cmd.setReadTimeout(timeout)
+	cmd.setReadTimeout(timeout + time.Second)
 	_ = c(cmd)
 	return cmd
 }


### PR DESCRIPTION
While the Redis server uses cron to check where there are clients reach
timeout. The clientsCron makes some effort to process all the clients
every second and cannot be strictly guaranteed, So we simply add 1
second here.

see also Redis `clientsCron` function