### PR TITLE
Support string array in pubsub message payload

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -284,9 +284,10 @@ func (m *Subscription) String() string {
 
 // Message received as result of a PUBLISH command issued by another client.
 type Message struct {
-	Channel string
-	Pattern string
-	Payload string
+	Channel      string
+	Pattern      string
+	Payload      string
+	PayloadSlice []string
 }
 
 func (m *Message) String() string {
@@ -322,10 +323,24 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 				Count:   int(reply[2].(int64)),
 			}, nil
 		case "message":
-			return &Message{
-				Channel: reply[1].(string),
-				Payload: reply[2].(string),
-			}, nil
+			switch payload := reply[2].(type) {
+			case string:
+				return &Message{
+					Channel: reply[1].(string),
+					Payload: payload,
+				}, nil
+			case []interface{}:
+				ss := make([]string, len(payload))
+				for i, s := range payload {
+					ss[i] = s.(string)
+				}
+				return &Message{
+					Channel:      reply[1].(string),
+					PayloadSlice: ss,
+				}, nil
+			default:
+				return nil, fmt.Errorf("redis: unsupported pubsub message payload: %T", payload)
+			}
 		case "pmessage":
 			return &Message{
 				Pattern: reply[1].(string),

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"context"
 	"io"
 	"net"
 	"sync"
@@ -14,11 +15,16 @@ import (
 
 var _ = Describe("PubSub", func() {
 	var client *redis.Client
+	var clientID int64
 
 	BeforeEach(func() {
 		opt := redisOptions()
 		opt.MinIdleConns = 0
 		opt.MaxConnAge = 0
+		opt.OnConnect = func(ctx context.Context, cn *redis.Conn) (err error) {
+			clientID, err = cn.ClientID(ctx).Result()
+			return err
+		}
 		client = redis.NewClient(opt)
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
@@ -413,6 +419,30 @@ var _ = Describe("PubSub", func() {
 		Eventually(ch).Should(Receive(&msg))
 		Expect(msg.Channel).To(Equal("mychannel"))
 		Expect(msg.Payload).To(Equal(string(bigVal)))
+	})
+
+	It("handles message payload slice with server-assisted client-size caching", func() {
+		pubsub := client.Subscribe(ctx, "__redis__:invalidate")
+		defer pubsub.Close()
+
+		client2 := redis.NewClient(redisOptions())
+		defer client2.Close()
+
+		err := client2.Do(ctx, "CLIENT", "TRACKING", "on", "REDIRECT", clientID).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = client2.Do(ctx, "GET", "mykey").Err()
+		Expect(err).To(Equal(redis.Nil))
+
+		err = client2.Do(ctx, "SET", "mykey", "myvalue").Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		ch := pubsub.Channel()
+
+		var msg *redis.Message
+		Eventually(ch).Should(Receive(&msg))
+		Expect(msg.Channel).To(Equal("__redis__:invalidate"))
+		Expect(msg.PayloadSlice).To(Equal([]string{"mykey"}))
 	})
 
 	It("supports concurrent Ping and Receive", func() {


### PR DESCRIPTION
Hi, I'd like to add the support of string array in pubsub message payload.

Since when enabling the ["Redis server-assisted client side caching"](https://redis.io/topics/client-side-caching) feature with RESP2 and Redis 6, the redis-server could send string array payload which contains keys to invalid via the pub/sub message.

This PR stores the string array payload into a new field `PayloadSlice` of the pubsub`Message` struct for not breaking the  existing code that using the existing `Payload` field.

This PR is far from a complete client side caching solution, but at least this may let user be able to use this new redis feature with this library.