### PR TITLE
Add SetEX command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -124,6 +124,7 @@ type Cmdable interface {
 	MSet(ctx context.Context, values ...interface{}) *StatusCmd
 	MSetNX(ctx context.Context, values ...interface{}) *BoolCmd
 	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd
+	SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd
 	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd
 	SetXX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd
 	SetRange(ctx context.Context, key string, offset int64, value string) *IntCmd
@@ -778,6 +779,19 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 	} else if expiration == KeepTTL {
 		args = append(args, "keepttl")
 	}
+
+	cmd := NewStatusCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// Redis `SETEX key expiration value` command.
+func (c cmdable) SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd {
+	args := make([]interface{}, 4)
+	args[0] = "setex"
+	args[1] = key
+	args[2] = formatSec(ctx, expiration)
+	args[3] = value
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)

--- a/commands.go
+++ b/commands.go
@@ -787,13 +787,7 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 
 // Redis `SETEX key expiration value` command.
 func (c cmdable) SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd {
-	args := make([]interface{}, 4)
-	args[0] = "setex"
-	args[1] = key
-	args[2] = formatSec(ctx, expiration)
-	args[3] = value
-
-	cmd := NewStatusCmd(ctx, args...)
+	cmd := NewStatusCmd(ctx, "setex", key, formatSec(ctx, expiration), value)
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1147,7 +1147,7 @@ var _ = Describe("Commands", func() {
 
 		It("should Set with keepttl", func() {
 			// set with ttl
-			set := client.Set(ctx, "key", "hello", 5 * time.Second)
+			set := client.Set(ctx, "key", "hello", 5*time.Second)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
 
@@ -1170,6 +1170,19 @@ var _ = Describe("Commands", func() {
 			get := client.Get(ctx, "key")
 			Expect(get.Err()).NotTo(HaveOccurred())
 			Expect(get.Val()).To(Equal("hello"))
+		})
+
+		It("should SetEX", func() {
+			err := client.SetEX(ctx, "key", "hello", 100*time.Millisecond).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			val, err := client.Get(ctx, "key").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("hello"))
+
+			Eventually(func() error {
+				return client.Get(ctx, "foo").Err()
+			}, "1s", "100ms").Should(Equal(redis.Nil))
 		})
 
 		It("should SetNX", func() {

--- a/example_test.go
+++ b/example_test.go
@@ -188,6 +188,13 @@ func ExampleClient_Set() {
 	}
 }
 
+func ExampleClient_SetEX() {
+	err := rdb.SetEX(ctx, "key", "value", time.Hour).Err()
+	if err != nil {
+		panic(err)
+	}
+}
+
 func ExampleClient_Incr() {
 	result, err := rdb.Incr(ctx, "counter").Result()
 	if err != nil {


### PR DESCRIPTION
I'm aware that, in essence, the `Set` function can do everything that `SetEX` function can do, however, I'm using this library to test a Redis-compatible server implementation, and due to the fact that there's no way to send the `SETEX` command using go-redis/redis, I'm unable to fully test the aforementioned Redis-compatible server.

Assuming this reasoning is fine with you, one of my concerns is that the order in which `SETEX` takes an argument is the following:
```
SETEX key seconds value
```

But in order to be consistent with other functions, I opted to use the following function signature:
```
SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration)
```
What do you think?