### PR TITLE
Prevent panic during nil to string type assertion

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -309,9 +309,10 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 	case []interface{}:
 		switch kind := reply[0].(string); kind {
 		case "subscribe", "unsubscribe", "psubscribe", "punsubscribe":
+			channel, _ := reply[1].(string)
 			return &Subscription{
 				Kind:    kind,
-				Channel: reply[1].(string),
+				Channel: channel,
 				Count:   int(reply[2].(int64)),
 			}, nil
 		case "message":


### PR DESCRIPTION
This change causes func `newMessage` to assert `reply[1].(string)` safely and prevents the function from panicking. This one closes #1319.
