### PR TITLE
fix test error

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -344,9 +344,11 @@ func startSentinel(port, masterName, masterPort string) (*redisProcess, error) {
 		return nil, err
 	}
 
+	// set down-after-milliseconds=2000
+	// link: https://github.com/redis/redis/issues/8607
 	for _, cmd := range []*redis.StatusCmd{
 		redis.NewStatusCmd(ctx, "SENTINEL", "MONITOR", masterName, "127.0.0.1", masterPort, "2"),
-		redis.NewStatusCmd(ctx, "SENTINEL", "SET", masterName, "down-after-milliseconds", "500"),
+		redis.NewStatusCmd(ctx, "SENTINEL", "SET", masterName, "down-after-milliseconds", "2000"),
 		redis.NewStatusCmd(ctx, "SENTINEL", "SET", masterName, "failover-timeout", "1000"),
 		redis.NewStatusCmd(ctx, "SENTINEL", "SET", masterName, "parallel-syncs", "1"),
 	} {

--- a/race_test.go
+++ b/race_test.go
@@ -308,7 +308,8 @@ var _ = Describe("races", func() {
 				Streams: []string{"test", "$"},
 				Block:   1 * time.Second,
 			}).Result()
-			Expect(err).To(Equal(context.Canceled))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Or(Equal(context.Canceled.Error()), ContainSubstring("operation was canceled")))
 		})
 
 		time.Sleep(10 * time.Millisecond)

--- a/redis_test.go
+++ b/redis_test.go
@@ -243,12 +243,16 @@ var _ = Describe("Client", func() {
 		cn, err := client.Pool().Get(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cn.UsedAt).NotTo(BeZero())
+
+		// set cn.SetUsedAt(time) or time.Sleep(>1*time.Second)
+		// simulate the last time Conn was used
+		// time.Sleep() is not the standard sleep time
+		// link: https://go-review.googlesource.com/c/go/+/232298
+		cn.SetUsedAt(time.Now().Add(-1 * time.Second))
 		createdAt := cn.UsedAt()
 
 		client.Pool().Put(ctx, cn)
 		Expect(cn.UsedAt().Equal(createdAt)).To(BeTrue())
-
-		time.Sleep(time.Second)
 
 		err = client.Ping(ctx).Err()
 		Expect(err).NotTo(HaveOccurred())

--- a/sentinel.go
+++ b/sentinel.go
@@ -317,6 +317,16 @@ func (c *SentinelClient) GetMasterAddrByName(ctx context.Context, name string) *
 	return cmd
 }
 
+func (c *SentinelClient) GetSlavesAddrByName(ctx context.Context, name string) []string {
+	addrs, err := c.Slaves(ctx, name).Result()
+	if err != nil {
+		internal.Logger.Printf(ctx, "sentinel: Slaves name=%q failed: %s",
+			name, err)
+		return []string{}
+	}
+	return parseSlaveAddrs(addrs, false)
+}
+
 func (c *SentinelClient) Sentinels(ctx context.Context, name string) *SliceCmd {
 	cmd := NewSliceCmd(ctx, "sentinel", "sentinels", name)
 	_ = c.Process(ctx, cmd)


### PR DESCRIPTION
Fix possible unit test errors:

```go
• Failure [1.005 seconds]
Client
/redis/redis_test.go:50
  should update conn.UsedAt on read/write [It]
  /redis/redis_test.go:242

  Expected
      <bool>: false
  to be true

  /redis/redis_test.go:259
```

```go
• Failure in Spec Setup (BeforeEach) [0.011 seconds]
Sentinel
/redis/sentinel_test.go:12
  supports DB selection [BeforeEach]
  /redis/sentinel_test.go:94

  Unexpected error:
      <*net.OpError | 0xc0009fb1d0>: {
          Op: "dial",
          Net: "tcp",
          Source: nil,
          Addr: {
              IP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1],
              Port: 9125,
              Zone: "",
          },
          Err: {Syscall: "connect", Err: 0x6f},
      }
      dial tcp 127.0.0.1:9125: connect: connection refused
  occurred

  /redis/sentinel_test.go:23
```

```go
• Failure [15.015 seconds]
Sentinel
/redis/sentinel_test.go:12
  should facilitate failover [It]
  /redis/sentinel_test.go:56

  Timed out after 15.001s.
  Expected
      <string>: 
  to equal
      <string>: master

  /redis/sentinel_test.go:79
```

```go
• Failure [0.024 seconds]
races
/redis/race_test.go:19
  should abort on context timeout [It]
  /redis/race_test.go:303

  Expected
      <*net.OpError | 0xc000303590>: {
          Op: "dial",
          Net: "tcp",
          Source: nil,
          Addr: {
              IP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1],
              Port: 8223,
              Zone: "",
          },
          Err: {
              s: "operation was canceled",
          },
      }
  to equal
      <*errors.errorString | 0xc0000302a0>: {
          s: "context canceled",
      }

  /redis/race_test.go:314
```