### PR TITLE
Fix performance degradation due to non-caching of command info in Redis 6 Cluster 

### DIFF
--- a/command.go
+++ b/command.go
@@ -2072,8 +2072,8 @@ func (cmd *CommandsInfoCmd) readReply(rd *proto.Reader) error {
 }
 
 func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
-	if n != 7 {
-		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 7", n)
+	if n != 6 && n != 7 {
+		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 6 or 7(Redis 6 or later)", n)
 	}
 
 	var cmd CommandInfo
@@ -2126,22 +2126,24 @@ func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
 	}
 	cmd.StepCount = int8(stepCount)
 
-	_, err = rd.ReadReply(func(rd *proto.Reader, n int64) (interface{}, error) {
-		cmd.ACLFlags = make([]string, n)
-		for i := 0; i < len(cmd.ACLFlags); i++ {
-			switch s, err := rd.ReadString(); {
-			case err == Nil:
-				cmd.ACLFlags[i] = ""
-			case err != nil:
-				return nil, err
-			default:
-				cmd.ACLFlags[i] = s
+	if n == 7 {
+		_, err = rd.ReadReply(func(rd *proto.Reader, n int64) (interface{}, error) {
+			cmd.ACLFlags = make([]string, n)
+			for i := 0; i < len(cmd.ACLFlags); i++ {
+				switch s, err := rd.ReadString(); {
+				case err == Nil:
+					cmd.ACLFlags[i] = ""
+				case err != nil:
+					return nil, err
+				default:
+					cmd.ACLFlags[i] = s
+				}
 			}
+			return nil, nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return nil, nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	for _, flag := range cmd.Flags {

--- a/command.go
+++ b/command.go
@@ -2019,6 +2019,7 @@ type CommandInfo struct {
 	Name        string
 	Arity       int8
 	Flags       []string
+	ACLFlags    []string
 	FirstKeyPos int8
 	LastKeyPos  int8
 	StepCount   int8
@@ -2071,8 +2072,8 @@ func (cmd *CommandsInfoCmd) readReply(rd *proto.Reader) error {
 }
 
 func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
-	if n != 6 {
-		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 6", n)
+	if n != 7 {
+		return nil, fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 7", n)
 	}
 
 	var cmd CommandInfo
@@ -2124,6 +2125,24 @@ func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
 		return nil, err
 	}
 	cmd.StepCount = int8(stepCount)
+
+	_, err = rd.ReadReply(func(rd *proto.Reader, n int64) (interface{}, error) {
+		cmd.ACLFlags = make([]string, n)
+		for i := 0; i < len(cmd.ACLFlags); i++ {
+			switch s, err := rd.ReadString(); {
+			case err == Nil:
+				cmd.ACLFlags[i] = ""
+			case err != nil:
+				return nil, err
+			default:
+				cmd.ACLFlags[i] = s
+			}
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	for _, flag := range cmd.Flags {
 		if flag == "readonly" {


### PR DESCRIPTION
## What is the problem?

I observed performance degradation when using redis.ClusterClient in Redis 6.
pprof reported the following bottleneck caused by mutex lock (https://github.com/go-redis/redis/blob/a999d1ecd81303df8128547746c62358f78048f5/command.go#L2153-L2154).

<img width="238" alt="ScreenShot 2020-06-04 at 9 01 38 PM" src="https://user-images.githubusercontent.com/473708/83835729-8b8e9b80-a72c-11ea-9bf0-68e9e19d2699.png">

This mutex lock is for the client to cache COMMAND reply just once (https://github.com/go-redis/redis/blob/a999d1ecd81303df8128547746c62358f78048f5/cluster.go#L688). 
However, I noticed that during the debugging of this performance degradation problem, for some reason the client executed COMMAND command every time.

## What caused the problem?

I got the following error that has already reported in https://github.com/go-redis/redis/issues/1329 in Redis 6. 

> redis: got 7 elements in COMMAND reply, wanted 6

This error prevented the internal.once from setting the done flag
(https://github.com/go-redis/redis/blob/a999d1ecd81303df8128547746c62358f78048f5/internal/once.go#L54-L57). As a result, the client did not cache COMMAND reply.

This error is caused by [the change of additional command categories](https://github.com/antirez/redis/commit/c5e717c637cbb1c80e1259560ebf995fb7920628) in Redis 6. 
I show the example of the output of COMMAND and COMMAND INFO reply. 

- Redis 5.0.8 (6 elements)

```
127.0.0.1:6379> COMMAND INFO xadd
1) 1) "xadd"
   2) (integer) -5
   3) 1) write
      2) denyoom
      3) random
      4) fast
   4) (integer) 1
   5) (integer) 1
   6) (integer) 1
```

- Redis 6.0.1 (7 elements)

```
127.0.0.1:6379> COMMAND INFO xadd
1) 1) "xadd"
   2) (integer) -5
   3) 1) write
      2) denyoom
      3) random
      4) fast
   4) (integer) 1
   5) (integer) 1
   6) (integer) 1
   7) 1) @write
      2) @stream
      3) @fast
```

Thus, I have fixed go-redis to handle this 7th elements for additional ACL categories. Finally, I solved my problem of performance degradation.
