### PR TITLE
Fix sample code for Sort method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Some corner cases:
 set, err := client.SetNX("key", "value", 10*time.Second).Result()
 
 // SORT list LIMIT 0 2 ASC
-vals, err := client.Sort("list", redis.Sort{Offset: 0, Count: 2, Order: "ASC"}).Result()
+vals, err := client.Sort("list", &redis.Sort{Offset: 0, Count: 2, Order: "ASC"}).Result()
 
 // ZRANGEBYSCORE zset -inf +inf WITHSCORES LIMIT 0 2
 vals, err := client.ZRangeByScoreWithScores("zset", redis.ZRangeBy{


### PR DESCRIPTION
Hi, I found the sample code for `Sort()` method missed the `&` symbol，because of the signature of `Sort()` method `func (c *Client) Sort(key string, sort *Sort) *StringSliceCmd` says it need a pointer of `redis.Sort{}`