### PR TITLE
Add support for slices in XAddArgs.Values

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -3413,18 +3413,20 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("1-0"))
 
+			// Values supports []interface{}.
 			id, err = client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "2-0",
-				Values: map[string]interface{}{"dos": "deux"},
+				Values: []interface{}{"dos", "deux"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("2-0"))
 
+			// Value supports []string.
 			id, err = client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "3-0",
-				Values: map[string]interface{}{"tres": "troix"},
+				Values: []string{"tres", "troix"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("3-0"))


### PR DESCRIPTION
This PR solves the problem described in https://github.com/go-redis/redis/issues/1388.

Previously, `XAddArgs.Values` was of type `map[string]interface{}`. Now, it is `interface{}`. This change is backward compatible.

This change uses `appendArgs` utility function in `XAdd`. It was extended to support `[]interface{}` for the first item in the `src` slice. This might be a bit controversial as `appendArgs` is not used directly like that anywhere else. If so, I will rewrite this fragment not to use `appendArgs`.