### PR TITLE
change the serialization interface naming to avoid repeated calls with gob serialization into an endless loop

### DIFF
--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -1,7 +1,6 @@
 package proto
 
 import (
-	"encoding"
 	"fmt"
 	"reflect"
 	"time"
@@ -106,11 +105,11 @@ func Scan(b []byte, v interface{}) error {
 		var err error
 		*v, err = time.Parse(time.RFC3339Nano, util.BytesToString(b))
 		return err
-	case encoding.BinaryUnmarshaler:
+	case BinaryUnmarshaler:
 		return v.UnmarshalBinary(b)
 	default:
 		return fmt.Errorf(
-			"redis: can't unmarshal %T (consider implementing BinaryUnmarshaler)", v)
+			"redis: can't unmarshal %T (consider implementing proto.BinaryUnmarshaler)", v)
 	}
 }
 

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -105,11 +105,11 @@ func Scan(b []byte, v interface{}) error {
 		var err error
 		*v, err = time.Parse(time.RFC3339Nano, util.BytesToString(b))
 		return err
-	case BinaryUnmarshaler:
-		return v.UnmarshalBinary(b)
+	case RedisBinaryUnmarshaler:
+		return v.RedisUnmarshalBinary(b)
 	default:
 		return fmt.Errorf(
-			"redis: can't unmarshal %T (consider implementing proto.BinaryUnmarshaler)", v)
+			"redis: can't unmarshal %T (consider implementing proto.RedisBinaryUnmarshaler)", v)
 	}
 }
 

--- a/internal/proto/serialization.go
+++ b/internal/proto/serialization.go
@@ -4,15 +4,10 @@ package proto
 // Created: 2020/11/25
 // Describe: struct serialization
 
-type BinaryMarshaler interface {
-	MarshalBinary() (data []byte, err error)
+type RedisBinaryMarshaler interface {
+	RedisMarshalBinary() (data []byte, err error)
 }
 
-type BinaryUnmarshaler interface {
-	UnmarshalBinary(data []byte) error
-}
-
-type RedisSerialization interface {
-	BinaryMarshaler
-	BinaryUnmarshaler
+type RedisBinaryUnmarshaler interface {
+	RedisUnmarshalBinary(data []byte) error
 }

--- a/internal/proto/serialization.go
+++ b/internal/proto/serialization.go
@@ -1,0 +1,18 @@
+package proto
+
+// Author: Licoy
+// Created: 2020/11/25
+// Describe: struct serialization
+
+type BinaryMarshaler interface {
+	MarshalBinary() (data []byte, err error)
+}
+
+type BinaryUnmarshaler interface {
+	UnmarshalBinary(data []byte) error
+}
+
+type RedisSerialization interface {
+	BinaryMarshaler
+	BinaryUnmarshaler
+}

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -1,7 +1,6 @@
 package proto
 
 import (
-	"encoding"
 	"fmt"
 	"io"
 	"strconv"
@@ -98,7 +97,7 @@ func (w *Writer) WriteArg(v interface{}) error {
 	case time.Time:
 		w.numBuf = v.AppendFormat(w.numBuf[:0], time.RFC3339Nano)
 		return w.bytes(w.numBuf)
-	case encoding.BinaryMarshaler:
+	case BinaryMarshaler:
 		b, err := v.MarshalBinary()
 		if err != nil {
 			return err
@@ -106,7 +105,7 @@ func (w *Writer) WriteArg(v interface{}) error {
 		return w.bytes(b)
 	default:
 		return fmt.Errorf(
-			"redis: can't marshal %T (implement encoding.BinaryMarshaler)", v)
+			"redis: can't marshal %T (implement proto.BinaryMarshaler)", v)
 	}
 }
 

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -97,15 +97,15 @@ func (w *Writer) WriteArg(v interface{}) error {
 	case time.Time:
 		w.numBuf = v.AppendFormat(w.numBuf[:0], time.RFC3339Nano)
 		return w.bytes(w.numBuf)
-	case BinaryMarshaler:
-		b, err := v.MarshalBinary()
+	case RedisBinaryMarshaler:
+		b, err := v.RedisMarshalBinary()
 		if err != nil {
 			return err
 		}
 		return w.bytes(b)
 	default:
 		return fmt.Errorf(
-			"redis: can't marshal %T (implement proto.BinaryMarshaler)", v)
+			"redis: can't marshal %T (implement proto.RedisBinaryMarshaler)", v)
 	}
 }
 


### PR DESCRIPTION
Add a custom serialization interface to avoid conflicts with native gob serialization and cause repeated calls to gob, enter an endless loop, and eventually cause stack overflow.