### PR TITLE
Allow setting the maximum number of connections per client

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -69,7 +69,9 @@ type ClusterOptions struct {
 	WriteTimeout time.Duration
 
 	// PoolSize applies per cluster node and not for the whole cluster.
-	PoolSize           int
+	PoolSize int
+	// MaxConns applies per cluster node and not for the whole cluster.
+	MaxConns           int
 	MinIdleConns       int
 	MaxConnAge         time.Duration
 	PoolTimeout        time.Duration

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -119,7 +119,7 @@ func (p *ConnPool) checkMinIdleConns() {
 	if p.opt.MinIdleConns == 0 {
 		return
 	}
-	for p.poolSize < p.opt.PoolSize && p.idleConnsLen < p.opt.MinIdleConns {
+	for p.poolSize < p.opt.PoolSize && p.idleConnsLen < p.opt.MinIdleConns && p.connsCount < p.opt.MaxConns {
 		p.poolSize++
 		p.idleConnsLen++
 		go func() {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -382,21 +382,19 @@ var _ = Describe("max connections", func() {
 	BeforeEach(func() {
 		connPool = pool.NewConnPool(&pool.Options{
 			Dialer:       dummyDialer,
-			PoolSize:     10,
-			MaxConns:     10,
-			MinIdleConns: 5,
+			PoolSize:     2,
+			MaxConns:     2,
+			MinIdleConns: 1,
 			PoolTimeout:  time.Second,
 		})
 
-		conns = make([]*pool.Conn, 10)
+		conns = make([]*pool.Conn, 2)
 
-		for i := 0; i < 5; i++ {
-			var err error
-			conns[2*i], err = connPool.Get(c)
-			Expect(err).NotTo(HaveOccurred())
-			conns[2*i+1], err = connPool.NewConn(c)
-			Expect(err).NotTo(HaveOccurred())
-		}
+		var err error
+		conns[0], err = connPool.NewConn(c)
+		Expect(err).NotTo(HaveOccurred())
+		conns[1], err = connPool.Get(c)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -388,6 +388,8 @@ var _ = Describe("max connections", func() {
 			PoolTimeout:  time.Second,
 		})
 
+		conns = make([]*pool.Conn, 10)
+
 		for i := 0; i < 5; i++ {
 			var err error
 			conns[2*i], err = connPool.Get(c)

--- a/options.go
+++ b/options.go
@@ -76,9 +76,12 @@ type Options struct {
 	// Default is ReadTimeout.
 	WriteTimeout time.Duration
 
-	// Maximum number of socket connections.
+	// Maximum number of pooled socket connections.
 	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
 	PoolSize int
+	// Maximum number of socket connections allowed at any point in time.
+	// Default is unlimited.
+	MaxConns int
 	// Minimum number of idle connections which is useful when establishing
 	// new connection is slow.
 	MinIdleConns int
@@ -249,6 +252,7 @@ func newConnPool(opt *Options) *pool.ConnPool {
 			return conn, err
 		},
 		PoolSize:           opt.PoolSize,
+		MaxConns:           opt.MaxConns,
 		MinIdleConns:       opt.MinIdleConns,
 		MaxConnAge:         opt.MaxConnAge,
 		PoolTimeout:        opt.PoolTimeout,


### PR DESCRIPTION
I have noticed while using go-redis that sometimes the application will have a surge of requests to redis. In response, we encounter many dial timeouts, saturate our pool, and start spinning through a massive number of one use connections. Instead of allowing these requests to go through, we would like to be able to restrict the number of active connections per client. This PR aims to implement that.