### PR TITLE
Fix/issue 1384

### DIFF
--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-redis/redis/v8/internal/util"
 )
 
-// Scan parses bytes `b` to 'v' with appropriate type.
+// Scan parses bytes `b` to `v` with appropriate type.
 func Scan(b []byte, v interface{}) error {
 	switch v := v.(type) {
 	case nil:

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -104,7 +104,7 @@ func Scan(b []byte, v interface{}) error {
 		return nil
 	case *time.Time:
 		var err error
-		*v, err = time.Parse(time.RFC3339, util.BytesToString(b))
+		*v, err = time.Parse(time.RFC3339Nano, util.BytesToString(b))
 		return err
 	case encoding.BinaryUnmarshaler:
 		return v.UnmarshalBinary(b)

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-redis/redis/v8/internal/util"
 )
 
+// Scan parses bytes `b` to `v` with appropriate type.
+// nolint: gocyclo
 func Scan(b []byte, v interface{}) error {
 	switch v := v.(type) {
 	case nil:

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -4,10 +4,12 @@ import (
 	"encoding"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-redis/redis/v8/internal/util"
 )
 
+// Scan parses bytes `b` to 'v' with appropriate type.
 func Scan(b []byte, v interface{}) error {
 	switch v := v.(type) {
 	case nil:
@@ -99,6 +101,10 @@ func Scan(b []byte, v interface{}) error {
 	case *bool:
 		*v = len(b) == 1 && b[0] == '1'
 		return nil
+	case *time.Time:
+		var err error
+		*v, err = time.Parse(time.RFC3339, util.BytesToString(b))
+		return err
 	case encoding.BinaryUnmarshaler:
 		return v.UnmarshalBinary(b)
 	default:

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-redis/redis/v8/internal/util"
 )
 
-// Scan parses bytes `b` to `v` with appropriate type.
 func Scan(b []byte, v interface{}) error {
 	switch v := v.(type) {
 	case nil:

--- a/internal/proto/scan_test.go
+++ b/internal/proto/scan_test.go
@@ -1,7 +1,10 @@
 package proto
 
 import (
+	"bytes"
 	"encoding/json"
+	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,3 +49,37 @@ var _ = Describe("ScanSlice", func() {
 		}))
 	})
 })
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+
+	t.Run("time", func(t *testing.T) {
+		t.Parallel()
+
+		toWrite := time.Now()
+		var toScan time.Time
+
+		buf := new(bytes.Buffer)
+		wr := NewWriter(buf)
+		err := wr.WriteArg(toWrite)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(buf)
+		b, err := r.readTmpBytesReply()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = Scan(b, &toScan)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !toWrite.Equal(toScan) {
+			t.Fatal(err)
+		}
+	})
+
+}

--- a/internal/proto/scan_test.go
+++ b/internal/proto/scan_test.go
@@ -3,6 +3,7 @@ package proto
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ func TestScan(t *testing.T) {
 		}
 
 		if !toWrite.Equal(toScan) {
-			t.Fatal(err)
+			t.Fatal(errors.New("toWrite and toScan is not equal"))
 		}
 	})
 


### PR DESCRIPTION
fix #1384 
Add time.Time type to Scan method.

PAY ATTENTION: there is a questionable part. I've added function level `nolint: gocyclo` cause with +1 branch limit is broken.
I can split the switch inside to 2 parts and move them to separate functions. And remove `nolint` of course. But IMHO the function will lose current readability.
WDYT? 