### PR TITLE
Store time in RFC3339Nano to keep nanoseconds

### DIFF
--- a/command.go
+++ b/command.go
@@ -671,7 +671,7 @@ func (cmd *StringCmd) Time() (time.Time, error) {
 	if cmd.err != nil {
 		return time.Time{}, cmd.err
 	}
-	return time.Parse(time.RFC3339, cmd.Val())
+	return time.Parse(time.RFC3339Nano, cmd.Val())
 }
 
 func (cmd *StringCmd) Scan(val interface{}) error {

--- a/command_test.go
+++ b/command_test.go
@@ -72,14 +72,14 @@ var _ = Describe("Cmd", func() {
 	})
 
 	It("supports time.Time", func() {
-		tm := time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC)
+		tm := time.Date(2019, 01, 01, 9, 45, 10, 222125, time.UTC)
 
 		err := client.Set("time_key", tm, 0).Err()
 		Expect(err).NotTo(HaveOccurred())
 
 		s, err := client.Get("time_key").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(s).To(Equal("2019-01-01T00:00:00Z"))
+		Expect(s).To(Equal("2019-01-01T09:45:10.000222125Z"))
 
 		tm2, err := client.Get("time_key").Time()
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/proto/write_buffer_test.go
+++ b/internal/proto/write_buffer_test.go
@@ -55,13 +55,14 @@ var _ = Describe("WriteBuffer", func() {
 	})
 
 	It("should append time", func() {
-		err := wr.WriteArgs([]interface{}{time.Unix(1414141414, 0).UTC()})
+		tm := time.Date(2019, 01, 01, 9, 45, 10, 222125, time.UTC)
+		err := wr.WriteArgs([]interface{}{tm})
 		Expect(err).NotTo(HaveOccurred())
 
 		err = wr.Flush()
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(buf.Len()).To(Equal(31))
+		Expect(buf.Len()).To(Equal(41))
 	})
 
 	It("should append marshalable args", func() {

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -93,7 +93,7 @@ func (w *Writer) writeArg(v interface{}) error {
 		}
 		return w.int(0)
 	case time.Time:
-		return w.string(v.Format(time.RFC3339))
+		return w.string(v.Format(time.RFC3339Nano))
 	case encoding.BinaryMarshaler:
 		b, err := v.MarshalBinary()
 		if err != nil {


### PR DESCRIPTION
Hi,

Time package has nanosecond precision.
Actually go-redis removes this precision when time is stored or fetched with RFC3339.

```
t := time.Now() // time with nanoseconds precision
_ := redisClient.Set("my-time", t, 0).Err()

ft, _ := redisClient.Get("my-time").Time() 

// ft != t
```

To deal with these nanoseconds, I suggest RFC3339Nano.