### PR TITLE
Fix not applying updated ClusterClient context after calling WithContext method

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -707,6 +707,7 @@ func (c *ClusterClient) WithContext(ctx context.Context) *ClusterClient {
 	clone.cmdable = clone.Process
 	clone.hooks.lock()
 	clone.ctx = ctx
+	clone.cmdsInfoCache = newCmdsInfoCache(clone.cmdsInfo)
 	return &clone
 }
 

--- a/command.go
+++ b/command.go
@@ -2135,21 +2135,21 @@ func commandInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
 //------------------------------------------------------------------------------
 
 type cmdsInfoCache struct {
-	fn func() (map[string]*CommandInfo, error)
+	fn func(ctx context.Context) (map[string]*CommandInfo, error)
 
 	once internal.Once
 	cmds map[string]*CommandInfo
 }
 
-func newCmdsInfoCache(fn func() (map[string]*CommandInfo, error)) *cmdsInfoCache {
+func newCmdsInfoCache(fn func(ctx context.Context) (map[string]*CommandInfo, error)) *cmdsInfoCache {
 	return &cmdsInfoCache{
 		fn: fn,
 	}
 }
 
-func (c *cmdsInfoCache) Get() (map[string]*CommandInfo, error) {
+func (c *cmdsInfoCache) Get(ctx context.Context) (map[string]*CommandInfo, error) {
 	err := c.once.Do(func() error {
-		cmds, err := c.fn()
+		cmds, err := c.fn(ctx)
 		if err != nil {
 			return err
 		}

--- a/ring.go
+++ b/ring.go
@@ -533,11 +533,11 @@ func (c *Ring) ForEachShard(
 	}
 }
 
-func (c *Ring) cmdsInfo() (map[string]*CommandInfo, error) {
+func (c *Ring) cmdsInfo(ctx context.Context) (map[string]*CommandInfo, error) {
 	shards := c.shards.List()
 	var firstErr error
 	for _, shard := range shards {
-		cmdsInfo, err := shard.Client.Command(context.TODO()).Result()
+		cmdsInfo, err := shard.Client.Command(ctx).Result()
 		if err == nil {
 			return cmdsInfo, nil
 		}
@@ -552,7 +552,7 @@ func (c *Ring) cmdsInfo() (map[string]*CommandInfo, error) {
 }
 
 func (c *Ring) cmdInfo(name string) *CommandInfo {
-	cmdsInfo, err := c.cmdsInfoCache.Get()
+	cmdsInfo, err := c.cmdsInfoCache.Get(c.ctx)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
In this method, аfter cloning `ClusterClient` instance, `cmdsInfoCache` will still use context from the original. Small fix for this.