### PR TITLE
fix nil node dereference when use RouteByLatency in cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -564,7 +564,11 @@ func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
 			node = n
 		}
 	}
-	return node, nil
+	if node != nil {
+		return node, nil
+	}
+	// If all nodes are failing - return random node
+	return c.nodes.Random()
 }
 
 func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {


### PR DESCRIPTION
There is was a nil pointer dereference when all nodes are failing, It was described early in this issues #1416 and #1401 