### PR TITLE
Prevent index out ouf bunds error

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -44,9 +44,10 @@ func (it *ScanIterator) Next(ctx context.Context) bool {
 		}
 
 		// Fetch next page.
-		if it.cmd.args[0] == "scan" {
+		switch it.cmd.args[0] {
+		case "scan", "qscan":
 			it.cmd.args[1] = it.cmd.cursor
-		} else {
+		default:
 			it.cmd.args[2] = it.cmd.cursor
 		}
 


### PR DESCRIPTION
I'm reusing this for disque client... and get index out of bounds error because there really are just 2 items in array not 3.

BTW.. is it possible to merge this down to 6.x series as we really don't want to do an upgrade