### PR TITLE
Add wrapper for net.Conn to support Context cancellation properly

### DIFF
--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ func isBadConn(err error, allowTimeout bool) bool {
 	switch err {
 	case nil:
 		return false
-	case context.Canceled, context.DeadlineExceeded:
+	case context.Canceled:
 		return true
 	}
 

--- a/internal/pool/netconn.go
+++ b/internal/pool/netconn.go
@@ -1,0 +1,166 @@
+package pool
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+)
+
+type netConn struct {
+	c       net.Conn
+	updated chan struct{}
+	wg      sync.WaitGroup
+
+	mu           sync.RWMutex
+	readCtx      context.Context
+	readCtxVer   int64
+	lastReadErr  error
+	writeCtx     context.Context
+	writeCtxVer  int64
+	lastWriteErr error
+	closed       bool
+}
+
+func newNetConn(c net.Conn) *netConn {
+	var nc netConn
+	nc.c = c
+	nc.updated = make(chan struct{}, 1)
+	nc.wg.Add(1)
+	go func() {
+		nc.serveContexts()
+		nc.wg.Done()
+	}()
+	return &nc
+}
+
+func (nc *netConn) serveContexts() {
+	readCtx := context.Background()
+	readCtxVer := int64(0)
+	writeCtx := context.Background()
+	writeCtxVer := int64(0)
+	for {
+		select {
+		case <-nc.updated:
+			nc.mu.Lock()
+			if nc.closed {
+				nc.mu.Unlock()
+				return
+			}
+			newReadCtx := nc.readCtx
+			newReadCtxVer := nc.readCtxVer
+			newWriteCtx := nc.writeCtx
+			newWriteCtxVer := nc.writeCtxVer
+			nc.mu.Unlock()
+			if newReadCtxVer != readCtxVer {
+				readCtx = newReadCtx
+				readCtxVer = newReadCtxVer
+			}
+			if newWriteCtxVer != writeCtxVer {
+				writeCtx = newWriteCtx
+				writeCtxVer = newWriteCtxVer
+			}
+		case <-readCtx.Done():
+			nc.mu.Lock()
+			if nc.closed {
+				nc.mu.Unlock()
+				return
+			}
+			if nc.readCtxVer == readCtxVer {
+				nc.lastReadErr = readCtx.Err()
+				// Make Read() return immediately.
+				_ = nc.c.SetReadDeadline(time.Now())
+			}
+			nc.mu.Unlock()
+			readCtx = context.Background()
+			readCtxVer = 0
+		case <-writeCtx.Done():
+			nc.mu.Lock()
+			if nc.closed {
+				nc.mu.Unlock()
+				return
+			}
+			if nc.writeCtxVer == writeCtxVer {
+				nc.lastWriteErr = writeCtx.Err()
+				// Make Write() return immediately.
+				_ = nc.c.SetWriteDeadline(time.Now())
+			}
+			nc.mu.Unlock()
+			writeCtx = context.Background()
+			writeCtxVer = 0
+		}
+	}
+}
+
+func (nc *netConn) Read(b []byte) (int, error) {
+	n, err := nc.c.Read(b)
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		nc.mu.Lock()
+		lastReadErr := nc.lastReadErr
+		nc.mu.Unlock()
+		switch lastReadErr {
+		case nil, context.DeadlineExceeded:
+		default:
+			return n, lastReadErr
+		}
+	}
+	return n, err
+}
+
+func (nc *netConn) Write(b []byte) (int, error) {
+	n, err := nc.c.Write(b)
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		nc.mu.Lock()
+		lastWriteErr := nc.lastWriteErr
+		nc.mu.Unlock()
+		switch lastWriteErr {
+		case nil, context.DeadlineExceeded:
+		default:
+			return n, lastWriteErr
+		}
+	}
+	return n, err
+}
+
+func (nc *netConn) Close() error {
+	nc.mu.Lock()
+	nc.closed = true
+	nc.mu.Unlock()
+	nc.update()
+	nc.wg.Wait()
+	return nc.c.Close()
+}
+
+func (nc *netConn) LocalAddr() net.Addr  { return nc.c.LocalAddr() }
+func (nc *netConn) RemoteAddr() net.Addr { return nc.c.RemoteAddr() }
+
+func (nc *netConn) SetReadContext(ctx context.Context) {
+	nc.mu.Lock()
+	nc.readCtx = ctx
+	nc.readCtxVer++
+	if nc.lastReadErr != nil {
+		nc.lastReadErr = nil
+		_ = nc.c.SetReadDeadline(time.Time{})
+	}
+	nc.mu.Unlock()
+	nc.update()
+}
+
+func (nc *netConn) SetWriteContext(ctx context.Context) {
+	nc.mu.Lock()
+	nc.writeCtx = ctx
+	nc.writeCtxVer++
+	if nc.lastWriteErr != nil {
+		nc.lastWriteErr = nil
+		_ = nc.c.SetWriteDeadline(time.Time{})
+	}
+	nc.mu.Unlock()
+	nc.update()
+}
+
+func (nc *netConn) update() {
+	select {
+	case nc.updated <- struct{}{}:
+	default:
+	}
+}

--- a/internal/pool/netconn_test.go
+++ b/internal/pool/netconn_test.go
@@ -1,0 +1,144 @@
+package pool
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("netConn", func() {
+	var nc *netConn
+	var peer net.Conn
+
+	BeforeEach(func() {
+		c1, c2, err := testMakeSocketPair()
+		Expect(err).NotTo(HaveOccurred())
+		nc = newNetConn(c1)
+		peer = c2
+	})
+
+	It("respect read context set", func() {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			_ = cancel
+			nc.SetReadContext(ctx)
+		}()
+		_, err := nc.Read(make([]byte, 1024))
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+		_, err = nc.Read(make([]byte, 1024))
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+	})
+
+	It("respect write context set", func() {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			_ = cancel
+			nc.SetWriteContext(ctx)
+		}()
+		buf := make([]byte, 10*1024*1024)
+		n, err := nc.Write(buf)
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+		Expect(n).NotTo(Equal(0))
+		n, err = nc.Write(buf)
+		Expect(err.(net.Error).Timeout()).To(BeTrue())
+		Expect(n).To(Equal(0))
+	})
+
+	It("read context can be reset", func() {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			_ = cancel
+			nc.SetReadContext(ctx)
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel = context.WithCancel(context.Background())
+			cancel()
+			nc.SetReadContext(ctx)
+		}()
+		_, err := nc.Read(make([]byte, 1024))
+		Expect(err).To(Equal(context.Canceled))
+		_, err = nc.Read(make([]byte, 1024))
+		Expect(err).To(Equal(context.Canceled))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_ = cancel
+		nc.SetReadContext(ctx)
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			peer.Write([]byte("hello"))
+			peer.Close()
+		}()
+		b, err := ioutil.ReadAll(nc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b).To(Equal([]byte("hello")))
+	})
+
+	It("write context can be reset", func() {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			_ = cancel
+			nc.SetWriteContext(ctx)
+			time.Sleep(100 * time.Millisecond)
+			ctx, cancel = context.WithCancel(context.Background())
+			cancel()
+			nc.SetWriteContext(ctx)
+		}()
+		buf := make([]byte, 10*1024*1024)
+		n, err := nc.Write(buf)
+		Expect(err).To(Equal(context.Canceled))
+		Expect(n).NotTo(Equal(0))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_ = cancel
+		nc.SetWriteContext(ctx)
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			_, _ = io.Copy(ioutil.Discard, peer)
+		}()
+		n, err = nc.Write([]byte("hello"))
+		nc.Close()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).NotTo(Equal(0))
+	})
+
+	AfterEach(func() {
+		nc.Close()
+		peer.Close()
+	})
+})
+
+func testMakeSocketPair() (_ net.Conn, _ net.Conn, returnedErr error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer l.Close()
+	type AcceptResult struct {
+		C   net.Conn
+		Err error
+	}
+	ch := make(chan AcceptResult, 1)
+	go func() {
+		c, err := l.Accept()
+		ch <- AcceptResult{c, err}
+	}()
+	c1, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		return nil, nil, err
+	}
+	ar := <-ch
+	if ar.Err != nil {
+		c1.Close()
+		return nil, nil, err
+	}
+	c2 := ar.C
+	return c1, c2, nil
+}


### PR DESCRIPTION
Hi, I just encountered the same issue as #1568, and after the review, I don't think this issue is resolved by #1572.

Let's figure out what's going on:

1. Since the Read/Write on `net.Conn` doesn't support `Context`, and there are no methods provided such as SetReadContext/SetWriteContext, `net.Conn` is unaware of the cancellation of `Context`.

2. In order to avoid the sustained blocking on `net.Conn` IO after the cancellation of `Context`, we spawn a new goroutine for `net.Conn` IO, and wait for the cancellation in the current goroutine ([code](https://github.com/go-redis/redis/blob/02ccf05ed073709d0c4a3b933a50b13a2b87c0b6/redis.go#L317)).

3. Once the current goroutine receives the cancellation of `Context`, we let the newly spawn goroutine alone, save the error to `cmd` and return it immediately ([code](https://github.com/go-redis/redis/blob/02ccf05ed073709d0c4a3b933a50b13a2b87c0b6/redis.go#L60)). 

4. Since the process of `cmd` is completed, the user try **retrieving the result** and error from `cmd` at once by `cmd.Result()` ([code](https://github.com/go-redis/redis/blob/02ccf05ed073709d0c4a3b933a50b13a2b87c0b6/command.go#L206))

5. At this timing, the newly spawn goroutine just finished the IO, and try **saving the result** to  `cmd` simultaneously ([code](https://github.com/go-redis/redis/blob/02ccf05ed073709d0c4a3b933a50b13a2b87c0b6/command.go#L318)). 

6. The data race takes place.

The root cause of this bug is that `net.Conn` doesn't support `Context` and we work it around, so things get complicated.

Finally, I made this PR implementing a wrapper for `net.Conn` to simulate  SetReadContext/SetWriteContext properly, feel free to edit or make any changes.