### PR TITLE
implement randezvous-hashing as an option for ring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/go-redis/redis/v7
 
 require (
+	github.com/cespare/xxhash v1.1.0
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/onsi/ginkgo v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -16,6 +19,7 @@ github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/consistenthash/consistenthash.go
+++ b/internal/consistenthash/consistenthash.go
@@ -21,18 +21,19 @@ import (
 	"hash/crc32"
 	"sort"
 	"strconv"
+
+	"github.com/go-redis/redis/v7/internal"
 )
 
-type Hash func(data []byte) uint32
 
 type Map struct {
-	hash     Hash
+	hash     internal.Hash
 	replicas int
 	keys     []int // Sorted
 	hashMap  map[int]string
 }
 
-func New(replicas int, fn Hash) *Map {
+func New(replicas int, fn internal.Hash) *Map {
 	m := &Map{
 		replicas: replicas,
 		hash:     fn,

--- a/internal/hash.go
+++ b/internal/hash.go
@@ -1,0 +1,3 @@
+package internal
+
+type Hash func(data []byte) uint32

--- a/internal/hash.go
+++ b/internal/hash.go
@@ -1,3 +1,3 @@
 package internal
 
-type Hash func(data []byte) uint32
+type Hash func(data []byte) uint64

--- a/internal/rendezvoushash/rendezvoushash.go
+++ b/internal/rendezvoushash/rendezvoushash.go
@@ -1,0 +1,58 @@
+package rendezvoushash
+
+import (
+	"crypto/sha1"
+	"hash/crc32"
+
+	"github.com/go-redis/redis/v7/internal"
+)
+
+type Map struct {
+	hash     internal.Hash
+	sites    []string
+}
+
+func New(fn internal.Hash) *Map {
+	m := &Map{
+		hash:     fn,
+	}
+	if m.hash == nil {
+		m.hash = crc32.ChecksumIEEE
+	}
+	return m
+}
+
+// Returns true if there are no items available.
+func (m *Map) IsEmpty() bool {
+	return len(m.sites) == 0
+}
+
+// Adds some keys to the hash.
+func (m *Map) Add(sites ...string) {
+	for _, site := range sites {
+		m.sites = append(m.sites, site)
+	}
+}
+
+// Gets the closest item in the hash to the provided key.
+func (m *Map) Get(key string) string {
+	if m.IsEmpty() {
+		return ""
+	}
+
+	// find the site that, when hashed with the key, yields the largest weight
+	maxWeight := uint32(0)
+	targetSite := ""
+	for _, site := range m.sites {
+		hasher := sha1.New()
+		hasher.Write([]byte(site + key))
+		siteWeight := m.hash(hasher.Sum(nil))
+
+		if siteWeight > maxWeight {
+			maxWeight = siteWeight
+			targetSite = site
+		}
+	}
+
+	return targetSite
+}

--- a/internal/rendezvoushash/rendezvoushash.go
+++ b/internal/rendezvoushash/rendezvoushash.go
@@ -27,9 +27,7 @@ func (m *Map) IsEmpty() bool {
 
 // Adds some keys to the hash.
 func (m *Map) Add(sites ...string) {
-	for _, site := range sites {
-		m.sites = append(m.sites, site)
-	}
+	m.sites = append(m.sites, sites...)
 }
 
 // Gets the closest item in the hash to the provided key.
@@ -40,10 +38,11 @@ func (m *Map) Get(key string) string {
 
 	// find the site that, when hashed with the key, yields the largest weight
 	var targetSite string
-
 	var maxWeight uint64
-	buf := make([]byte, len(key), 2*len(key))
+
+	buf := make([]byte, len(key))
 	copy(buf, key)
+
 	for _, site := range m.sites {
 		buf = buf[:len(key)]
 		buf = append(buf, site...)

--- a/internal/rendezvoushash/rendezvoushash_test.go
+++ b/internal/rendezvoushash/rendezvoushash_test.go
@@ -1,0 +1,86 @@
+package rendezvoushash
+
+import (
+	"fmt"
+	"hash/crc32"
+	"testing"
+)
+
+func TestHashing(t *testing.T) {
+	hash := New(crc32.ChecksumIEEE)
+	hash.Add("site1", "site2", "site3")
+
+	verifyFn := func(cases map[string]string) {
+		for k, v := range cases {
+			site := hash.Get(k)
+			if site != v {
+				t.Errorf("Asking for %s, should have return site %s, returned site %s", k, v, site)
+			}
+		}
+	}
+
+	testCases := map[string]string{
+		"key1": "site2",
+		"key2": "site1",
+		"key3": "site2",
+		"key4": "site1",
+		"key5": "site2",
+		"key6": "site3",
+		"key7": "site1",
+		"key8": "site1",
+		"key9": "site3",
+		"key10": "site2",
+		"key11": "site3",
+		"key12": "site1",
+		"key13": "site2",
+		"key14": "site2",
+		"key15": "site3",
+		"key16": "site2",
+	}
+
+	verifyFn(testCases)
+
+	hash.Add("site4")
+
+	// remaps existing keys to all sites
+	testCases["key1"] = "site4"
+	testCases["key2"] = "site4"
+	testCases["key9"] = "site4"
+	testCases["key10"] = "site4"
+	testCases["key11"] = "site4"
+	testCases["key12"] = "site4"
+	testCases["key15"] = "site4"
+
+	// add new keys
+	testCases["key17"] = "site1"
+	testCases["key18"] = "site2"
+	testCases["key19"] = "site4"
+	testCases["key20"] = "site4"
+	testCases["key21"] = "site1"
+	testCases["key22"] = "site2"
+
+	verifyFn(testCases)
+}
+
+func BenchmarkGet8(b *testing.B)   { benchmarkGet(b, 8) }
+func BenchmarkGet32(b *testing.B)  { benchmarkGet(b, 32) }
+func BenchmarkGet128(b *testing.B) { benchmarkGet(b, 128) }
+func BenchmarkGet512(b *testing.B) { benchmarkGet(b, 512) }
+
+func benchmarkGet(b *testing.B, shards int) {
+
+	hash := New(nil)
+
+	var buckets []string
+	for i := 0; i < shards; i++ {
+		buckets = append(buckets, fmt.Sprintf("shard-%d", i))
+	}
+
+	hash.Add(buckets...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hash.Get(buckets[i&(shards-1)])
+	}
+}

--- a/internal/rendezvoushash/rendezvoushash_test.go
+++ b/internal/rendezvoushash/rendezvoushash_test.go
@@ -2,12 +2,12 @@ package rendezvoushash
 
 import (
 	"fmt"
-	"hash/crc32"
+	"strconv"
 	"testing"
 )
 
 func TestHashing(t *testing.T) {
-	hash := New(crc32.ChecksumIEEE)
+	hash := New(nil)
 	hash.Add("site1", "site2", "site3")
 
 	verifyFn := func(cases map[string]string) {
@@ -20,15 +20,15 @@ func TestHashing(t *testing.T) {
 	}
 
 	testCases := map[string]string{
-		"key1": "site2",
-		"key2": "site1",
-		"key3": "site2",
-		"key4": "site1",
-		"key5": "site2",
-		"key6": "site3",
-		"key7": "site1",
-		"key8": "site1",
-		"key9": "site3",
+		"key1":  "site2",
+		"key2":  "site1",
+		"key3":  "site2",
+		"key4":  "site1",
+		"key5":  "site2",
+		"key6":  "site3",
+		"key7":  "site1",
+		"key8":  "site1",
+		"key9":  "site3",
 		"key10": "site2",
 		"key11": "site3",
 		"key12": "site1",
@@ -83,4 +83,24 @@ func benchmarkGet(b *testing.B, shards int) {
 	for i := 0; i < b.N; i++ {
 		hash.Get(buckets[i&(shards-1)])
 	}
+}
+
+func TestDistribution(t *testing.T) {
+	hash := New(nil)
+	hash.Add("1", "2", "3", "4", "5", "6")
+
+	results := make(map[string]int, 10)
+
+	for i := 0; i < 1000000; i++ {
+		key := strconv.Itoa(i)
+
+		site := hash.Get(key)
+		if val, ok := results[site]; ok {
+			results[site] = val + 1
+		} else {
+			results[site] = 1
+		}
+	}
+
+	fmt.Println(results)
 }

--- a/internal/rendezvoushash/rendezvoushash_test.go
+++ b/internal/rendezvoushash/rendezvoushash_test.go
@@ -21,20 +21,20 @@ func TestHashing(t *testing.T) {
 
 	testCases := map[string]string{
 		"key1":  "site2",
-		"key2":  "site1",
-		"key3":  "site2",
-		"key4":  "site1",
-		"key5":  "site2",
-		"key6":  "site3",
+		"key2":  "site2",
+		"key3":  "site3",
+		"key4":  "site2",
+		"key5":  "site3",
+		"key6":  "site2",
 		"key7":  "site1",
 		"key8":  "site1",
 		"key9":  "site3",
 		"key10": "site2",
-		"key11": "site3",
-		"key12": "site1",
-		"key13": "site2",
-		"key14": "site2",
-		"key15": "site3",
+		"key11": "site2",
+		"key12": "site2",
+		"key13": "site3",
+		"key14": "site1",
+		"key15": "site2",
 		"key16": "site2",
 	}
 
@@ -43,20 +43,20 @@ func TestHashing(t *testing.T) {
 	hash.Add("site4")
 
 	// remaps existing keys to all sites
-	testCases["key1"] = "site4"
-	testCases["key2"] = "site4"
-	testCases["key9"] = "site4"
+	testCases["key1"] = "site2"
+	testCases["key2"] = "site2"
+	testCases["key3"] = "site4"
+	testCases["key4"] = "site4"
+	testCases["key6"] = "site4"
+	testCases["key8"] = "site4"
 	testCases["key10"] = "site4"
-	testCases["key11"] = "site4"
-	testCases["key12"] = "site4"
-	testCases["key15"] = "site4"
 
 	// add new keys
-	testCases["key17"] = "site1"
+	testCases["key17"] = "site2"
 	testCases["key18"] = "site2"
-	testCases["key19"] = "site4"
-	testCases["key20"] = "site4"
-	testCases["key21"] = "site1"
+	testCases["key19"] = "site1"
+	testCases["key20"] = "site1"
+	testCases["key21"] = "site2"
 	testCases["key22"] = "site2"
 
 	verifyFn(testCases)

--- a/ring_test.go
+++ b/ring_test.go
@@ -54,8 +54,8 @@ var _ = Describe("Redis Ring", func() {
 		setRingKeys()
 
 		// Both shards should have some keys now.
-		Expect(ringShard1.Info("keyspace").Val()).To(ContainSubstring("keys=57"))
-		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=43"))
+		Expect(ringShard1.Info("keyspace").Val()).To(ContainSubstring("keys=47"))
+		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=53"))
 	})
 
 	It("distributes keys when using EVAL", func() {
@@ -71,8 +71,8 @@ var _ = Describe("Redis Ring", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		Expect(ringShard1.Info("keyspace").Val()).To(ContainSubstring("keys=57"))
-		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=43"))
+		Expect(ringShard1.Info("keyspace").Val()).To(ContainSubstring("keys=47"))
+		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=53"))
 	})
 
 	It("uses single shard when one of the shards is down", func() {
@@ -100,7 +100,7 @@ var _ = Describe("Redis Ring", func() {
 		setRingKeys()
 
 		// RingShard2 should have its keys.
-		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=43"))
+		Expect(ringShard2.Info("keyspace").Val()).To(ContainSubstring("keys=53"))
 	})
 
 	It("supports hash tags", func() {
@@ -131,8 +131,8 @@ var _ = Describe("Redis Ring", func() {
 			}
 
 			// Both shards should have some keys now.
-			Expect(ringShard1.Info().Val()).To(ContainSubstring("keys=57"))
-			Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=43"))
+			Expect(ringShard1.Info().Val()).To(ContainSubstring("keys=47"))
+			Expect(ringShard2.Info().Val()).To(ContainSubstring("keys=53"))
 		})
 
 		It("is consistent with ring", func() {


### PR DESCRIPTION
Hello and thanks for the awesome project 😄 

My team uses this lib in some very high-load services, specially the ring client. We've used rings sized as small as a couple nodes and as big as a couple of dozens of nodes, depending on traffic.

We've experienced some great variations in distributions of keys through the nodes. We've tweaked and tested changing the `replicas` param, tryng values such as 10, 100, 500, 1000, 2000 and others, but in the best scenario the node with most keys would still have around 20% more keys than the one with less keys (up to 40% in the worst scenarios).

We've decided to try the [randezvous hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing) algorithm instead of the consistent hashing. Using this algorithm, the difference between the nodes with the least and the most keys dropped to around 2%.

To get a sense of the distribution, you could run this test (not included in the PR):

```go
func TestDistribution(t *testing.T) {
	hash := New(nil)
	hash.Add("1", "2", "3", "4", "5", "6")

	results := make(map[string]int, 10)

	for i := 0; i < 1000000; i++ {
		key := strconv.Itoa(i)

		site := hash.Get(key)
		if val, ok := results[site]; ok {
			results[site] = val + 1
		} else {
			results[site] = 1
		}
	}

	fmt.Println(results)
}
```

This yields the distribution (across 6 nodes) `map[1:167014 2:166473 3:165828 4:166104 5:167113 6:167468]`, which is very well balanced (less than 1% of difference between nodes)

This doesn't come for free, as the node resolution algorithm has complexity O(n), where n is the number of nodes. The benchmarks, though, showed that even with 512 nodes, **we are still talking about microseconds or even nanoseconds** in the difference. In a scenario like ours (couple of dozens of nodes), that difference is absolutly negligible (nanoseconds).

The usage of the randezvous-hashing as proposed in this PR is optional, the default continues to be the consistent hashing. The changes in the existing code are minimal to support both.

The only point I'm not totally satisfied with the implementation is:

```go
hasher := sha1.New()
hasher.Write([]byte(site + key))
siteWeight := m.hash(hasher.Sum(nil))
```

In my tests, that was to only way I could get a good distribution. I think that using a `sha1` there wouldn't be necessary, but I couldn't get good results without it. I've tried all the functions in the `hash` package (FNV, CRC etc), but no cigar. Actually, that was a point of confusion, the `m.hash` seems to me to be a checksum, not a hash (I'm no crypto expert). Maybe the bad distribution without the `sha1` hash has something to do with the nature of the keys I was using in the tests (sequential numbers converted to string, with or without a 0's padding).

Anyway, I would gladly improve that part if you have any suggestion.
