### PR TITLE
fix ring test `Process hook` data race

### DIFF
--- a/ring_test.go
+++ b/ring_test.go
@@ -189,6 +189,12 @@ var _ = Describe("Redis Ring", func() {
 	})
 
 	It("supports Process hook", func() {
+		//the health check leads to data race for variable "stack []string".
+		//here, the health check time is set to 72 hours to avoid health check
+		opt := redisRingOptions()
+		opt.HeartbeatFrequency = 72 * time.Hour
+		ring = redis.NewRing(opt)
+
 		err := ring.Ping(ctx).Err()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/ring_test.go
+++ b/ring_test.go
@@ -188,159 +188,162 @@ var _ = Describe("Redis Ring", func() {
 		})
 	})
 
-	It("supports Process hook", func() {
-		//the health check leads to data race for variable "stack []string".
-		//here, the health check time is set to 72 hours to avoid health check
-		opt := redisRingOptions()
-		opt.HeartbeatFrequency = 72 * time.Hour
-		ring = redis.NewRing(opt)
-
-		err := ring.Ping(ctx).Err()
-		Expect(err).NotTo(HaveOccurred())
-
-		var stack []string
-
-		ring.AddHook(&hook{
-			beforeProcess: func(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
-				Expect(cmd.String()).To(Equal("ping: "))
-				stack = append(stack, "ring.BeforeProcess")
-				return ctx, nil
-			},
-			afterProcess: func(ctx context.Context, cmd redis.Cmder) error {
-				Expect(cmd.String()).To(Equal("ping: PONG"))
-				stack = append(stack, "ring.AfterProcess")
-				return nil
-			},
+	Describe("Process hook", func() {
+		BeforeEach(func() {
+			//the health check leads to data race for variable "stack []string".
+			//here, the health check time is set to 72 hours to avoid health check
+			opt := redisRingOptions()
+			opt.HeartbeatFrequency = 72 * time.Hour
+			ring = redis.NewRing(opt)
 		})
+		It("supports Process hook", func() {
+			err := ring.Ping(ctx).Err()
+			Expect(err).NotTo(HaveOccurred())
 
-		ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
-			shard.AddHook(&hook{
+			var stack []string
+
+			ring.AddHook(&hook{
 				beforeProcess: func(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
 					Expect(cmd.String()).To(Equal("ping: "))
-					stack = append(stack, "shard.BeforeProcess")
+					stack = append(stack, "ring.BeforeProcess")
 					return ctx, nil
 				},
 				afterProcess: func(ctx context.Context, cmd redis.Cmder) error {
 					Expect(cmd.String()).To(Equal("ping: PONG"))
-					stack = append(stack, "shard.AfterProcess")
+					stack = append(stack, "ring.AfterProcess")
 					return nil
 				},
 			})
-			return nil
-		})
 
-		err = ring.Ping(ctx).Err()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stack).To(Equal([]string{
-			"ring.BeforeProcess",
-			"shard.BeforeProcess",
-			"shard.AfterProcess",
-			"ring.AfterProcess",
-		}))
-	})
-
-	It("supports Pipeline hook", func() {
-		err := ring.Ping(ctx).Err()
-		Expect(err).NotTo(HaveOccurred())
-
-		var stack []string
-
-		ring.AddHook(&hook{
-			beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
-				Expect(cmds).To(HaveLen(1))
-				Expect(cmds[0].String()).To(Equal("ping: "))
-				stack = append(stack, "ring.BeforeProcessPipeline")
-				return ctx, nil
-			},
-			afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
-				Expect(cmds).To(HaveLen(1))
-				Expect(cmds[0].String()).To(Equal("ping: PONG"))
-				stack = append(stack, "ring.AfterProcessPipeline")
+			ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
+				shard.AddHook(&hook{
+					beforeProcess: func(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+						Expect(cmd.String()).To(Equal("ping: "))
+						stack = append(stack, "shard.BeforeProcess")
+						return ctx, nil
+					},
+					afterProcess: func(ctx context.Context, cmd redis.Cmder) error {
+						Expect(cmd.String()).To(Equal("ping: PONG"))
+						stack = append(stack, "shard.AfterProcess")
+						return nil
+					},
+				})
 				return nil
-			},
+			})
+
+			err = ring.Ping(ctx).Err()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stack).To(Equal([]string{
+				"ring.BeforeProcess",
+				"shard.BeforeProcess",
+				"shard.AfterProcess",
+				"ring.AfterProcess",
+			}))
 		})
 
-		ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
-			shard.AddHook(&hook{
+		It("supports Pipeline hook", func() {
+			err := ring.Ping(ctx).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			var stack []string
+
+			ring.AddHook(&hook{
 				beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
 					Expect(cmds).To(HaveLen(1))
 					Expect(cmds[0].String()).To(Equal("ping: "))
-					stack = append(stack, "shard.BeforeProcessPipeline")
+					stack = append(stack, "ring.BeforeProcessPipeline")
 					return ctx, nil
 				},
 				afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
 					Expect(cmds).To(HaveLen(1))
 					Expect(cmds[0].String()).To(Equal("ping: PONG"))
-					stack = append(stack, "shard.AfterProcessPipeline")
+					stack = append(stack, "ring.AfterProcessPipeline")
 					return nil
 				},
 			})
-			return nil
-		})
 
-		_, err = ring.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.Ping(ctx)
-			return nil
-		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stack).To(Equal([]string{
-			"ring.BeforeProcessPipeline",
-			"shard.BeforeProcessPipeline",
-			"shard.AfterProcessPipeline",
-			"ring.AfterProcessPipeline",
-		}))
-	})
-
-	It("supports TxPipeline hook", func() {
-		err := ring.Ping(ctx).Err()
-		Expect(err).NotTo(HaveOccurred())
-
-		var stack []string
-
-		ring.AddHook(&hook{
-			beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
-				Expect(cmds).To(HaveLen(1))
-				Expect(cmds[0].String()).To(Equal("ping: "))
-				stack = append(stack, "ring.BeforeProcessPipeline")
-				return ctx, nil
-			},
-			afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
-				Expect(cmds).To(HaveLen(1))
-				Expect(cmds[0].String()).To(Equal("ping: PONG"))
-				stack = append(stack, "ring.AfterProcessPipeline")
+			ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
+				shard.AddHook(&hook{
+					beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+						Expect(cmds).To(HaveLen(1))
+						Expect(cmds[0].String()).To(Equal("ping: "))
+						stack = append(stack, "shard.BeforeProcessPipeline")
+						return ctx, nil
+					},
+					afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
+						Expect(cmds).To(HaveLen(1))
+						Expect(cmds[0].String()).To(Equal("ping: PONG"))
+						stack = append(stack, "shard.AfterProcessPipeline")
+						return nil
+					},
+				})
 				return nil
-			},
+			})
+
+			_, err = ring.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Ping(ctx)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stack).To(Equal([]string{
+				"ring.BeforeProcessPipeline",
+				"shard.BeforeProcessPipeline",
+				"shard.AfterProcessPipeline",
+				"ring.AfterProcessPipeline",
+			}))
 		})
 
-		ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
-			shard.AddHook(&hook{
+		It("supports TxPipeline hook", func() {
+			err := ring.Ping(ctx).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			var stack []string
+
+			ring.AddHook(&hook{
 				beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
-					Expect(cmds).To(HaveLen(3))
-					Expect(cmds[1].String()).To(Equal("ping: "))
-					stack = append(stack, "shard.BeforeProcessPipeline")
+					Expect(cmds).To(HaveLen(1))
+					Expect(cmds[0].String()).To(Equal("ping: "))
+					stack = append(stack, "ring.BeforeProcessPipeline")
 					return ctx, nil
 				},
 				afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
-					Expect(cmds).To(HaveLen(3))
-					Expect(cmds[1].String()).To(Equal("ping: PONG"))
-					stack = append(stack, "shard.AfterProcessPipeline")
+					Expect(cmds).To(HaveLen(1))
+					Expect(cmds[0].String()).To(Equal("ping: PONG"))
+					stack = append(stack, "ring.AfterProcessPipeline")
 					return nil
 				},
 			})
-			return nil
-		})
 
-		_, err = ring.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.Ping(ctx)
-			return nil
+			ring.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
+				shard.AddHook(&hook{
+					beforeProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+						Expect(cmds).To(HaveLen(3))
+						Expect(cmds[1].String()).To(Equal("ping: "))
+						stack = append(stack, "shard.BeforeProcessPipeline")
+						return ctx, nil
+					},
+					afterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) error {
+						Expect(cmds).To(HaveLen(3))
+						Expect(cmds[1].String()).To(Equal("ping: PONG"))
+						stack = append(stack, "shard.AfterProcessPipeline")
+						return nil
+					},
+				})
+				return nil
+			})
+
+			_, err = ring.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Ping(ctx)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stack).To(Equal([]string{
+				"ring.BeforeProcessPipeline",
+				"shard.BeforeProcessPipeline",
+				"shard.AfterProcessPipeline",
+				"ring.AfterProcessPipeline",
+			}))
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stack).To(Equal([]string{
-			"ring.BeforeProcessPipeline",
-			"shard.BeforeProcessPipeline",
-			"shard.AfterProcessPipeline",
-			"ring.AfterProcessPipeline",
-		}))
 	})
 })
 


### PR DESCRIPTION
fix the possible `data race`, details:

WARNING: DATA RACE
Read at 0x00c000302618 by goroutine 27:
  github.com/go-redis/redis/v8_test.glob..func20.11.3.2()
      /redis/ring_test.go:219 +0x1a4
  github.com/go-redis/redis/v8_test.(*hook).AfterProcess()
      /redis/main_test.go:429 +0x9a
  github.com/go-redis/redis/v8.hooks.process()
      /redis/redis.go:81 +0x24a
  github.com/go-redis/redis/v8.(*Client).Process()
      /redis/redis.go:617 +0x215
  github.com/go-redis/redis/v8.(*Ring).process()
      /redis/ring.go:603 +0x14e
  github.com/go-redis/redis/v8.(*Ring).process-fm()
      /redis/ring.go:589 +0x7e
  github.com/go-redis/redis/v8.hooks.process.func2()
      /redis/redis.go:75 +0x326
  github.com/go-redis/redis/v8.hooks.withContext()
      /redis/redis.go:134 +0x2e7
  github.com/go-redis/redis/v8.hooks.process()
      /redis/redis.go:74 +0x2e6
  github.com/go-redis/redis/v8.(*Ring).Process()
      /redis/ring.go:453 +0xdc
  github.com/go-redis/redis/v8.(*Ring).Process-fm()
      /redis/ring.go:452 +0x33
  github.com/go-redis/redis/v8.cmdable.Ping()
      /redis/commands.go:425 +0x16e
  github.com/go-redis/redis/v8_test.glob..func20.11()
      /redis/ring_test.go:226 +0x624
  ..............
  ..............
  ..............
  github.com/go-redis/redis/v8_test.TestGinkgoSuite()
      /redis/main_test.go:117 +0x108
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1194 +0x202

Previous write at 0x00c000302618 by goroutine 118:
  github.com/go-redis/redis/v8_test.glob..func20.11.3.2()
      /redis/ring_test.go:219 +0x22b
  github.com/go-redis/redis/v8_test.(*hook).AfterProcess()
      /redis/main_test.go:429 +0x9a
  github.com/go-redis/redis/v8.hooks.process()
      /redis/redis.go:81 +0x24a
  github.com/go-redis/redis/v8.(*Client).Process()
      /redis/redis.go:617 +0xed
  github.com/go-redis/redis/v8.(*Client).Process-fm()
      /redis/redis.go:616 +0x33
  github.com/go-redis/redis/v8.cmdable.Ping()
      /redis/commands.go:425 +0x16e
  github.com/go-redis/redis/v8.(*ringShards).Heartbeat()
      /redis/ring.go:317 +0x1a6