### PR TITLE
README Fix: Added client variable initialisation (redis.NewClient) in quickstartExampleClient()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ func ExampleClient() {
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	})
-
 	err := client.Set("key", "value", 0).Err()
 	if err != nil {
 		panic(err)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ func ExampleNewClient() {
 }
 
 func ExampleClient() {
+	client := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
 	err := client.Set("key", "value", 0).Err()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I was going through the quickstart and got tripped up by the `client` variable being used in the `ExampleClient()` function without initialization. I assumed that it's implied that you have to initialize it first when actually running it but I thought this would make it more explicit and clear.