### PR TITLE
trace moved from otel/api/trace into otel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
-	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel v0.13.1-0.20201015173547-786a78ea3677
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-go.opentelemetry.io/otel v0.13.0 h1:2isEnyzjjJZq6r2EKMsFj4TxiQiexsM04AVhwbR/oBA=
-go.opentelemetry.io/otel v0.13.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
+go.opentelemetry.io/otel v0.13.1-0.20201015173547-786a78ea3677 h1:phC8wiGiRfl8YBJpzZphYRC6Ucx+LMuULZ5vCCI2E/Q=
+go.opentelemetry.io/otel v0.13.1-0.20201015173547-786a78ea3677/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-redis/redis/v8/internal"
 	"github.com/go-redis/redis/v8/internal/proto"
-	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel"
 )
 
 var noDeadline = time.Time{}
@@ -66,7 +66,7 @@ func (cn *Conn) RemoteAddr() net.Addr {
 }
 
 func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(rd *proto.Reader) error) error {
-	return internal.WithSpan(ctx, "with_reader", func(ctx context.Context, span trace.Span) error {
+	return internal.WithSpan(ctx, "with_reader", func(ctx context.Context, span otel.Span) error {
 		if err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout)); err != nil {
 			return internal.RecordError(ctx, err)
 		}
@@ -80,7 +80,7 @@ func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(r
 func (cn *Conn) WithWriter(
 	ctx context.Context, timeout time.Duration, fn func(wr *proto.Writer) error,
 ) error {
-	return internal.WithSpan(ctx, "with_writer", func(ctx context.Context, span trace.Span) error {
+	return internal.WithSpan(ctx, "with_writer", func(ctx context.Context, span otel.Span) error {
 		if err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout)); err != nil {
 			return internal.RecordError(ctx, err)
 		}

--- a/internal/util.go
+++ b/internal/util.go
@@ -7,11 +7,11 @@ import (
 	"github.com/go-redis/redis/v8/internal/proto"
 	"github.com/go-redis/redis/v8/internal/util"
 	"go.opentelemetry.io/otel/api/global"
-	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel"
 )
 
 func Sleep(ctx context.Context, dur time.Duration) error {
-	return WithSpan(ctx, "sleep", func(ctx context.Context, span trace.Span) error {
+	return WithSpan(ctx, "sleep", func(ctx context.Context, span otel.Span) error {
 		t := time.NewTimer(dur)
 		defer t.Stop()
 
@@ -62,8 +62,8 @@ func Unwrap(err error) error {
 
 //------------------------------------------------------------------------------
 
-func WithSpan(ctx context.Context, name string, fn func(context.Context, trace.Span) error) error {
-	if span := trace.SpanFromContext(ctx); !span.IsRecording() {
+func WithSpan(ctx context.Context, name string, fn func(context.Context, otel.Span) error) error {
+	if span := otel.SpanFromContext(ctx); !span.IsRecording() {
 		return fn(ctx, span)
 	}
 
@@ -75,7 +75,7 @@ func WithSpan(ctx context.Context, name string, fn func(context.Context, trace.S
 
 func RecordError(ctx context.Context, err error) error {
 	if err != proto.Nil {
-		trace.SpanFromContext(ctx).RecordError(ctx, err)
+		otel.SpanFromContext(ctx).RecordError(ctx, err)
 	}
 	return err
 }

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/go-redis/redis/v8/internal"
 	"github.com/go-redis/redis/v8/internal/pool"
-	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/label"
 )
 
@@ -293,7 +293,7 @@ func newConnPool(opt *Options) *pool.ConnPool {
 	return pool.NewConnPool(&pool.Options{
 		Dialer: func(ctx context.Context) (net.Conn, error) {
 			var conn net.Conn
-			err := internal.WithSpan(ctx, "dialer", func(ctx context.Context, span trace.Span) error {
+			err := internal.WithSpan(ctx, "dialer", func(ctx context.Context, span otel.Span) error {
 				var err error
 				span.SetAttributes(
 					label.String("redis.network", opt.Network),

--- a/redis.go
+++ b/redis.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-redis/redis/v8/internal"
 	"github.com/go-redis/redis/v8/internal/pool"
 	"github.com/go-redis/redis/v8/internal/proto"
-	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/label"
 )
 
@@ -225,7 +225,7 @@ func (c *baseClient) _getConn(ctx context.Context) (*pool.Conn, error) {
 		return cn, nil
 	}
 
-	err = internal.WithSpan(ctx, "init_conn", func(ctx context.Context, span trace.Span) error {
+	err = internal.WithSpan(ctx, "init_conn", func(ctx context.Context, span otel.Span) error {
 		return c.initConn(ctx, cn)
 	})
 	if err != nil {
@@ -299,7 +299,7 @@ func (c *baseClient) releaseConn(ctx context.Context, cn *pool.Conn, err error) 
 func (c *baseClient) withConn(
 	ctx context.Context, fn func(context.Context, *pool.Conn) error,
 ) error {
-	return internal.WithSpan(ctx, "with_conn", func(ctx context.Context, span trace.Span) error {
+	return internal.WithSpan(ctx, "with_conn", func(ctx context.Context, span otel.Span) error {
 		cn, err := c.getConn(ctx)
 		if err != nil {
 			return err
@@ -326,7 +326,7 @@ func (c *baseClient) process(ctx context.Context, cmd Cmder) error {
 		attempt := attempt
 
 		var retry bool
-		err := internal.WithSpan(ctx, "process", func(ctx context.Context, span trace.Span) error {
+		err := internal.WithSpan(ctx, "process", func(ctx context.Context, span otel.Span) error {
 			if attempt > 0 {
 				if err := internal.Sleep(ctx, c.retryBackoff(attempt)); err != nil {
 					return err


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go/commit/27c84d689d64167e8a1873311782750da6defa39#diff-14c2529eb4498c5d1ffd6915d05bf58a91bdda796af59f41d480d11c099d0479

Not this sure this workflow works at all.