### PR TITLE
remove ctx fields, as they serve no purpose anymore

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -208,36 +208,6 @@ func BenchmarkZAdd(b *testing.B) {
 	})
 }
 
-var clientSink *redis.Client
-
-func BenchmarkWithContext(b *testing.B) {
-	ctx := context.Background()
-	rdb := benchmarkRedisClient(ctx, 10)
-	defer rdb.Close()
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		clientSink = rdb.WithContext(ctx)
-	}
-}
-
-var ringSink *redis.Ring
-
-func BenchmarkRingWithContext(b *testing.B) {
-	ctx := context.Background()
-	rdb := redis.NewRing(&redis.RingOptions{})
-	defer rdb.Close()
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		ringSink = rdb.WithContext(ctx)
-	}
-}
-
 //------------------------------------------------------------------------------
 
 func newClusterScenario() *clusterScenario {

--- a/cluster.go
+++ b/cluster.go
@@ -1058,7 +1058,6 @@ func (c *ClusterClient) reaper(idleCheckFrequency time.Duration) {
 
 func (c *ClusterClient) Pipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processPipeline,
 	}
 	pipe.init()
@@ -1240,7 +1239,6 @@ func (c *ClusterClient) checkMovedErr(
 // TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
 func (c *ClusterClient) TxPipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processTxPipeline,
 	}
 	pipe.init()

--- a/pipeline.go
+++ b/pipeline.go
@@ -40,7 +40,6 @@ type Pipeline struct {
 	cmdable
 	statefulCmdable
 
-	ctx  context.Context
 	exec pipelineExecer
 
 	mu     sync.Mutex

--- a/race_test.go
+++ b/race_test.go
@@ -288,13 +288,6 @@ var _ = Describe("races", func() {
 		wg.Wait()
 		Expect(atomic.LoadUint32(&received)).To(Equal(uint32(C * N)))
 	})
-
-	It("should WithContext", func() {
-		perform(C, func(_ int) {
-			err := client.WithContext(ctx).Ping(ctx).Err()
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
 })
 
 var _ = Describe("cluster races", func() {

--- a/redis.go
+++ b/redis.go
@@ -542,7 +542,6 @@ type Client struct {
 	*baseClient
 	cmdable
 	hooks
-	ctx context.Context
 }
 
 // NewClient returns a client to the Redis Server specified by Options.
@@ -551,7 +550,6 @@ func NewClient(opt *Options) *Client {
 
 	c := Client{
 		baseClient: newBaseClient(opt, newConnPool(opt)),
-		ctx:        context.Background(),
 	}
 	c.cmdable = c.Process
 
@@ -568,19 +566,6 @@ func (c *Client) clone() *Client {
 func (c *Client) WithTimeout(timeout time.Duration) *Client {
 	clone := c.clone()
 	clone.baseClient = c.baseClient.withTimeout(timeout)
-	return clone
-}
-
-func (c *Client) Context() context.Context {
-	return c.ctx
-}
-
-func (c *Client) WithContext(ctx context.Context) *Client {
-	if ctx == nil {
-		panic("nil context")
-	}
-	clone := c.clone()
-	clone.ctx = ctx
 	return clone
 }
 
@@ -626,7 +611,6 @@ func (c *Client) Pipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmd
 
 func (c *Client) Pipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processPipeline,
 	}
 	pipe.init()
@@ -640,7 +624,6 @@ func (c *Client) TxPipelined(ctx context.Context, fn func(Pipeliner) error) ([]C
 // TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
 func (c *Client) TxPipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processTxPipeline,
 	}
 	pipe.init()
@@ -743,7 +726,6 @@ func (c *Conn) Pipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder
 
 func (c *Conn) Pipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processPipeline,
 	}
 	pipe.init()
@@ -757,7 +739,6 @@ func (c *Conn) TxPipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmd
 // TxPipeline acts like Pipeline, but wraps queued commands with MULTI/EXEC.
 func (c *Conn) TxPipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx:  c.ctx,
 		exec: c.processTxPipeline,
 	}
 	pipe.init()

--- a/sentinel.go
+++ b/sentinel.go
@@ -185,7 +185,6 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 
 	c := Client{
 		baseClient: newBaseClient(opt, connPool),
-		ctx:        context.Background(),
 	}
 	c.cmdable = c.Process
 	c.onClose = failover.Close

--- a/tx.go
+++ b/tx.go
@@ -111,7 +111,6 @@ func (c *Tx) Unwatch(ctx context.Context, keys ...string) *StatusCmd {
 // Pipeline creates a pipeline. Usually it is more convenient to use Pipelined.
 func (c *Tx) Pipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx: c.ctx,
 		exec: func(ctx context.Context, cmds []Cmder) error {
 			return c.hooks.processPipeline(ctx, cmds, c.baseClient.processPipeline)
 		},
@@ -141,7 +140,6 @@ func (c *Tx) TxPipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder
 // TxPipeline creates a pipeline. Usually it is more convenient to use TxPipelined.
 func (c *Tx) TxPipeline() Pipeliner {
 	pipe := Pipeline{
-		ctx: c.ctx,
 		exec: func(ctx context.Context, cmds []Cmder) error {
 			return c.hooks.processTxPipeline(ctx, cmds, c.baseClient.processTxPipeline)
 		},

--- a/universal.go
+++ b/universal.go
@@ -173,7 +173,6 @@ func (o *UniversalOptions) Simple() *Options {
 // cluster-specific applications locally.
 type UniversalClient interface {
 	Cmdable
-	Context() context.Context
 	AddHook(Hook)
 	Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error
 	Do(ctx context.Context, args ...interface{}) *Cmd


### PR DESCRIPTION
While migrating one of my projects to v8, I realized that there are still `context` fields left, which don't server any purpose anymore after https://github.com/go-redis/redis/pull/1493.

So I propose to remove them altogether.