### PR TITLE
Fixes #1386; pipeline.Exec() sometimes returns spurious `StatusCmd`

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,6 +1,8 @@
 package redis_test
 
 import (
+	"strconv"
+
 	"github.com/go-redis/redis/v8"
 
 	. "github.com/onsi/ginkgo"
@@ -66,6 +68,21 @@ var _ = Describe("pipelining", func() {
 			cmds, err := pipe.Exec(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cmds).To(HaveLen(1))
+		})
+
+		It("handles large pipelines", func() {
+			for callCount := 1; callCount < 16; callCount++ {
+				for i := 1; i <= callCount; i++ {
+					pipe.SetNX(ctx, strconv.Itoa(i)+"_key", strconv.Itoa(i)+"_value", 0)
+				}
+
+				cmds, err := pipe.Exec(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmds).To(HaveLen(callCount))
+				for _, cmd := range cmds {
+					Expect(cmd).To(BeAssignableToTypeOf(&redis.BoolCmd{}))
+				}
+			}
 		})
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -492,11 +492,11 @@ func wrapMultiExec(ctx context.Context, cmds []Cmder) []Cmder {
 	if len(cmds) == 0 {
 		panic("not reached")
 	}
-	cmds = append(cmds, make([]Cmder, 2)...)
-	copy(cmds[1:], cmds[:len(cmds)-2])
-	cmds[0] = NewStatusCmd(ctx, "multi")
-	cmds[len(cmds)-1] = NewSliceCmd(ctx, "exec")
-	return cmds
+	cmdCopy := make([]Cmder, len(cmds)+2)
+	cmdCopy[0] = NewStatusCmd(ctx, "multi")
+	copy(cmdCopy[1:], cmds)
+	cmdCopy[len(cmdCopy)-1] = NewSliceCmd(ctx, "exec")
+	return cmdCopy
 }
 
 func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) error {


### PR DESCRIPTION
This is caused by function `wrapMultiExec` sometimes clobbering the caller's
cmd slice, corrupting future requests.