### PR TITLE
add support for context cancelation (#1196)

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -58,35 +58,73 @@ func (cn *Conn) RemoteAddr() net.Addr {
 }
 
 func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(rd *proto.Reader) error) error {
-	err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout))
-	if err != nil {
-		return err
-	}
-	return fn(cn.rd)
+	return cn.cancelWithSetDeadline(ctx, func() error {
+		err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout))
+		if err != nil {
+			return err
+		}
+		return fn(cn.rd)
+	})
 }
 
 func (cn *Conn) WithWriter(
 	ctx context.Context, timeout time.Duration, fn func(wr *proto.Writer) error,
 ) error {
-	err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout))
-	if err != nil {
-		return err
-	}
+	return cn.cancelWithSetDeadline(ctx, func() error {
+		err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout))
+		if err != nil {
+			return err
+		}
 
-	if cn.wr.Buffered() > 0 {
-		cn.wr.Reset(cn.netConn)
-	}
+		if cn.wr.Buffered() > 0 {
+			cn.wr.Reset(cn.netConn)
+		}
 
-	err = fn(cn.wr)
-	if err != nil {
-		return err
-	}
+		err = fn(cn.wr)
+		if err != nil {
+			return err
+		}
 
-	return cn.wr.Flush()
+		return cn.wr.Flush()
+	})
 }
 
 func (cn *Conn) Close() error {
 	return cn.netConn.Close()
+}
+
+// cancelWithSetDeadline will cancel the netConn using an immediate SetDeadline if the ctx is canceled.
+func (cn *Conn) cancelWithSetDeadline(ctx context.Context, fn func() error) error {
+	// done can be nil, in which case we just call fn
+	if ctx.Done() == nil {
+		return fn()
+	}
+
+	// stop is used to kill the background goroutine waiting on the Done channel
+	stop := make(chan struct{})
+	defer close(stop)
+
+	errs := make(chan error, 1) // we buffer here in case both the function and the background goroutine manage to run
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			// if the context was canceled (as opposed to timed out), return the Canceled error
+			if err == context.Canceled {
+				errs <- err
+				// we can cancel a netConn by setting the deadline to the current time
+				_ = cn.netConn.SetDeadline(time.Now())
+			}
+		case <-stop:
+		}
+	}()
+
+	go func() {
+		errs <- fn()
+	}()
+
+	return <-errs
 }
 
 func (cn *Conn) deadline(ctx context.Context, timeout time.Duration) time.Time {


### PR DESCRIPTION
Hi. These changes add support for context cancellation and should fix #1196 .

Cancellation of an underlying network connection is implemented by calling `SetDeadline` with `time.Now`.