### PR TITLE
Add SetArgs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ bench: testdeps
 
 testdata/redis:
 	mkdir -p $@
-	wget -qO- http://download.redis.io/redis-stable.tar.gz | tar xvz --strip-components=1 -C $@
+	wget -qO- https://download.redis.io/releases/redis-6.2-rc3.tar.gz | tar xvz --strip-components=1 -C $@
 
 testdata/redis/src/redis-server: testdata/redis
 	cd $< && make all

--- a/commands.go
+++ b/commands.go
@@ -797,9 +797,9 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 //
 // When Get is true, the command returns the old value stored at key, or nil when key did not exist.
 type SetArgs struct {
-	Mode     string
-	ExpireAt time.Duration
-	Get      bool
+	Mode string
+	TTL  time.Duration
+	Get  bool
 }
 
 // SetArgs provides a way to call the SET command with SetArgs arguments.
@@ -809,13 +809,13 @@ func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *
 	// We set a rule to only use EX & PX options for expire time.
 	// We only need to support one of the two format (EX, PX) OR (EXAT, PXAT)
 	// because it is transparent to the user what we use here.
-	if a.ExpireAt > 0 {
-		if usePrecise(a.ExpireAt) {
-			args = append(args, "px", formatMs(ctx, a.ExpireAt))
+	if a.TTL > 0 {
+		if usePrecise(a.TTL) {
+			args = append(args, "px", formatMs(ctx, a.TTL))
 		} else {
-			args = append(args, "ex", formatSec(ctx, a.ExpireAt))
+			args = append(args, "ex", formatSec(ctx, a.TTL))
 		}
-	} else if a.ExpireAt == KeepTTL {
+	} else if a.TTL == KeepTTL {
 		args = append(args, "keepttl")
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -810,16 +810,18 @@ type SetArgs struct {
 func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 
-	if !a.ExpireAt.IsZero() {
+	if a.KeepTTL {
+		args = append(args, "keepttl")
+	}
+
+	if !a.ExpireAt.IsZero() && !a.KeepTTL {
 		args = append(args, "exat", a.ExpireAt.Unix())
-	} else if a.TTL > 0 {
+	} else if a.TTL > 0 && !a.KeepTTL {
 		if usePrecise(a.TTL) {
 			args = append(args, "px", formatMs(ctx, a.TTL))
 		} else {
 			args = append(args, "ex", formatSec(ctx, a.TTL))
 		}
-	} else if a.KeepTTL {
-		args = append(args, "keepttl")
 	}
 
 	if a.Mode != "" {

--- a/commands.go
+++ b/commands.go
@@ -802,7 +802,7 @@ type SetArgs struct {
 	Get      bool
 }
 
-// Redis `SET key value [EX seconds|PX milliseconds|EXAT timestamp|PXAT milliseconds-timestamp|KEEPTTL] [NX|XX] [GET]` command.
+// SetWithArgs provides a way to call the SET command with SetArgs arguments.
 func (c cmdable) SetWithArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 

--- a/commands.go
+++ b/commands.go
@@ -788,23 +788,25 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 	return cmd
 }
 
-// SetArgs provides arguments for the SetWithArgs command.
-//
-// Mode can be `NX` or `XX` or empty.
-//
-// Zero expiration means the key has no expiration time.
-// KeepTTL(-1) expiration is a Redis KEEPTTL option to keep existing TTL.
-//
-// When Get is true, the command returns the old value stored at key, or nil when key did not exist.
+// SetArgs provides arguments for the SetArgs function.
 type SetArgs struct {
-	Mode     string
+	// Mode can be `NX` or `XX` or empty
+	Mode string
+
+	// Zero `TTL` or `Expiration` means that the key has no expiration time.
 	TTL      time.Duration
 	ExpireAt time.Time
-	Get      bool
-	KeepTTL  bool
+
+	// When Get is true, the command returns the old value stored at key, or nil when key did not exist.
+	Get bool
+
+	// KeepTTL is a Redis KEEPTTL option to keep existing TTL
+	KeepTTL bool
 }
 
-// SetArgs provides a way to call the SET command with SetArgs arguments.
+// SetArgs supports all the options that the SET command supports.
+// It is the granular alternative to use when you want
+// to have more control over the SET command.
 func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 

--- a/commands.go
+++ b/commands.go
@@ -802,8 +802,8 @@ type SetArgs struct {
 	Get      bool
 }
 
-// SetWithArgs provides a way to call the SET command with SetArgs arguments.
-func (c cmdable) SetWithArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
+// SetArgs provides a way to call the SET command with SetArgs arguments.
+func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 
 	// We set a rule to only use EX & PX options for expire time.

--- a/commands.go
+++ b/commands.go
@@ -797,9 +797,10 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 //
 // When Get is true, the command returns the old value stored at key, or nil when key did not exist.
 type SetArgs struct {
-	Mode string
-	TTL  time.Duration
-	Get  bool
+	Mode    string
+	TTL     time.Duration
+	Get     bool
+	KeepTTL bool
 }
 
 // SetArgs provides a way to call the SET command with SetArgs arguments.
@@ -815,7 +816,7 @@ func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *
 		} else {
 			args = append(args, "ex", formatSec(ctx, a.TTL))
 		}
-	} else if a.TTL == KeepTTL {
+	} else if a.KeepTTL {
 		args = append(args, "keepttl")
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -797,20 +797,20 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 //
 // When Get is true, the command returns the old value stored at key, or nil when key did not exist.
 type SetArgs struct {
-	Mode    string
-	TTL     time.Duration
-	Get     bool
-	KeepTTL bool
+	Mode     string
+	TTL      time.Duration
+	ExpireAt time.Time
+	Get      bool
+	KeepTTL  bool
 }
 
 // SetArgs provides a way to call the SET command with SetArgs arguments.
 func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 
-	// We set a rule to only use EX & PX options for expire time.
-	// We only need to support one of the two format (EX, PX) OR (EXAT, PXAT)
-	// because it is transparent to the user what we use here.
-	if a.TTL > 0 {
+	if !a.ExpireAt.IsZero() {
+		args = append(args, "exat", a.ExpireAt.Unix())
+	} else if a.TTL > 0 {
 		if usePrecise(a.TTL) {
 			args = append(args, "px", formatMs(ctx, a.TTL))
 		} else {

--- a/commands.go
+++ b/commands.go
@@ -793,20 +793,20 @@ type SetArgs struct {
 	// Mode can be `NX` or `XX` or empty
 	Mode string
 
-	// Zero `TTL` or `Expiration` means that the key has no expiration time.
+	// Zero `TTL` or `Expiration` means that the key has no expiration time
 	TTL      time.Duration
 	ExpireAt time.Time
 
 	// When Get is true, the command returns the old value stored at key, or nil when key did not exist.
 	Get bool
 
-	// KeepTTL is a Redis KEEPTTL option to keep existing TTL
+	// KeepTTL is a Redis KEEPTTL option to keep existing TTL.
 	KeepTTL bool
 }
 
 // SetArgs supports all the options that the SET command supports.
-// It is the granular alternative to use when you want
-// to have more control over the SET command.
+// It is the alternative to the Set function when you want
+// to have more control over the options.
 func (c cmdable) SetArgs(ctx context.Context, key string, value interface{}, a *SetArgs) *StatusCmd {
 	args := []interface{}{"set", key, value}
 

--- a/commands.go
+++ b/commands.go
@@ -790,10 +790,10 @@ func (c cmdable) Set(ctx context.Context, key string, value interface{}, expirat
 
 // SetArgs provides arguments for the SetArgs function.
 type SetArgs struct {
-	// Mode can be `NX` or `XX` or empty
+	// Mode can be `NX` or `XX` or empty.
 	Mode string
 
-	// Zero `TTL` or `Expiration` means that the key has no expiration time
+	// Zero `TTL` or `Expiration` means that the key has no expiration time.
 	TTL      time.Duration
 	ExpireAt time.Time
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -1160,7 +1160,7 @@ var _ = Describe("Commands", func() {
 			Expect(mSetNX.Val()).To(Equal(false))
 		})
 
-		It("should SetWithArgs with expiration", func() {
+		It("should SetWithArgs with TTL", func() {
 			args := &redis.SetArgs{
 				TTL: 500 * time.Millisecond,
 			}
@@ -1174,6 +1174,19 @@ var _ = Describe("Commands", func() {
 			Eventually(func() error {
 				return client.Get(ctx, "key").Err()
 			}, "2s", "100ms").Should(Equal(redis.Nil))
+		})
+
+		It("should SetWithArgs with expiration date", func() {
+			expireAt := time.Now().AddDate(1, 1, 1)
+			args := &redis.SetArgs{
+				ExpireAt: expireAt,
+			}
+			err := client.SetArgs(ctx, "key", "hello", args).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			val, err := client.Get(ctx, "key").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("hello"))
 		})
 
 		It("should SetWithArgs with keepttl", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -1178,16 +1178,18 @@ var _ = Describe("Commands", func() {
 
 		It("should SetWithArgs with keepttl", func() {
 			// Set with ttl
-			args := &redis.SetArgs{
+			argsWithTTL := &redis.SetArgs{
 				TTL: 5 * time.Second,
 			}
-			set := client.SetArgs(ctx, "key", "hello", args)
+			set := client.SetArgs(ctx, "key", "hello", argsWithTTL)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
 
 			// Set with keepttl
-			args.TTL = redis.KeepTTL
-			set = client.SetArgs(ctx, "key", "hello", args)
+			argsWithKeepTTL := &redis.SetArgs{
+				KeepTTL: true,
+			}
+			set = client.SetArgs(ctx, "key", "hello", argsWithKeepTTL)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -1162,7 +1162,7 @@ var _ = Describe("Commands", func() {
 
 		It("should SetWithArgs with expiration", func() {
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
+				TTL: 500 * time.Millisecond,
 			}
 			err := client.SetArgs(ctx, "key", "hello", args).Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -1179,14 +1179,14 @@ var _ = Describe("Commands", func() {
 		It("should SetWithArgs with keepttl", func() {
 			// Set with ttl
 			args := &redis.SetArgs{
-				ExpireAt: 5 * time.Second,
+				TTL: 5 * time.Second,
 			}
 			set := client.SetArgs(ctx, "key", "hello", args)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
 
 			// Set with keepttl
-			args.ExpireAt = redis.KeepTTL
+			args.TTL = redis.KeepTTL
 			set = client.SetArgs(ctx, "key", "hello", args)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
@@ -1230,8 +1230,8 @@ var _ = Describe("Commands", func() {
 
 		It("should SetWithArgs with expiration, NX mode, and key does not exist", func() {
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
-				Mode:     "nx",
+				TTL:  500 * time.Millisecond,
+				Mode: "nx",
 			}
 			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -1247,8 +1247,8 @@ var _ = Describe("Commands", func() {
 			Expect(e.Err()).NotTo(HaveOccurred())
 
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
-				Mode:     "nx",
+				TTL:  500 * time.Millisecond,
+				Mode: "nx",
 			}
 			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).To(Equal(redis.Nil))
@@ -1257,9 +1257,9 @@ var _ = Describe("Commands", func() {
 
 		It("should SetWithArgs with expiration, NX mode, and GET option", func() {
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
-				Mode:     "nx",
-				Get:      true,
+				TTL:  500 * time.Millisecond,
+				Mode: "nx",
+				Get:  true,
 			}
 			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).To(Equal(proto.RedisError("ERR syntax error")))
@@ -1313,9 +1313,9 @@ var _ = Describe("Commands", func() {
 
 		It("should SetWithArgs with expiration, XX mode, GET option, and key does not exist", func() {
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
-				Mode:     "xx",
-				Get:      true,
+				TTL:  500 * time.Millisecond,
+				Mode: "xx",
+				Get:  true,
 			}
 
 			val, err := client.SetArgs(ctx, "key", "world", args).Result()
@@ -1328,9 +1328,9 @@ var _ = Describe("Commands", func() {
 			Expect(e.Err()).NotTo(HaveOccurred())
 
 			args := &redis.SetArgs{
-				ExpireAt: 500 * time.Millisecond,
-				Mode:     "xx",
-				Get:      true,
+				TTL:  500 * time.Millisecond,
+				Mode: "xx",
+				Get:  true,
 			}
 
 			val, err := client.SetArgs(ctx, "key", "world", args).Result()

--- a/commands_test.go
+++ b/commands_test.go
@@ -1164,7 +1164,7 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				ExpireAt: 500 * time.Millisecond,
 			}
-			err := client.SetWithArgs(ctx, "key", "hello", args).Err()
+			err := client.SetArgs(ctx, "key", "hello", args).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			val, err := client.Get(ctx, "key").Result()
@@ -1181,13 +1181,13 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				ExpireAt: 5 * time.Second,
 			}
-			set := client.SetWithArgs(ctx, "key", "hello", args)
+			set := client.SetArgs(ctx, "key", "hello", args)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
 
 			// Set with keepttl
 			args.ExpireAt = redis.KeepTTL
-			set = client.SetWithArgs(ctx, "key", "hello", args)
+			set = client.SetArgs(ctx, "key", "hello", args)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Result()).To(Equal("OK"))
 
@@ -1204,7 +1204,7 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				Mode: "nx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1213,7 +1213,7 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				Mode: "nx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("OK"))
 		})
@@ -1223,7 +1223,7 @@ var _ = Describe("Commands", func() {
 				Mode: "nx",
 				Get:  true,
 			}
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).To(Equal(proto.RedisError("ERR syntax error")))
 			Expect(val).To(Equal(""))
 		})
@@ -1233,7 +1233,7 @@ var _ = Describe("Commands", func() {
 				ExpireAt: 500 * time.Millisecond,
 				Mode:     "nx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("OK"))
 
@@ -1250,7 +1250,7 @@ var _ = Describe("Commands", func() {
 				ExpireAt: 500 * time.Millisecond,
 				Mode:     "nx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1261,7 +1261,7 @@ var _ = Describe("Commands", func() {
 				Mode:     "nx",
 				Get:      true,
 			}
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).To(Equal(proto.RedisError("ERR syntax error")))
 			Expect(val).To(Equal(""))
 		})
@@ -1270,7 +1270,7 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				Mode: "xx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1282,7 +1282,7 @@ var _ = Describe("Commands", func() {
 			args := &redis.SetArgs{
 				Mode: "xx",
 			}
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("OK"))
 		})
@@ -1295,7 +1295,7 @@ var _ = Describe("Commands", func() {
 				Mode: "xx",
 				Get:  true,
 			}
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("hello"))
 		})
@@ -1306,7 +1306,7 @@ var _ = Describe("Commands", func() {
 				Get:  true,
 			}
 
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1318,7 +1318,7 @@ var _ = Describe("Commands", func() {
 				Get:      true,
 			}
 
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1333,7 +1333,7 @@ var _ = Describe("Commands", func() {
 				Get:      true,
 			}
 
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("hello"))
 
@@ -1347,7 +1347,7 @@ var _ = Describe("Commands", func() {
 				Get: true,
 			}
 
-			val, err := client.SetWithArgs(ctx, "key", "hello", args).Result()
+			val, err := client.SetArgs(ctx, "key", "hello", args).Result()
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(Equal(""))
 		})
@@ -1360,7 +1360,7 @@ var _ = Describe("Commands", func() {
 				Get: true,
 			}
 
-			val, err := client.SetWithArgs(ctx, "key", "world", args).Result()
+			val, err := client.SetArgs(ctx, "key", "world", args).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("hello"))
 		})

--- a/commands_test.go
+++ b/commands_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Commands", func() {
 		It("should Command", func() {
 			cmds, err := client.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(cmds)).To(BeNumerically("~", 200, 20))
+			Expect(len(cmds)).To(BeNumerically("~", 200, 25))
 
 			cmd := cmds["mget"]
 			Expect(cmd.Name).To(Equal("mget"))


### PR DESCRIPTION
SetArgs supports all the SET command options. 
It is the alternative to the Set function when the user wants more control over the SET options.