### PR TITLE
Make universal options functions public

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -49,6 +49,7 @@ type UniversalOptions struct {
 	MasterName string
 }
 
+// Cluster returns cluster options created from the universal options.
 func (o *UniversalOptions) Cluster() *ClusterOptions {
 	if len(o.Addrs) == 0 {
 		o.Addrs = []string{"127.0.0.1:6379"}
@@ -84,6 +85,7 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 	}
 }
 
+// Failover returns failover options created from the universal options.
 func (o *UniversalOptions) Failover() *FailoverOptions {
 	if len(o.Addrs) == 0 {
 		o.Addrs = []string{"127.0.0.1:26379"}
@@ -118,6 +120,7 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 	}
 }
 
+// Simple returns basic options created from the universal options.
 func (o *UniversalOptions) Simple() *Options {
 	addr := "127.0.0.1:6379"
 	if len(o.Addrs) > 0 {

--- a/universal.go
+++ b/universal.go
@@ -49,7 +49,7 @@ type UniversalOptions struct {
 	MasterName string
 }
 
-func (o *UniversalOptions) cluster() *ClusterOptions {
+func (o *UniversalOptions) Cluster() *ClusterOptions {
 	if len(o.Addrs) == 0 {
 		o.Addrs = []string{"127.0.0.1:6379"}
 	}
@@ -84,7 +84,7 @@ func (o *UniversalOptions) cluster() *ClusterOptions {
 	}
 }
 
-func (o *UniversalOptions) failover() *FailoverOptions {
+func (o *UniversalOptions) Failover() *FailoverOptions {
 	if len(o.Addrs) == 0 {
 		o.Addrs = []string{"127.0.0.1:26379"}
 	}
@@ -118,7 +118,7 @@ func (o *UniversalOptions) failover() *FailoverOptions {
 	}
 }
 
-func (o *UniversalOptions) simple() *Options {
+func (o *UniversalOptions) Simple() *Options {
 	addr := "127.0.0.1:6379"
 	if len(o.Addrs) > 0 {
 		addr = o.Addrs[0]
@@ -183,9 +183,9 @@ var _ UniversalClient = (*Ring)(nil)
 // 3. otherwise, a single-node redis Client will be returned.
 func NewUniversalClient(opts *UniversalOptions) UniversalClient {
 	if opts.MasterName != "" {
-		return NewFailoverClient(opts.failover())
+		return NewFailoverClient(opts.Failover())
 	} else if len(opts.Addrs) > 1 {
-		return NewClusterClient(opts.cluster())
+		return NewClusterClient(opts.Cluster())
 	}
-	return NewClient(opts.simple())
+	return NewClient(opts.Simple())
 }


### PR DESCRIPTION
**Why is it necessary?**

The built-in `NewUniversalClient` function logic is not compatible with our logic. Therefore, we wanted to implement our logic. The following is our code snippet:

```
if opts.MasterName != "" {
	client = redis.NewFailoverClient(opts.failover())
} else if cfg.EnableCluster {
	client = redis.NewClusterClient(opts.cluster())
} else {
	client = redis.NewClient(opts.simple())
}
```

To handle it, I copied private `failover`, `cluster` and `simple` functions to my repo redundantly. If they were public, it would be very useful. See: https://github.com/TykTechnologies/tyk/blob/c7634e7703796ea64c1cc21d663e45de3b0970cf/storage/redis_cluster.go#L174-L275

If you are ok with this change, I can add comments to those functions with your guidance.