### PR TITLE
Fixes bufio buffer full error when reading from an array larger than 4096 bytes

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -55,12 +55,9 @@ func (r *Reader) Reset(rd io.Reader) {
 }
 
 func (r *Reader) ReadLine() ([]byte, error) {
-	line, err := r.rd.ReadBytes('\n')
-	if err != nil && err != io.EOF {
+	line, err := r.readLine()
+	if err != nil {
 		return nil, err
-	}
-	if len(line) == 0 {
-		return nil, fmt.Errorf("redis: reply is empty")
 	}
 	if isNilReply(line) {
 		return nil, Nil
@@ -72,15 +69,29 @@ func (r *Reader) ReadLine() ([]byte, error) {
 //   - there is a pending read error;
 //   - or line does not end with \r\n.
 func (r *Reader) readLine() ([]byte, error) {
-	b, err := r.rd.ReadSlice('\n')
-	if err != nil {
-		return nil, err
+	var s []byte
+	multi := false
+	for {
+		b, err := r.rd.ReadSlice('\n')
+		if err != nil {
+			// in case the end of the buffer is not reached
+			if err == bufio.ErrBufferFull {
+				s = append(s, b...)
+				multi = true
+				continue
+			} else {
+				return nil, err
+			}
+		}
+		if len(b) <= 2 || b[len(b)-1] != '\n' || b[len(b)-2] != '\r' {
+			return nil, fmt.Errorf("redis: invalid reply: %q", b)
+		}
+		if multi {
+			b = append(s, b...)
+		}
+		b = b[:len(b)-2]
+		return b, nil
 	}
-	if len(b) <= 2 || b[len(b)-1] != '\n' || b[len(b)-2] != '\r' {
-		return nil, fmt.Errorf("redis: invalid reply: %q", b)
-	}
-	b = b[:len(b)-2]
-	return b, nil
 }
 
 func (r *Reader) ReadReply(m MultiBulkParse) (interface{}, error) {

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -55,9 +55,12 @@ func (r *Reader) Reset(rd io.Reader) {
 }
 
 func (r *Reader) ReadLine() ([]byte, error) {
-	line, err := r.readLine()
-	if err != nil {
+	line, err := r.rd.ReadBytes('\n')
+	if err != nil && err != io.EOF {
 		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, fmt.Errorf("redis: reply is empty")
 	}
 	if isNilReply(line) {
 		return nil, Nil

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -27,6 +27,19 @@ func BenchmarkReader_ParseReply_Slice(b *testing.B) {
 	benchmarkParseReply(b, "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", multiBulkParse, false)
 }
 
+func TestReader_ReadLine(t *testing.T) {
+	original := bytes.Repeat([]byte("a"), 8192)
+	r := proto.NewReader(bytes.NewReader(original))
+	read, err := r.ReadLine()
+	if err != nil {
+		t.Errorf("Should be able to read the full buffer: %v", err)
+	}
+
+	if bytes.Compare(read, original) != 0 {
+		t.Errorf("Values must be equal: %q", read)
+	}
+}
+
 func benchmarkParseReply(b *testing.B, reply string, m proto.MultiBulkParse, wanterr bool) {
 	buf := new(bytes.Buffer)
 	for i := 0; i < b.N; i++ {

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -2,6 +2,7 @@ package proto_test
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/go-redis/redis/v8/internal/proto"
@@ -29,14 +30,16 @@ func BenchmarkReader_ParseReply_Slice(b *testing.B) {
 
 func TestReader_ReadLine(t *testing.T) {
 	original := bytes.Repeat([]byte("a"), 8192)
+	original[len(original)-2] = '\r'
+	original[len(original)-1] = '\n'
 	r := proto.NewReader(bytes.NewReader(original))
 	read, err := r.ReadLine()
-	if err != nil {
+	if err != nil && err != io.EOF {
 		t.Errorf("Should be able to read the full buffer: %v", err)
 	}
 
-	if bytes.Compare(read, original) != 0 {
-		t.Errorf("Values must be equal: %q", read)
+	if bytes.Compare(read, original[:len(original)-2]) != 0 {
+		t.Errorf("Values must be equal: %d expected %d", len(read), len(original[:len(original)-2]))
 	}
 }
 


### PR DESCRIPTION
I get this issue when retrieving large blobs from [redix](https://github.com/alash3al/redix) which is API compliant with redis.

I created a test that reproduces that error. It happens when reading from a byte array which length is larger than 4096.

See also #641

## Expected Behavior

The blob should be read in full.

## Current Behavior

An error is returned.

## Possible Solution

See, patch in this PR.

## Steps to Reproduce

See the added test case in this PR which (when ran without the fix added) would result in the following:

```bash
❯ go test internal/proto/reader.go internal/proto/reader_test.go 
--- FAIL: TestReader_ReadLine (0.00s)
    reader_test.go:51: Should be able to read the full buffer: bufio: buffer full
    reader_test.go:55: Values must be equal: ""
FAIL
FAIL	command-line-arguments	0.272s
FAIL
```
