### PR TITLE
    FIX: data race warning in sentinel client since the newConnPool would spawn the new goroutine and use the onFailover at the same time.

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -177,11 +177,13 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 	opt.init()
 
 	connPool := newConnPool(opt)
+	failover.mu.Lock()
 	failover.onFailover = func(ctx context.Context, addr string) {
 		_ = connPool.Filter(func(cn *pool.Conn) bool {
 			return cn.RemoteAddr().String() != addr
 		})
 	}
+	failover.mu.Unlock()
 
 	c := Client{
 		baseClient: newBaseClient(opt, connPool),


### PR DESCRIPTION
we can reproduce it with the below piece of code:

```go
func TestFailoverClient(t *testing.T) {
	options := redis.FailoverOptions{
		SentinelAddrs: []string{"127.0.0.1:26379"},
		MasterName:    "mymaster",
	}
	client := redis.NewFailoverClient(&options)
	var waitGroup sync.WaitGroup
	for i := 0; i < 10; i++ {
		waitGroup.Add(1)
		go func() {
			defer waitGroup.Done()
			v, err := client.Get(context.TODO(), "no_exists_key").Result()
			assert.Empty(t, v)
			assert.Equal(t, err, redis.Nil)
		}()
	}
	waitGroup.Wait()

}
```

run it some times with -race flag enabled and would get the data race warning(It seems no harm even we don't fix it, but may annoy someone who uses the `FailoverClient` in the test case with the data race detect flag enabled.):

```
redis: 2020/11/19 20:09:09 sentinel.go:607: sentinel: new master="mymaster" addr="127.0.0.1:6379"
==================
WARNING: DATA RACE
Write at 0x00c00037d130 by goroutine 12:
  github.com/go-redis/redis/v8.NewFailoverClient()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/sentinel.go:180 +0x9c4
  command-line-arguments.NewFailoverClient()
      /Users/automizely/code/go/gopkg/redisx/sentinel.go:35 +0x7c
  command-line-arguments.TestNewFailoverClient()
      /Users/automizely/code/go/gopkg/redisx/sentinel_test.go:15 +0x23d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202

Previous read at 0x00c00037d130 by goroutine 14:
  github.com/go-redis/redis/v8.(*sentinelFailover).trySwitchMaster()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/sentinel.go:609 +0x338
  github.com/go-redis/redis/v8.masterSlaveDialer.func1()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/sentinel.go:208 +0x3f6
  github.com/go-redis/redis/v8.newConnPool.func1.1()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/options.go:302 +0x483
  github.com/go-redis/redis/v8/internal.WithSpan()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/util.go:67 +0x296
  github.com/go-redis/redis/v8.newConnPool.func1()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/options.go:296 +0xbb
  github.com/go-redis/redis/v8/internal/pool.(*ConnPool).dialConn()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/pool/pool.go:179 +0x1dd
  github.com/go-redis/redis/v8/internal/pool.(*ConnPool).addIdleConn()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/pool/pool.go:133 +0x84
  github.com/go-redis/redis/v8/internal/pool.(*ConnPool).checkMinIdleConns.func1()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/pool/pool.go:121 +0x3c

Goroutine 12 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1168 +0x5bb
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1439 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1437 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1345 +0x3b3
  main.main()
      _testmain.go:43 +0x236

Goroutine 14 (finished) created at:
  github.com/go-redis/redis/v8/internal/pool.(*ConnPool).checkMinIdleConns()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/pool/pool.go:120 +0x104
  github.com/go-redis/redis/v8/internal/pool.NewConnPool()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/internal/pool/pool.go:103 +0x317
  github.com/go-redis/redis/v8.newConnPool()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/options.go:293 +0x2c4
  github.com/go-redis/redis/v8.NewFailoverClient()
      /Users/automizely/go/pkg/mod/github.com/go-redis/redis/v8@v8.3.3/sentinel.go:179 +0x926
  command-line-arguments.NewFailoverClient()
      /Users/automizely/code/go/gopkg/redisx/sentinel.go:35 +0x7c
  command-line-arguments.TestNewFailoverClient()
      /Users/automizely/code/go/gopkg/redisx/sentinel_test.go:15 +0x23d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202
==================
    testing.go:1038: race detected during execution of test
```