### PR TITLE
Add fuzzer to integrate go-redis into OSS-fuzz

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,44 @@
+package redis
+
+import (
+	"context"
+	"time"
+)
+
+var (
+	ctx = context.Background()
+	rdb *Client
+)
+
+func init() {
+	rdb = NewClient(&Options{
+		Addr:         ":6379",
+		DialTimeout:  10 * time.Second,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		PoolSize:     10,
+		PoolTimeout:  10 * time.Second,
+	})
+}
+
+func Fuzz(data []byte) int {
+	array_len := len(data)
+	if array_len < 4 {
+		return -1
+	}
+	max_iter := int(uint(data[0]))
+	for i := 0; i < max_iter && i < array_len; i++ {
+		n := i % array_len
+		if n == 0 {
+			_ = rdb.Set(ctx, string(data[i:]), string(data[i:]), 0).Err()
+		} else if n == 1 {
+			_, _ = rdb.Get(ctx, string(data[i:])).Result()
+		} else if n == 2 {
+			_, _ = rdb.Incr(ctx, string(data[i:])).Result()
+		} else if n == 3 {
+			var cursor uint64
+			_, _, _ = rdb.Scan(ctx, cursor, string(data[i:]), 10).Result()
+		}
+	}
+	return 1
+}

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,5 @@
+// +build gofuzz
+
 package redis
 
 import (
@@ -22,13 +24,13 @@ func init() {
 }
 
 func Fuzz(data []byte) int {
-	array_len := len(data)
-	if array_len < 4 {
+	arrayLen := len(data)
+	if arrayLen < 4 {
 		return -1
 	}
-	max_iter := int(uint(data[0]))
-	for i := 0; i < max_iter && i < array_len; i++ {
-		n := i % array_len
+	maxIter := int(uint(data[0]))
+	for i := 0; i < maxIter && i < arrayLen; i++ {
+		n := i % arrayLen
 		if n == 0 {
 			_ = rdb.Set(ctx, string(data[i:]), string(data[i:]), 0).Err()
 		} else if n == 1 {


### PR DESCRIPTION
This PR adds a fuzzer.

Fuzzing is a way of testing programs whereby pseudo-random data is passed to a target function with the goal of finding bugs and vulnerabilities.

I have been working on running this fuzzer continuously on OSS-fuzz's platform, and I will be happy to integrate go-redis into the project so that this fuzzer can run continuously. OSS-fuzz is a free service for open source projects, and if bugs are found an email with a link to a detailed bug report is sent out to the maintainers on the mailing list. The mailing list is public and can be changed at any time, and there is a public disclosure policy of 90 days. 