### PR TITLE
Add redis.Error interface and export ErrClosed

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,8 +6,23 @@ import (
 	"net"
 	"strings"
 
+	"github.com/go-redis/redis/v7/internal/pool"
 	"github.com/go-redis/redis/v7/internal/proto"
 )
+
+var ErrClosed = pool.ErrClosed
+
+type Error interface {
+	error
+
+	// RedisError is a no-op function but
+	// serves to distinguish types that are Redis
+	// errors from ordinary errors: a type is a
+	// Redis error if it has a RedisError method.
+	RedisError()
+}
+
+var _ Error = proto.RedisError("")
 
 func isRetryableError(err error, retryTimeout bool) bool {
 	switch err {

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -24,6 +24,8 @@ type RedisError string
 
 func (e RedisError) Error() string { return string(e) }
 
+func (RedisError) RedisError() {}
+
 //------------------------------------------------------------------------------
 
 type MultiBulkParse func(*Reader, int64) (interface{}, error)


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/1295
Closes https://github.com/go-redis/redis/pull/1296