### PR TITLE
Use maxRedirects only for Redirect errors and maxRetries for network errors

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -31,7 +31,7 @@ type ClusterOptions struct {
 	NewClient func(opt *Options) *Client
 
 	// The maximum number of retries before giving up. Command is retried
-	// on network errors and MOVED/ASK redirects.
+	// on MOVED/ASK redirects.
 	// Default is 3 retries.
 	MaxRedirects int
 
@@ -60,6 +60,8 @@ type ClusterOptions struct {
 	Username string
 	Password string
 
+	// The maximum number of retries on network errors
+	// Default is 0.
 	MaxRetries      int
 	MinRetryBackoff time.Duration
 	MaxRetryBackoff time.Duration

--- a/cluster.go
+++ b/cluster.go
@@ -775,7 +775,7 @@ func (c *ClusterClient) _process(ctx context.Context, cmd Cmder) error {
 			if err := internal.Sleep(ctx, c.retryBackoff(failureAttempt)); err != nil {
 				return err
 			}
-		}else if redirectAttempt > 0 {
+		} else if redirectAttempt > 0 {
 			if err := internal.Sleep(ctx, c.retryBackoff(redirectAttempt)); err != nil {
 				return err
 			}
@@ -809,7 +809,7 @@ func (c *ClusterClient) _process(ctx context.Context, cmd Cmder) error {
 				c.state.LazyReload(ctx)
 			}
 			node = nil
-			redirectAttempt ++
+			redirectAttempt++
 			failureAttempt = 0
 			continue
 		}
@@ -818,7 +818,7 @@ func (c *ClusterClient) _process(ctx context.Context, cmd Cmder) error {
 		if c.opt.ReadOnly && isLoadingError(lastErr) {
 			node.MarkAsFailing()
 			node = nil
-			redirectAttempt ++
+			redirectAttempt++
 			failureAttempt = 0
 			continue
 		}
@@ -832,13 +832,13 @@ func (c *ClusterClient) _process(ctx context.Context, cmd Cmder) error {
 			if err != nil {
 				return err
 			}
-			redirectAttempt ++
+			redirectAttempt++
 			failureAttempt = 0
 			continue
 		}
 
 		if failureAttempt < c.opt.MaxRetries && shouldRetry(lastErr, cmd.readTimeout() == nil) {
-			failureAttempt ++
+			failureAttempt++
 			// First retry the same node.
 			if failureAttempt == 1 {
 				continue


### PR DESCRIPTION
Use maxRedirects only for Redirect errors(moved/ask/read only/loading...)
use maxRetries for network error retries.