### PR TITLE
add disable/-1 comment to max retries

### DIFF
--- a/options.go
+++ b/options.go
@@ -58,7 +58,7 @@ type Options struct {
 	DB int
 
 	// Maximum number of retries before giving up.
-	// Default is 3 retries.
+	// Default is 3 retries; -1 (not 0) disables retries.
 	MaxRetries int
 	// Minimum backoff between each retry.
 	// Default is 8 milliseconds; -1 disables backoff.


### PR DESCRIPTION
Since 0 will not disable max retries (defaults to 3), add an explicit comment regarding how to disable.