### PR TITLE
Ensure Watch closes the transaction on panic

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -65,16 +65,13 @@ func (c *Tx) Process(ctx context.Context, cmd Cmder) error {
 // The transaction is automatically closed when fn exits.
 func (c *Client) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	tx := c.newTx(ctx)
+	defer tx.Close(ctx)
 	if len(keys) > 0 {
 		if err := tx.Watch(ctx, keys...).Err(); err != nil {
-			_ = tx.Close(ctx)
 			return err
 		}
 	}
-
-	err := fn(tx)
-	_ = tx.Close(ctx)
-	return err
+	return fn(tx)
 }
 
 // Close closes the transaction, releasing any open resources.


### PR DESCRIPTION
This PR ensures that `Watch` will close the transaction if the user provided function `panic`s. 

Panics which occur inside `fn` but are recover outside of it render the client unusable (the connection pool never recovers since `tx.Close` is never called).