### PR TITLE
Make SetArgs available to Pipeliner

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -124,6 +124,7 @@ type Cmdable interface {
 	MSet(ctx context.Context, values ...interface{}) *StatusCmd
 	MSetNX(ctx context.Context, values ...interface{}) *BoolCmd
 	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd
+	SetArgs(ctx context.Context, key string, value interface{}, a SetArgs) *StatusCmd
 	SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd
 	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd
 	SetXX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd

--- a/commands_test.go
+++ b/commands_test.go
@@ -1400,6 +1400,23 @@ var _ = Describe("Commands", func() {
 			Expect(val).To(Equal("hello"))
 		})
 
+		It("should Pipelined SetArgs with Get and key exists", func() {
+			e := client.Set(ctx, "key", "hello", 0)
+			Expect(e.Err()).NotTo(HaveOccurred())
+
+			args := redis.SetArgs{
+				Get: true,
+			}
+
+			pipe := client.Pipeline()
+			setArgs := pipe.SetArgs(ctx, "key", "world", args)
+			_, err := pipe.Exec(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(setArgs.Err()).NotTo(HaveOccurred())
+			Expect(setArgs.Val()).To(Equal("hello"))
+		})
+
 		It("should Set with expiration", func() {
 			err := client.Set(ctx, "key", "hello", 100*time.Millisecond).Err()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
SetArgs is amazing! It would be even more amazing to be able to use it
within a non-transactional Pipeline.