### PR TITLE
Add required context parameter in example client

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ import "github.com/go-redis/redis/v8"
 ## Quickstart
 
 ```go
-func ExampleNewClient() {
+func ExampleNewClient(ctx context.Context) {
 	client := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
 		Password: "", // no password set
 		DB:       0,  // use default DB
 	})
 
-	pong, err := client.Ping().Result()
+	pong, err := client.Ping(ctx).Result()
 	fmt.Println(pong, err)
 	// Output: PONG <nil>
 }


### PR DESCRIPTION
Client.Ping() requires a context, so the example as shown does not work.