### PR TITLE
Re-added password support for AUTH purposes

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -121,6 +121,7 @@ func (opt *RingOptions) clientOptions() *Options {
 		OnConnect: opt.OnConnect,
 
 		DB: opt.DB,
+		Password: opt.Password,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,


### PR DESCRIPTION
As of v8-beta1, Ring can no longer executes 'AUTH password' now. This is meant to fix that. See issue https://github.com/go-redis/redis/issues/1370 for rationale.