### PR TITLE
Rename HMSet to HSet and restore old HMSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2
+
+- Existing `HMSet` is renamed to `HSet` and old deprecated `HMSet` is restored for Redis 3 users.
+
 ## v7
 
 - *Important*. Tx.Pipeline now returns a non-transactional pipeline. Use Tx.TxPipeline for a transactional pipeline.
@@ -11,6 +15,7 @@
 - Add PubSub.ChannelWithSubscriptions that sends `*Subscription` in addition to `*Message` to allow detecting reconnections.
 - `time.Time` is now marshalled in RFC3339 format. `rdb.Get("foo").Time()` helper is added to parse the time.
 - `SetLimiter` is removed and added `Options.Limiter` instead.
+- `HMSet` is deprecated as of Redis v4.
 
 ## v6.15
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -1325,7 +1325,7 @@ var _ = Describe("Commands", func() {
 		It("should HIncrByFloat", func() {
 			hSet := client.HSet("hash", "field", "10.50")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(true))
+			Expect(hSet.Val()).To(Equal(int64(1)))
 
 			hIncrByFloat := client.HIncrByFloat("hash", "field", 0.1)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1333,7 +1333,7 @@ var _ = Describe("Commands", func() {
 
 			hSet = client.HSet("hash", "field", "5.0e3")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(false))
+			Expect(hSet.Val()).To(Equal(int64(0)))
 
 			hIncrByFloat = client.HIncrByFloat("hash", "field", 2.0e2)
 			Expect(hIncrByFloat.Err()).NotTo(HaveOccurred())
@@ -1367,7 +1367,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HMGet", func() {
-			err := client.HMSet("hash", "key1", "hello1", "key2", "hello2").Err()
+			err := client.HSet("hash", "key1", "hello1", "key2", "hello2").Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			vals, err := client.HMGet("hash", "key1", "key2", "_").Result()
@@ -1375,8 +1375,8 @@ var _ = Describe("Commands", func() {
 			Expect(vals).To(Equal([]interface{}{"hello1", "hello2", nil}))
 		})
 
-		It("should HMSet", func() {
-			ok, err := client.HMSet("hash", map[string]interface{}{
+		It("should HSet", func() {
+			ok, err := client.HSet("hash", map[string]interface{}{
 				"key1": "hello1",
 				"key2": "hello2",
 			}).Result()
@@ -1399,7 +1399,7 @@ var _ = Describe("Commands", func() {
 		It("should HSet", func() {
 			hSet := client.HSet("hash", "key", "hello")
 			Expect(hSet.Err()).NotTo(HaveOccurred())
-			Expect(hSet.Val()).To(Equal(true))
+			Expect(hSet.Val()).To(Equal(int64(1)))
 
 			hGet := client.HGet("hash", "key")
 			Expect(hGet.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/1262
Closes https://github.com/go-redis/redis/pull/1246
Closes https://github.com/go-redis/redis/pull/1245