### PR TITLE
fix unit test errors that may appear in pool_test.go

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -17,7 +17,7 @@ var _ = Describe("pool", func() {
 		opt := redisOptions()
 		opt.MinIdleConns = 0
 		opt.MaxConnAge = 0
-		opt.IdleTimeout = 2 * time.Second
+		opt.IdleTimeout = time.Second
 		client = redis.NewClient(opt)
 	})
 
@@ -105,6 +105,13 @@ var _ = Describe("pool", func() {
 	})
 
 	It("reuses connections", func() {
+		// explain: https://github.com/go-redis/redis/pull/1675
+		opt := redisOptions()
+		opt.MinIdleConns = 0
+		opt.MaxConnAge = 0
+		opt.IdleTimeout = 2 * time.Second
+		client = redis.NewClient(opt)
+
 		for i := 0; i < 100; i++ {
 			val, err := client.Ping(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -135,7 +142,7 @@ var _ = Describe("pool", func() {
 			StaleConns: 0,
 		}))
 
-		time.Sleep(3 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		stats = client.PoolStats()
 		Expect(stats).To(Equal(&redis.PoolStats{

--- a/pool_test.go
+++ b/pool_test.go
@@ -17,7 +17,7 @@ var _ = Describe("pool", func() {
 		opt := redisOptions()
 		opt.MinIdleConns = 0
 		opt.MaxConnAge = 0
-		opt.IdleTimeout = time.Second
+		opt.IdleTimeout = 2 * time.Second
 		client = redis.NewClient(opt)
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("pool", func() {
 			StaleConns: 0,
 		}))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 
 		stats = client.PoolStats()
 		Expect(stats).To(Equal(&redis.PoolStats{


### PR DESCRIPTION
possible errors：

```go
/redis/pool_test.go:13
  reuses connections [It]
  /redis/pool_test.go:119

  Expected
      <uint32>: 98
  to equal
      <uint32>: 99

  /redis/pool_test.go:148
```

Code:
```go
It("reuses connections", func() {
		for i := 0; i < 100; i++ {
			val, err := client.Ping(ctx).Result()
			Expect(err).NotTo(HaveOccurred())
			Expect(val).To(Equal("PONG"))
		}

		pool := client.Pool()
		Expect(pool.Len()).To(Equal(1))
		Expect(pool.IdleLen()).To(Equal(1))

		stats := pool.Stats()
		Expect(stats.Hits).To(Equal(uint32(99)))
		Expect(stats.Misses).To(Equal(uint32(1)))
		Expect(stats.Timeouts).To(Equal(uint32(0)))
})
```

because `opt.IdleTimeout = 1 * time.Second` and `conn.UsedAt` are unix timestamps.
if 100 times `client.Ping()` exceeds 1 second, `conn.deadline()` will be triggered to drop the connection, `conn.Get()` will create a new conn, and the number of `stats.Misses` will change.