### PR TITLE
allow cluster client to use limiter

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -76,6 +76,7 @@ type ClusterOptions struct {
 	IdleCheckFrequency time.Duration
 
 	TLSConfig *tls.Config
+	Limiter   Limiter
 }
 
 func (opt *ClusterOptions) init() {
@@ -145,6 +146,7 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		IdleCheckFrequency: disableIdleCheck,
 
 		TLSConfig: opt.TLSConfig,
+		Limiter:   opt.Limiter,
 	}
 }
 


### PR DESCRIPTION
code users can pass a limiter struct into cluster client then allow each node client in the cluster to use that limiter 