### PR TITLE
Add redis.Scan() to scan results from redis maps into structs.

### DIFF
--- a/command.go
+++ b/command.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8/internal"
+	"github.com/go-redis/redis/v8/internal/hscan"
 	"github.com/go-redis/redis/v8/internal/proto"
 	"github.com/go-redis/redis/v8/internal/util"
 )
@@ -369,6 +370,13 @@ func (cmd *SliceCmd) Result() ([]interface{}, error) {
 
 func (cmd *SliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
+}
+
+// Scan scans the results from a key-value Redis map result set ([]interface{})
+// like HMGET and HGETALL to a destination struct.
+// The Redis keys are matched to the struct's field with the `redis` tag.
+func (cmd *SliceCmd) Scan(val interface{}) error {
+	return hscan.Scan(cmd.val, val)
 }
 
 func (cmd *SliceCmd) readReply(rd *proto.Reader) error {

--- a/commands_test.go
+++ b/commands_test.go
@@ -1375,6 +1375,22 @@ var _ = Describe("Commands", func() {
 			Expect(m).To(Equal(map[string]string{"key1": "hello1", "key2": "hello2"}))
 		})
 
+		It("should scan", func() {
+			err := client.HMSet(ctx, "hash", "key1", "hello1", "key2", 123).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			res := client.HGetAll(ctx, "hash")
+			Expect(res.Err()).NotTo(HaveOccurred())
+
+			type data struct {
+				Key1 string `redis:"key1"`
+				Key2 int    `redis:"key2"`
+			}
+			var d data
+			Expect(res.Scan(&d)).NotTo(HaveOccurred())
+			Expect(d).To(Equal(data{Key1: "hello1", Key2: 123}))
+		})
+
 		It("should HIncrBy", func() {
 			hSet := client.HSet(ctx, "hash", "key", "5")
 			Expect(hSet.Err()).NotTo(HaveOccurred())

--- a/example_test.go
+++ b/example_test.go
@@ -276,6 +276,40 @@ func ExampleClient_ScanType() {
 	// Output: found 33 keys
 }
 
+// ExampleStringStringMapCmd_Scan shows how to scan the results of a map fetch
+// into a struct.
+func ExampleStringStringMapCmd_Scan() {
+	rdb.FlushDB(ctx)
+	err := rdb.HMSet(ctx, "map",
+		"name", "hello",
+		"count", 123,
+		"correct", true).Err()
+	if err != nil {
+		panic(err)
+	}
+
+	// Get the map. The same approach works for HmGet().
+	res := rdb.HGetAll(ctx, "map")
+	if res.Err() != nil {
+		panic(err)
+	}
+
+	type data struct {
+		Name    string `redis:"name"`
+		Count   int    `redis:"count"`
+		Correct bool   `redis:"correct"`
+	}
+
+	// Scan the results into the struct.
+	var d data
+	if err := res.Scan(&d); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(d)
+	// Output: {hello 123 true}
+}
+
 func ExampleClient_Pipelined() {
 	var incr *redis.IntCmd
 	_, err := rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {

--- a/example_test.go
+++ b/example_test.go
@@ -310,6 +310,39 @@ func ExampleStringStringMapCmd_Scan() {
 	// Output: {hello 123 true}
 }
 
+// ExampleSliceCmd_Scan shows how to scan the results of a multi key fetch
+// into a struct.
+func ExampleSliceCmd_Scan() {
+	rdb.FlushDB(ctx)
+	err := rdb.MSet(ctx,
+		"name", "hello",
+		"count", 123,
+		"correct", true).Err()
+	if err != nil {
+		panic(err)
+	}
+
+	res := rdb.MGet(ctx, "name", "count", "empty", "correct")
+	if res.Err() != nil {
+		panic(err)
+	}
+
+	type data struct {
+		Name    string `redis:"name"`
+		Count   int    `redis:"count"`
+		Correct bool   `redis:"correct"`
+	}
+
+	// Scan the results into the struct.
+	var d data
+	if err := res.Scan(&d); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(d)
+	// Output: {hello 123 true}
+}
+
 func ExampleClient_Pipelined() {
 	var incr *redis.IntCmd
 	_, err := rdb.Pipelined(ctx, func(pipe redis.Pipeliner) error {

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -11,7 +11,7 @@ import (
 type decoderFunc func(reflect.Value, string) error
 
 var (
-	// List of built-in decoders indexed by their numeric constant values (eg: reflect.Bool = 1)
+	// List of built-in decoders indexed by their numeric constant values (eg: reflect.Bool = 1).
 	decoders = []decoderFunc{
 		reflect.Bool:          decodeBool,
 		reflect.Int:           decodeInt,

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -34,7 +34,7 @@ var (
 		reflect.Interface:     decodeUnsupported,
 		reflect.Map:           decodeUnsupported,
 		reflect.Ptr:           decodeUnsupported,
-		reflect.Slice:         decodeStringSlice,
+		reflect.Slice:         decodeSlice,
 		reflect.String:        decodeString,
 		reflect.Struct:        decodeUnsupported,
 		reflect.UnsafePointer: decodeUnsupported,
@@ -69,12 +69,7 @@ func Scan(vals []interface{}, dest interface{}) error {
 	// iterating through the fields of a struct type every time values are
 	// scanned into it.
 	typ := v.Type()
-	fMap, ok := structSpecs.get(typ)
-
-	if !ok {
-		fMap = makeStructSpecs(v, "redis")
-		structSpecs.set(typ, fMap)
-	}
+	fMap := structSpecs.get(typ)
 
 	// Iterate through the (key, value) sequence.
 	for i := 0; i < len(vals); i += 2 {
@@ -143,7 +138,7 @@ func decodeString(f reflect.Value, s string) error {
 	return nil
 }
 
-func decodeStringSlice(f reflect.Value, s string) error {
+func decodeSlice(f reflect.Value, s string) error {
 	// []byte slice ([]uint8).
 	if f.Type().Elem().Kind() == reflect.Uint8 {
 		f.SetBytes([]byte(s))
@@ -151,6 +146,6 @@ func decodeStringSlice(f reflect.Value, s string) error {
 	return nil
 }
 
-func decodeUnsupported(f reflect.Value, s string) error {
-	return fmt.Errorf("redis.Scan(unsupported type %v)", f)
+func decodeUnsupported(v reflect.Value, s string) error {
+	return fmt.Errorf("redis.Scan(unsupported %s)", v.Type())
 }

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -46,12 +46,11 @@ var (
 	structSpecs = newStructMap()
 )
 
-// Scan scans the results from a key-value Redis map result set ([]interface{})
-// to a destination struct. The Redis keys are matched to the struct's field
-// with the `redis` tag.
-func Scan(vals []interface{}, dest interface{}) error {
-	if len(vals)%2 != 0 {
-		return errors.New("args should have an even number of items (key-val)")
+// Scan scans the results from a key-value Redis map result set to a destination struct.
+// The Redis keys are matched to the struct's field with the `redis` tag.
+func Scan(keys []interface{}, vals []interface{}, dest interface{}) error {
+	if len(keys) != len(vals) {
+		return errors.New("args should have the same number of keys and vals")
 	}
 
 	// The destination to scan into should be a struct pointer.
@@ -72,13 +71,13 @@ func Scan(vals []interface{}, dest interface{}) error {
 	fMap := structSpecs.get(typ)
 
 	// Iterate through the (key, value) sequence.
-	for i := 0; i < len(vals); i += 2 {
-		key, ok := vals[i].(string)
+	for i := 0; i < len(vals); i++ {
+		key, ok := keys[i].(string)
 		if !ok {
 			continue
 		}
 
-		val, ok := vals[i+1].(string)
+		val, ok := vals[i].(string)
 		if !ok {
 			continue
 		}

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -1,0 +1,156 @@
+package hscan
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// decoderFunc represents decoding functions for default built-in types.
+type decoderFunc func(reflect.Value, string) error
+
+var (
+	// List of built-in decoders indexed by their numeric constant values (eg: reflect.Bool = 1)
+	decoders = []decoderFunc{
+		reflect.Bool:          decodeBool,
+		reflect.Int:           decodeInt,
+		reflect.Int8:          decodeInt,
+		reflect.Int16:         decodeInt,
+		reflect.Int32:         decodeInt,
+		reflect.Int64:         decodeInt,
+		reflect.Uint:          decodeUint,
+		reflect.Uint8:         decodeUint,
+		reflect.Uint16:        decodeUint,
+		reflect.Uint32:        decodeUint,
+		reflect.Uint64:        decodeUint,
+		reflect.Float32:       decodeFloat,
+		reflect.Float64:       decodeFloat,
+		reflect.Complex64:     decodeUnsupported,
+		reflect.Complex128:    decodeUnsupported,
+		reflect.Array:         decodeUnsupported,
+		reflect.Chan:          decodeUnsupported,
+		reflect.Func:          decodeUnsupported,
+		reflect.Interface:     decodeUnsupported,
+		reflect.Map:           decodeUnsupported,
+		reflect.Ptr:           decodeUnsupported,
+		reflect.Slice:         decodeStringSlice,
+		reflect.String:        decodeString,
+		reflect.Struct:        decodeUnsupported,
+		reflect.UnsafePointer: decodeUnsupported,
+	}
+
+	// Global map of struct field specs that is populated once for every new
+	// struct type that is scanned. This caches the field types and the corresponding
+	// decoder functions to avoid iterating through struct fields on subsequent scans.
+	structSpecs = newStructMap()
+)
+
+// Scan scans the results from a key-value Redis map result set ([]interface{})
+// to a destination struct. The Redis keys are matched to the struct's field
+// with the `redis` tag.
+func Scan(vals []interface{}, dest interface{}) error {
+	if len(vals)%2 != 0 {
+		return errors.New("args should have an even number of items (key-val)")
+	}
+
+	// The destination to scan into should be a struct pointer.
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("redis.Scan(non-pointer %T)", dest)
+	}
+	v = v.Elem()
+
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("redis.Scan(non-struct %T)", dest)
+	}
+
+	// If the struct field spec is not cached, build and cache it to avoid
+	// iterating through the fields of a struct type every time values are
+	// scanned into it.
+	typ := v.Type()
+	fMap, ok := structSpecs.get(typ)
+
+	if !ok {
+		fMap = makeStructSpecs(v, "redis")
+		structSpecs.set(typ, fMap)
+	}
+
+	// Iterate through the (key, value) sequence.
+	for i := 0; i < len(vals); i += 2 {
+		key, ok := vals[i].(string)
+		if !ok {
+			continue
+		}
+
+		val, ok := vals[i+1].(string)
+		if !ok {
+			continue
+		}
+
+		// Check if the field name is in the field spec map.
+		field, ok := fMap.get(key)
+		if !ok {
+			continue
+		}
+
+		if err := field.fn(v.Field(field.index), val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeBool(f reflect.Value, s string) error {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	f.SetBool(b)
+	return nil
+}
+
+func decodeInt(f reflect.Value, s string) error {
+	v, err := strconv.ParseInt(s, 10, 0)
+	if err != nil {
+		return err
+	}
+	f.SetInt(v)
+	return nil
+}
+
+func decodeUint(f reflect.Value, s string) error {
+	v, err := strconv.ParseUint(s, 10, 0)
+	if err != nil {
+		return err
+	}
+	f.SetUint(v)
+	return nil
+}
+
+func decodeFloat(f reflect.Value, s string) error {
+	v, err := strconv.ParseFloat(s, 0)
+	if err != nil {
+		return err
+	}
+	f.SetFloat(v)
+	return nil
+}
+
+func decodeString(f reflect.Value, s string) error {
+	f.SetString(s)
+	return nil
+}
+
+func decodeStringSlice(f reflect.Value, s string) error {
+	// []byte slice ([]uint8).
+	if f.Type().Elem().Kind() == reflect.Uint8 {
+		f.SetBytes([]byte(s))
+	}
+	return nil
+}
+
+func decodeUnsupported(f reflect.Value, s string) error {
+	return fmt.Errorf("redis.Scan(unsupported type %v)", f)
+}

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -1,0 +1,125 @@
+package hscan
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type data struct {
+	Omit  string `redis:"-"`
+	Empty string
+
+	String string  `redis:"string"`
+	Bytes  []byte  `redis:"byte"`
+	Int    int     `redis:"int"`
+	Uint   uint    `redis:"uint"`
+	Float  float32 `redis:"float"`
+	Bool   bool    `redis:"bool"`
+}
+
+func TestGinkgoSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "hscan")
+}
+
+var _ = Describe("Scan", func() {
+	It("catches bad args", func() {
+		var d data
+
+		Expect(Scan([]interface{}{}, &d)).NotTo(HaveOccurred())
+		Expect(d).To(Equal(data{}))
+
+		Expect(Scan([]interface{}{"key"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"key", "1", "2"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"key", "1"}, nil)).To(HaveOccurred())
+
+		var i map[string]interface{}
+		Expect(Scan([]interface{}{"key", "1"}, &i)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"key", "1"}, data{})).To(HaveOccurred())
+		Expect(Scan([]interface{}{"key", nil, "string", nil}, data{})).To(HaveOccurred())
+	})
+
+	It("scans good values", func() {
+		var d data
+
+		// non-tagged fields.
+		Expect(Scan([]interface{}{"key", "value"}, &d)).NotTo(HaveOccurred())
+		Expect(d).To(Equal(data{}))
+
+		res := []interface{}{"string", "str!",
+			"byte", "bytes!",
+			"int", "123",
+			"uint", "456",
+			"float", "123.456",
+			"bool", "1"}
+		Expect(Scan(res, &d)).NotTo(HaveOccurred())
+		Expect(d).To(Equal(data{
+			String: "str!",
+			Bytes:  []byte("bytes!"),
+			Int:    123,
+			Uint:   456,
+			Float:  123.456,
+			Bool:   true,
+		}))
+
+		// Scan a different type with the same values to test that
+		// the struct spec maps don't conflict.
+		type data2 struct {
+			String string  `redis:"string"`
+			Bytes  []byte  `redis:"byte"`
+			Int    int     `redis:"int"`
+			Uint   uint    `redis:"uint"`
+			Float  float32 `redis:"float"`
+			Bool   bool    `redis:"bool"`
+		}
+		var d2 data2
+		Expect(Scan(res, &d2)).NotTo(HaveOccurred())
+		Expect(d2).To(Equal(data2{
+			String: "str!",
+			Bytes:  []byte("bytes!"),
+			Int:    123,
+			Uint:   456,
+			Float:  123.456,
+			Bool:   true,
+		}))
+
+		Expect(Scan([]interface{}{
+			"string", "",
+			"float", "1",
+			"bool", "t"}, &d)).NotTo(HaveOccurred())
+		Expect(d).To(Equal(data{
+			String: "",
+			Bytes:  []byte("bytes!"),
+			Int:    123,
+			Uint:   456,
+			Float:  1.0,
+			Bool:   true,
+		}))
+	})
+
+	It("omits untagged fields", func() {
+		var d data
+
+		Expect(Scan([]interface{}{
+			"empty", "value",
+			"omit", "value",
+			"string", "str!"}, &d)).NotTo(HaveOccurred())
+		Expect(d).To(Equal(data{
+			String: "str!",
+		}))
+	})
+
+	It("catches bad values", func() {
+		var d data
+
+		Expect(Scan([]interface{}{"int", "a"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"uint", "a"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"uint", ""}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"float", "b"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"bool", "-1"}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"bool", ""}, &d)).To(HaveOccurred())
+		Expect(Scan([]interface{}{"bool", "123"}, &d)).To(HaveOccurred())
+	})
+})

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -28,33 +28,31 @@ func TestGinkgoSuite(t *testing.T) {
 
 var _ = Describe("Scan", func() {
 	It("catches bad args", func() {
-		var (
-			d data
-		)
+		var d data
 
-		Expect(Scan(i{}, i{}, &d)).NotTo(HaveOccurred())
+		Expect(Scan(&d, i{}, i{})).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{}))
 
-		Expect(Scan(i{"key"}, i{}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"key"}, i{"1", "2"}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"key", "1"}, i{}, nil)).To(HaveOccurred())
+		Expect(Scan(&d, i{"key"}, i{})).To(HaveOccurred())
+		Expect(Scan(&d, i{"key"}, i{"1", "2"})).To(HaveOccurred())
+		Expect(Scan(nil, i{"key", "1"}, i{})).To(HaveOccurred())
 
 		var m map[string]interface{}
-		Expect(Scan(i{"key"}, i{"1"}, &m)).To(HaveOccurred())
-		Expect(Scan(i{"key"}, i{"1"}, data{})).To(HaveOccurred())
-		Expect(Scan(i{"key", "string"}, i{nil, nil}, data{})).To(HaveOccurred())
+		Expect(Scan(&m, i{"key"}, i{"1"})).To(HaveOccurred())
+		Expect(Scan(data{}, i{"key"}, i{"1"})).To(HaveOccurred())
+		Expect(Scan(data{}, i{"key", "string"}, i{nil, nil})).To(HaveOccurred())
 	})
 
 	It("scans good values", func() {
 		var d data
 
 		// non-tagged fields.
-		Expect(Scan(i{"key"}, i{"value"}, &d)).NotTo(HaveOccurred())
+		Expect(Scan(&d, i{"key"}, i{"value"})).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{}))
 
 		keys := i{"string", "byte", "int", "uint", "float", "bool"}
 		vals := i{"str!", "bytes!", "123", "456", "123.456", "1"}
-		Expect(Scan(keys, vals, &d)).NotTo(HaveOccurred())
+		Expect(Scan(&d, keys, vals)).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{
 			String: "str!",
 			Bytes:  []byte("bytes!"),
@@ -75,7 +73,7 @@ var _ = Describe("Scan", func() {
 			Bool   bool    `redis:"bool"`
 		}
 		var d2 data2
-		Expect(Scan(keys, vals, &d2)).NotTo(HaveOccurred())
+		Expect(Scan(&d2, keys, vals)).NotTo(HaveOccurred())
 		Expect(d2).To(Equal(data2{
 			String: "str!",
 			Bytes:  []byte("bytes!"),
@@ -85,7 +83,7 @@ var _ = Describe("Scan", func() {
 			Bool:   true,
 		}))
 
-		Expect(Scan(i{"string", "float", "bool"}, i{"", "1", "t"}, &d)).NotTo(HaveOccurred())
+		Expect(Scan(&d, i{"string", "float", "bool"}, i{"", "1", "t"})).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{
 			String: "",
 			Bytes:  []byte("bytes!"),
@@ -99,7 +97,7 @@ var _ = Describe("Scan", func() {
 	It("omits untagged fields", func() {
 		var d data
 
-		Expect(Scan(i{"empty", "omit", "string"}, i{"value", "value", "str!"}, &d)).NotTo(HaveOccurred())
+		Expect(Scan(&d, i{"empty", "omit", "string"}, i{"value", "value", "str!"})).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{
 			String: "str!",
 		}))
@@ -108,12 +106,12 @@ var _ = Describe("Scan", func() {
 	It("catches bad values", func() {
 		var d data
 
-		Expect(Scan(i{"int"}, i{"a"}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"uint"}, i{"a"}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"uint"}, i{""}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"float"}, i{"b"}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"bool"}, i{"-1"}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"bool"}, i{""}, &d)).To(HaveOccurred())
-		Expect(Scan(i{"bool"}, i{"123"}, &d)).To(HaveOccurred())
+		Expect(Scan(&d, i{"int"}, i{"a"})).To(HaveOccurred())
+		Expect(Scan(&d, i{"uint"}, i{"a"})).To(HaveOccurred())
+		Expect(Scan(&d, i{"uint"}, i{""})).To(HaveOccurred())
+		Expect(Scan(&d, i{"float"}, i{"b"})).To(HaveOccurred())
+		Expect(Scan(&d, i{"bool"}, i{"-1"})).To(HaveOccurred())
+		Expect(Scan(&d, i{"bool"}, i{""})).To(HaveOccurred())
+		Expect(Scan(&d, i{"bool"}, i{"123"})).To(HaveOccurred())
 	})
 })

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -24,22 +24,17 @@ type structMap struct {
 }
 
 func newStructMap() *structMap {
-	return &structMap{
-		m: sync.Map{},
-	}
+	return new(structMap)
 }
 
-func (s *structMap) get(t reflect.Type) (*structFields, bool) {
-	m, ok := s.m.Load(t)
-	if !ok {
-		return nil, ok
+func (s *structMap) get(t reflect.Type) *structFields {
+	if v, ok := s.m.Load(t); ok {
+		return m.(*structFields), ok
 	}
 
-	return m.(*structFields), true
-}
-
-func (s *structMap) set(t reflect.Type, sf *structFields) {
-	s.m.Store(t, sf)
+	fMap := getStructFields(v, "redis")
+	s.m.Store(t, fMap)
+	return fmap, true
 }
 
 func newStructFields() *structFields {
@@ -57,7 +52,7 @@ func (s *structFields) get(tag string) (*structField, bool) {
 	return f, ok
 }
 
-func makeStructSpecs(ob reflect.Value, fieldTag string) *structFields {
+func getStructFields(ob reflect.Value, fieldTag string) *structFields {
 	var (
 		num = ob.NumField()
 		out = newStructFields()

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -37,11 +37,6 @@ func (s *structSpec) set(tag string, sf *structField) {
 	s.m[tag] = sf
 }
 
-func (s *structSpec) get(tag string) (*structField, bool) {
-	f, ok := s.m[tag]
-	return f, ok
-}
-
 func newStructSpec(t reflect.Type, fieldTag string) *structSpec {
 	out := &structSpec{
 		m: make(map[string]*structField),

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -1,0 +1,87 @@
+package hscan
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// structField represents a single field in a target struct.
+type structField struct {
+	index int
+	fn    decoderFunc
+}
+
+// structFields contains the list of all fields in a target struct.
+type structFields struct {
+	m map[string]*structField
+}
+
+// structMap contains the map of struct fields for target structs
+// indexed by the struct type.
+type structMap struct {
+	m sync.Map
+}
+
+func newStructMap() *structMap {
+	return &structMap{
+		m: sync.Map{},
+	}
+}
+
+func (s *structMap) get(t reflect.Type) (*structFields, bool) {
+	m, ok := s.m.Load(t)
+	if !ok {
+		return nil, ok
+	}
+
+	return m.(*structFields), true
+}
+
+func (s *structMap) set(t reflect.Type, sf *structFields) {
+	s.m.Store(t, sf)
+}
+
+func newStructFields() *structFields {
+	return &structFields{
+		m: make(map[string]*structField),
+	}
+}
+
+func (s *structFields) set(tag string, sf *structField) {
+	s.m[tag] = sf
+}
+
+func (s *structFields) get(tag string) (*structField, bool) {
+	f, ok := s.m[tag]
+	return f, ok
+}
+
+func makeStructSpecs(ob reflect.Value, fieldTag string) *structFields {
+	var (
+		num = ob.NumField()
+		out = newStructFields()
+	)
+
+	for i := 0; i < num; i++ {
+		f := ob.Field(i)
+		if !f.IsValid() || !f.CanSet() {
+			continue
+		}
+
+		tag := ob.Type().Field(i).Tag.Get(fieldTag)
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		tag = strings.Split(tag, ",")[0]
+		if tag == "" {
+			continue
+		}
+
+		// Use the built-in decoder.
+		out.set(tag, &structField{index: i, fn: decoders[f.Kind()]})
+	}
+
+	return out
+}

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -61,7 +61,7 @@ func getStructFields(t reflect.Type, fieldTag string) *structFields {
 	for i := 0; i < num; i++ {
 		f := t.Field(i)
 
-		tag := t.Field(i).Tag.Get(fieldTag)
+		tag := f.Tag.Get(fieldTag)
 		if tag == "" || tag == "-" {
 			continue
 		}


### PR DESCRIPTION
The package uses reflection to decode default types (int, string etc.) from Redis map results (key-value pair sequences) into
struct fields where the fields are matched to Redis keys by tags.

Similar to how `encoding/json` allows custom decoders using`UnmarshalJSON()`, the package supports decoding of arbitrary
types into struct fields by defining a `Decode(string) error`function on types.

The field/type spec of every struct that's passed to Scan() is cached in the package so that subsequent scans avoid iteration
and reflection of the struct's fields.

Issue: https://github.com/go-redis/redis/issues/1603