### PR TITLE
Add client instantiation callback to allow more flexible configuration

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -68,8 +68,8 @@ type RingOptions struct {
 
 	OnConnect func(*Conn) error
 
-	DB       int
-	Password string
+	DB        int
+	Password  string
 	TLSConfig *tls.Config
 
 	MaxRetries      int
@@ -115,8 +115,8 @@ func (opt *RingOptions) clientOptions(shard string) *Options {
 	return &Options{
 		OnConnect: opt.OnConnect,
 
-		DB:       opt.DB,
-		Password: opt.getPassword(shard),
+		DB:        opt.DB,
+		Password:  opt.getPassword(shard),
 		TLSConfig: opt.getTLSConfig(shard),
 
 		DialTimeout:  opt.DialTimeout,

--- a/ring.go
+++ b/ring.go
@@ -140,7 +140,7 @@ func (opt *RingOptions) getPassword(shard string) string {
 }
 
 func (opt *RingOptions) getTLSConfig(shard string) *tls.Config {
-	if opt.TLSConfig != nil {
+	if opt.TLSConfig == nil {
 		return opt.TLSConfigs[shard]
 	}
 	return opt.TLSConfig

--- a/ring_test.go
+++ b/ring_test.go
@@ -3,7 +3,6 @@ package redis_test
 import (
 	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
@@ -197,26 +196,17 @@ var _ = Describe("Redis Ring", func() {
 		})
 	})
 
-	Describe("shard tls configuration", func() {
-		It("can be initialized with a single tls configuration, used for all shards", func() {
+	Describe("new client callback", func() {
+		It("can be initialized with a new client callback", func() {
 			opts := redisRingOptions()
-			opts.TLSConfig = &tls.Config{}
-			ring = redis.NewRing(opts)
-
-			err := ring.Ping().Err()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("can be initialized with a passwords map, one for each shard", func() {
-			opts := redisRingOptions()
-			opts.TLSConfigs = map[string]*tls.Config{
-				"ringShardOne": &tls.Config{},
-				"ringShardTwo": &tls.Config{},
+			opts.NewClient = func(name string, opt *redis.Options) *redis.Client {
+				opt.Password = "password1"
+				return redis.NewClient(opt)
 			}
 			ring = redis.NewRing(opts)
 
 			err := ring.Ping().Err()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("ERR Client sent AUTH, but no password is set"))
 		})
 	})
 

--- a/ring_test.go
+++ b/ring_test.go
@@ -3,6 +3,7 @@ package redis_test
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
@@ -193,6 +194,29 @@ var _ = Describe("Redis Ring", func() {
 
 			err := ring.Ping().Err()
 			Expect(err).To(MatchError("ERR Client sent AUTH, but no password is set"))
+		})
+	})
+
+	Describe("shard tls configuration", func() {
+		It("can be initialized with a single tls configuration, used for all shards", func() {
+			opts := redisRingOptions()
+			opts.TLSConfig = &tls.Config{}
+			ring = redis.NewRing(opts)
+
+			err := ring.Ping().Err()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can be initialized with a passwords map, one for each shard", func() {
+			opts := redisRingOptions()
+			opts.TLSConfigs = map[string]*tls.Config{
+				"ringShardOne": &tls.Config{},
+				"ringShardTwo": &tls.Config{},
+			}
+			ring = redis.NewRing(opts)
+
+			err := ring.Ping().Err()
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
There's currently no way to specify a TLS configuration for a Redis Ring setup. This adds configuration for this so it can be set up in a similar way as the password, with either a single one for all shards or a
configuration per shard.