### PR TITLE
Add connection pool metrics via OpenTelemetry

### DIFF
--- a/example/otel/example-client.go
+++ b/example/otel/example-client.go
@@ -70,6 +70,18 @@ func main() {
 	}
 	group.Wait()
 
+	for i := 0; i < 20; i++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			val := rdb.Get(ctx, "Second value").Val()
+			if val != "value_2" {
+				log.Fatalf("val was not set. expected: %s but got: %s", "value_2", val)
+			}
+		}()
+	}
+	group.Wait()
+
 	rdb.Del(ctx, "First value")
 	rdb.Del(ctx, "Second value")
 

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -28,9 +28,6 @@ var (
 
 	// ConnectionsReusedCounter counts the number of times connections have been reused
 	ConnectionsReusedCounter metric.Int64Counter
-
-	// ConnectionUsedTimeRecorder records the duration in milliseconds that connections are being used
-	ConnectionUsedTimeRecorder metric.Int64ValueRecorder
 )
 
 func init() {

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -29,7 +29,6 @@ var (
 	// ConnectionsReusedCounter counts the number of times connections have been reused
 	ConnectionsReusedCounter metric.Int64Counter
 
-	// TODO impl
 	// ConnectionUsedTimeRecorder records the duration in milliseconds that connections are being used
 	ConnectionUsedTimeRecorder metric.Int64ValueRecorder
 )

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -66,8 +66,4 @@ func init() {
 	ConnectionsClosedCounter = meter.NewInt64Counter("redis.connections_closed",
 		metric.WithDescription("the number of connections closed"),
 	)
-
-	ConnectionUsedTimeRecorder = meter.NewInt64ValueRecorder("redis.connection_used_time",
-		metric.WithDescription("the number of milliseconds for which a connection is used"),
-	)
 }

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -11,8 +11,8 @@ var (
 	// WritesCounter counts the number of write commands performed.
 	WritesCounter metric.Int64Counter
 
-	// NewConnectionsCounter counts the number of new connections.
-	NewConnectionsCounter metric.Int64Counter
+	// ConnectionsNewCounter counts the number of new connections.
+	ConnectionsNewCounter metric.Int64Counter
 
 	// DialErrorCounter counts the number of dial errors that have come up
 	DialErrorCounter metric.Int64Counter
@@ -47,7 +47,7 @@ func init() {
 		metric.WithDescription("the number of errors encountered after dialling"),
 	)
 
-	NewConnectionsCounter = meter.NewInt64Counter("redis.connections.new",
+	ConnectionsNewCounter = meter.NewInt64Counter("redis.connections.new",
 		metric.WithDescription("the number of connections created"),
 	)
 

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -8,10 +8,30 @@ import (
 )
 
 var (
-	// WritesCounter is a count of write commands performed.
+	// WritesCounter counts the number of write commands performed.
 	WritesCounter metric.Int64Counter
-	// NewConnectionsCounter is a count of new connections.
+
+	// NewConnectionsCounter counts the number of new connections.
 	NewConnectionsCounter metric.Int64Counter
+
+	// DialErrorCounter counts the number of errors that have come up
+	DialErrorCounter metric.Int64Counter
+
+	// ConnectionsTakenCounter counts the number of times connections were taken
+	ConnectionsTakenCounter metric.Int64Counter
+
+	// ConnectionsClosedCounter counts the number of closed connections
+	ConnectionsClosedCounter metric.Int64Counter
+
+	// ConnectionsReturnedCounter counts the number of connections returned to the pool
+	ConnectionsReturnedCounter metric.Int64Counter
+
+	// ConnectionsReusedCounter counts the number of times connections have been reused
+	ConnectionsReusedCounter metric.Int64Counter
+
+	// TODO impl
+	// ConnectionUsedTimeRecorder records the duration in milliseconds that connections are used
+	ConnectionUsedTimeRecorder metric.Int64ValueRecorder
 )
 
 func init() {
@@ -27,7 +47,31 @@ func init() {
 		metric.WithDescription("the number of writes initiated"),
 	)
 
+	DialErrorCounter = meter.NewInt64Counter("redis.dial_errors",
+		metric.WithDescription("the number of errors encountered after dialling"),
+	)
+
 	NewConnectionsCounter = meter.NewInt64Counter("redis.new_connections",
 		metric.WithDescription("the number of connections created"),
+	)
+
+	ConnectionsTakenCounter = meter.NewInt64Counter("redis.connections_taken",
+		metric.WithDescription("the number of connections taken"),
+	)
+
+	ConnectionsReturnedCounter = meter.NewInt64Counter("redis.connections_returned",
+		metric.WithDescription("the number of connections returned to the connection pool"),
+	)
+
+	ConnectionsReusedCounter = meter.NewInt64Counter("redis.connections_reused",
+		metric.WithDescription("the number of connections that have been reused"),
+	)
+
+	ConnectionsClosedCounter = meter.NewInt64Counter("redis.connections_closed",
+		metric.WithDescription("the number of connections closed"),
+	)
+
+	ConnectionUsedTimeRecorder = meter.NewInt64ValueRecorder("redis.connection_used_time",
+		metric.WithDescription("the number of milliseconds for which a connection is used"),
 	)
 }

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -47,23 +47,23 @@ func init() {
 		metric.WithDescription("the number of errors encountered after dialling"),
 	)
 
-	NewConnectionsCounter = meter.NewInt64Counter("redis.new_connections",
+	NewConnectionsCounter = meter.NewInt64Counter("redis.connections.new",
 		metric.WithDescription("the number of connections created"),
 	)
 
-	ConnectionsTakenCounter = meter.NewInt64Counter("redis.connections_taken",
+	ConnectionsTakenCounter = meter.NewInt64Counter("redis.connections.taken",
 		metric.WithDescription("the number of connections taken"),
 	)
 
-	ConnectionsReturnedCounter = meter.NewInt64Counter("redis.connections_returned",
+	ConnectionsReturnedCounter = meter.NewInt64Counter("redis.connections.returned",
 		metric.WithDescription("the number of connections returned to the connection pool"),
 	)
 
-	ConnectionsReusedCounter = meter.NewInt64Counter("redis.connections_reused",
+	ConnectionsReusedCounter = meter.NewInt64Counter("redis.connections.reused",
 		metric.WithDescription("the number of connections that have been reused"),
 	)
 
-	ConnectionsClosedCounter = meter.NewInt64Counter("redis.connections_closed",
+	ConnectionsClosedCounter = meter.NewInt64Counter("redis.connections.closed",
 		metric.WithDescription("the number of connections closed"),
 	)
 }

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -14,23 +14,23 @@ var (
 	// NewConnectionsCounter counts the number of new connections.
 	NewConnectionsCounter metric.Int64Counter
 
-	// DialErrorCounter counts the number of errors that have come up
+	// DialErrorCounter counts the number of dial errors that have come up
 	DialErrorCounter metric.Int64Counter
 
 	// ConnectionsTakenCounter counts the number of times connections were taken
 	ConnectionsTakenCounter metric.Int64Counter
 
-	// ConnectionsClosedCounter counts the number of closed connections
+	// ConnectionsClosedCounter counts the number of connections closed
 	ConnectionsClosedCounter metric.Int64Counter
 
-	// ConnectionsReturnedCounter counts the number of connections returned to the pool
+	// ConnectionsReturnedCounter counts the number of times connections have been returned to the pool
 	ConnectionsReturnedCounter metric.Int64Counter
 
 	// ConnectionsReusedCounter counts the number of times connections have been reused
 	ConnectionsReusedCounter metric.Int64Counter
 
 	// TODO impl
-	// ConnectionUsedTimeRecorder records the duration in milliseconds that connections are used
+	// ConnectionUsedTimeRecorder records the duration in milliseconds that connections are being used
 	ConnectionUsedTimeRecorder metric.Int64ValueRecorder
 )
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -185,7 +185,7 @@ func (p *ConnPool) dialConn(ctx context.Context, pooled bool) (*Conn, error) {
 		return nil, err
 	}
 
-	internal.NewConnectionsCounter.Add(ctx, 1)
+	internal.ConnectionsNewCounter.Add(ctx, 1)
 	cn := NewConn(netConn)
 	cn.pooled = pooled
 	return cn, nil

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -197,15 +197,15 @@ func (p *ConnPool) tryDial() {
 			return
 		}
 
-		conn, err := p.opt.Dialer(context.Background())
+		ctx := context.Background()
+
+		conn, err := p.opt.Dialer(ctx)
 		if err != nil {
-			internal.DialErrorCounter.Add(context.TODO(), 1)
+			internal.DialErrorCounter.Add(ctx, 1)
 			p.setLastDialError(err)
 			time.Sleep(time.Second)
 			continue
 		}
-
-		// TODO QUESTION: Should we record this in the metrics as a connection opened + closed?
 
 		atomic.StoreUint32(&p.dialErrorsNum, 0)
 		_ = conn.Close()


### PR DESCRIPTION
### Description
Adding metrics support for connection pool data via OpenTelemetry (https://github.com/open-telemetry/opentelemetry-go)

Addresses: https://github.com/go-redis/redis/issues/1392

**Metrics added include:**
- The number of dial errors that have come up
- The number of times connections were taken
- The number of connections closed
- The number of times connections have been returned to the pool
- The number of times connections have been reused
- The durations that connections are being used

**Tested manually with the example client**