### PR TITLE
modify HSET to support multiple fieldValue and return an integer reply

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -131,7 +131,7 @@ type Cmdable interface {
 	HLen(key string) *IntCmd
 	HMGet(key string, fields ...string) *SliceCmd
 	HMSet(key string, values ...interface{}) *IntCmd
-	HSet(key, field string, fieldValues ...interface{}) *IntCmd
+	HSet(key string, fieldValues ...interface{}) *IntCmd
 	HSetNX(key, field string, value interface{}) *BoolCmd
 	HVals(key string) *StringSliceCmd
 	BLPop(timeout time.Duration, keys ...string) *StringSliceCmd
@@ -999,7 +999,7 @@ func (c cmdable) HMSet(key string, values ...interface{}) *IntCmd {
 	return cmd
 }
 
-func (c cmdable) HSet(key, field string, fieldValues ...interface{}) *IntCmd {
+func (c cmdable) HSet(key string, fieldValues ...interface{}) *IntCmd {
 	args := make([]interface{}, 2, 2+len(fieldValues))
 	args[0] = "hset"
 	args[1] = key

--- a/commands.go
+++ b/commands.go
@@ -131,7 +131,7 @@ type Cmdable interface {
 	HLen(key string) *IntCmd
 	HMGet(key string, fields ...string) *SliceCmd
 	HMSet(key string, values ...interface{}) *IntCmd
-	HSet(key, field string, value interface{}) *BoolCmd
+	HSet(key, field string, fieldValues ...interface{}) *IntCmd
 	HSetNX(key, field string, value interface{}) *BoolCmd
 	HVals(key string) *StringSliceCmd
 	BLPop(timeout time.Duration, keys ...string) *StringSliceCmd
@@ -999,8 +999,12 @@ func (c cmdable) HMSet(key string, values ...interface{}) *IntCmd {
 	return cmd
 }
 
-func (c cmdable) HSet(key, field string, value interface{}) *BoolCmd {
-	cmd := NewBoolCmd("hset", key, field, value)
+func (c cmdable) HSet(key, field string, fieldValues ...interface{}) *IntCmd {
+	args := make([]interface{}, 2, 2+len(fieldValues))
+	args[0] = "hset"
+	args[1] = key
+	args = appendArgs(args, fieldValues)
+	cmd := NewIntCmd(args...)
 	_ = c(cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1325,7 +1325,7 @@ var _ = Describe("Commands", func() {
 		It("should HIncrByFloat", func() {
 			hSet := client.HSet("hash", "field", "10.50")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(true))
+			Expect(hSet.Val()).To(Equal(1))
 
 			hIncrByFloat := client.HIncrByFloat("hash", "field", 0.1)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1333,7 +1333,7 @@ var _ = Describe("Commands", func() {
 
 			hSet = client.HSet("hash", "field", "5.0e3")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(false))
+			Expect(hSet.Val()).To(Equal(0))
 
 			hIncrByFloat = client.HIncrByFloat("hash", "field", 2.0e2)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1399,11 +1399,25 @@ var _ = Describe("Commands", func() {
 		It("should HSet", func() {
 			hSet := client.HSet("hash", "key", "hello")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(true))
+			Expect(hSet.Val()).To(Equal(1))
 
 			hGet := client.HGet("hash", "key")
 			Expect(hGet.Err()).NotTo(HaveOccurred())
 			Expect(hGet.Val()).To(Equal("hello"))
+		})
+
+		It("should HSet with multiple values", func() {
+			hSet := client.HSet("hash", "key1", "hello1", "key2", "hello2")
+			Expect(hSet.Err()).NotTo(HaveOccurred())
+			Expect(hSet.Val()).To(Equal(2))
+
+			hGet := client.HGet("hash", "key1")
+			Expect(hGet.Err()).NotTo(HaveOccurred())
+			Expect(hGet.Val()).To(Equal("hello1"))
+
+			hGet = client.HGet("hash", "key2")
+			Expect(hGet.Err()).NotTo(HaveOccurred())
+			Expect(hGet.Val()).To(Equal("hello2"))
 		})
 
 		It("should HSetNX", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -1325,7 +1325,7 @@ var _ = Describe("Commands", func() {
 		It("should HIncrByFloat", func() {
 			hSet := client.HSet("hash", "field", "10.50")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(1))
+			Expect(hSet.Val()).To(Equal(int64(1)))
 
 			hIncrByFloat := client.HIncrByFloat("hash", "field", 0.1)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1333,7 +1333,7 @@ var _ = Describe("Commands", func() {
 
 			hSet = client.HSet("hash", "field", "5.0e3")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(0))
+			Expect(hSet.Val()).To(Equal(int64(0)))
 
 			hIncrByFloat = client.HIncrByFloat("hash", "field", 2.0e2)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1399,7 +1399,7 @@ var _ = Describe("Commands", func() {
 		It("should HSet", func() {
 			hSet := client.HSet("hash", "key", "hello")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(1))
+			Expect(hSet.Val()).To(Equal(int64(1)))
 
 			hGet := client.HGet("hash", "key")
 			Expect(hGet.Err()).NotTo(HaveOccurred())
@@ -1409,7 +1409,7 @@ var _ = Describe("Commands", func() {
 		It("should HSet with multiple values", func() {
 			hSet := client.HSet("hash", "key1", "hello1", "key2", "hello2")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(2))
+			Expect(hSet.Val()).To(Equal(int64(2)))
 
 			hGet := client.HGet("hash", "key1")
 			Expect(hGet.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION
- change interface to return IntCmd to support Integer reply 
- change signature to make HSet variadic to support multiple fieldValue pairs 
- Add tests for multiple fieldValue pairs in HSet 

ref: https://redis.io/commands/hset
Issue : #1242 