### PR TITLE
make error message for unreachable sentinels more clear

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -485,7 +485,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		return addr, nil
 	}
 
-	return "", errors.New("redis: all sentinels are unreachable")
+	return "", errors.New("redis: all sentinels specified in configuration are unreachable")
 }
 
 func (c *sentinelFailover) slaveAddrs(ctx context.Context) ([]string, error) {
@@ -530,7 +530,7 @@ func (c *sentinelFailover) slaveAddrs(ctx context.Context) ([]string, error) {
 		return addrs, nil
 	}
 
-	return []string{}, errors.New("redis: all sentinels are unreachable")
+	return []string{}, errors.New("redis: all sentinels specified in configuration are unreachable")
 }
 
 func (c *sentinelFailover) getMasterAddr(ctx context.Context, sentinel *SentinelClient) string {


### PR DESCRIPTION
The original text `all sentinels are unreachable` can sometimes be misleading, making some users think that all of their redis sentinels are down.

But it might not be the reality especially when using kubernetes and specify `c.sentinelAddrs` with the Service's domain. In this case, when the sentinel to which the domain is redirected runs into some errors despite other sentinels running healthily, the original text given by redis client will be confusing and delivering false message!

Just got out of a similar dilemma after checking the source code, feel free to correct me if I am wrong :)