### PR TITLE
cmdsInfo to actually use and return the first error

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -508,7 +508,7 @@ func (c *Ring) ForEachShard(
 
 func (c *Ring) cmdsInfo() (map[string]*CommandInfo, error) {
 	shards := c.shards.List()
-	firstErr := errRingShardsDown
+	var firstErr error
 	for _, shard := range shards {
 		cmdsInfo, err := shard.Client.Command(context.TODO()).Result()
 		if err == nil {
@@ -517,6 +517,9 @@ func (c *Ring) cmdsInfo() (map[string]*CommandInfo, error) {
 		if firstErr == nil {
 			firstErr = err
 		}
+	}
+	if firstErr == nil {
+		return nil, errRingShardsDown
 	}
 	return nil, firstErr
 }


### PR DESCRIPTION
`cmdsInfo` at the moment sets the `firstErr` to the fallback option, which means line 518 would never execute, and the actual error would be masked.

(For example, I just had to track this down because I was trying to use Redis 6, and it isn't compatible)