### PR TITLE
Update OpenTelemetry to 0.17.0 and fix "undefined: otel.Meter"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
-	go.opentelemetry.io/otel v0.16.0
+	go.opentelemetry.io/otel v0.17.0
 )

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -3,8 +3,8 @@ package internal
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
 )
 
 var (
@@ -21,7 +21,7 @@ func init() {
 		}
 	}()
 
-	meter := metric.Must(otel.Meter("github.com/go-redis/redis"))
+	meter := metric.Must(global.Meter("github.com/go-redis/redis"))
 
 	WritesCounter = meter.NewInt64Counter("redis.writes",
 		metric.WithDescription("the number of writes initiated"),


### PR DESCRIPTION
function `otel.Meter` has been [moved](https://github.com/open-telemetry/opentelemetry-go/commit/9b242bc4015d82acd63614a9e9ddba0cd1bceca8#diff-a07b5af0fea95be688fdc26a39e3b3aed8d3f4a2adba86258a393566f8b82fc6) to `otel/metric/global.Meter` in OpenTelemetry 0.17.0.