### PR TITLE
let XReadGroup skip empty message and process next message

### DIFF
--- a/command.go
+++ b/command.go
@@ -1004,8 +1004,12 @@ func xMessageSliceParser(rd *proto.Reader, n int64) (interface{}, error) {
 			}
 
 			v, err := rd.ReadArrayReply(stringInterfaceMapParser)
-			if err != nil {
+			if err != nil && err != proto.Nil {
 				return nil, err
+			}
+
+			if v == nil || err == proto.Nil {
+				v = make(map[string]interface{})
 			}
 
 			msgs[i] = XMessage{

--- a/commands_test.go
+++ b/commands_test.go
@@ -3623,6 +3623,27 @@ var _ = Describe("Commands", func() {
 				Expect(n).To(Equal(int64(1)))
 			})
 
+			It("should XReadGroup skip empty", func() {
+				n, err := client.XDel("stream", "2-0").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(n).To(Equal(int64(1)))
+
+				res, err := client.XReadGroup(&redis.XReadGroupArgs{
+					Group:    "group",
+					Consumer: "consumer",
+					Streams:  []string{"stream", "0"},
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(Equal([]redis.XStream{{
+					Stream: "stream",
+					Messages: []redis.XMessage{
+						{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+						{ID: "2-0", Values: map[string]interface{}{}},
+						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+					}},
+				}))
+			})
+
 			It("should XGroupCreateMkStream", func() {
 				err := client.XGroupCreateMkStream("stream2", "group", "0").Err()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
XReadGroup stops processing a Redis Stream if any item in the stream is deleted by XDel or XTrim (or XAdd with Maxlen). It returns a `RedisError("redis: nil")` and stop processing the rest items in the stream, which makes XReadGroup not usable in some realistic scenarios (e.g. It is typical to call XTrim to limit the Redis Stream size).

This problem does not exist in Redis CLI. See the example below. 
In the Redis CLI console, if we delete an item (1579681634428-1) from a stream (str0), we can still get the rest items from this stream correctly. Redis CLI shows the deleted item as (nil). Based on the [Redis Protocol](https://redis.io/topics/protocol), this makes perfect sense because Redis server returns `*-1\r\n` for the deleted items in the stream.
```
127.0.0.1:6379> xreadgroup Group g1 c1 Streams str0 0
1) 1) "str0"
   2) 1) 1) "1579681634428-0"
         2) 1) "f1"
            2) "v1"
      2) 1) "1579681634428-1"
         2) 1) "f2"
            2) "v2"
      3) 1) "1579681634428-2"
         2) 1) "f3"
            2) "v3"
      4) 1) "1579681648438-0"
         2) 1) "fn"
            2) "fn"
127.0.0.1:6379>
127.0.0.1:6379>
127.0.0.1:6379> xdel str0 1579681634428-1
(integer) 1
127.0.0.1:6379>
127.0.0.1:6379>
127.0.0.1:6379> xreadgroup Group g1 c1 Streams str0 0
1) 1) "str0"
   2) 1) 1) "1579681634428-0"
         2) 1) "f1"
            2) "v1"
      2) 1) "1579681634428-1"
         2) (nil)
      3) 1) "1579681634428-2"
         2) 1) "f3"
            2) "v3"
      4) 1) "1579681648438-0"
         2) 1) "fn"
            2) "fn"
```