### PR TITLE
Make cluster client get updated nodes' addrs

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1013,6 +1013,16 @@ func (c *ClusterClient) loadState(ctx context.Context) (*clusterState, error) {
 		return newClusterState(c.nodes, slots, node.Client.opt.Addr)
 	}
 
+	/*
+	 * No node is connectable. It's possible that all nodes' IP has changed.
+	 * Clear clusterAddrs to let client be able to re-connect using the initial
+	 * setting of the addresses (e.g. [redsi-cluster-0:6379, redis-cluster-1:6379]),
+	 * which might have chance to resolve domain name and get updated IP address.
+	 */
+	c.nodes.mu.Lock()
+	c.nodes.clusterAddrs = nil
+	c.nodes.mu.Unlock()
+
 	return nil, firstErr
 }
 


### PR DESCRIPTION
During loading state, if all the nodes can't be connected, it's
possible that all the nodes' IP addresses have changed at the same
time. Clear the clusterAddrs so that the cluster client has chance
to get updated nodes' IP addresses by using the initial setting of
cluster addresses.