### PR TITLE
discoverSentinels read the addr field incorrectly

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -666,15 +666,22 @@ func (c *sentinelFailover) discoverSentinels(ctx context.Context) {
 	}
 	for _, sentinel := range sentinels {
 		vals := sentinel.([]interface{})
+		var ip, port string
 		for i := 0; i < len(vals); i += 2 {
 			key := vals[i].(string)
-			if key == "name" {
-				sentinelAddr := vals[i+1].(string)
-				if !contains(c.sentinelAddrs, sentinelAddr) {
-					internal.Logger.Printf(ctx, "sentinel: discovered new sentinel=%q for master=%q",
-						sentinelAddr, c.opt.MasterName)
-					c.sentinelAddrs = append(c.sentinelAddrs, sentinelAddr)
-				}
+			switch key {
+			case "ip":
+				ip = vals[i+1].(string)
+			case "port":
+				port = vals[i+1].(string)
+			}
+		}
+		if ip != "" && port != "" {
+			sentinelAddr := net.JoinHostPort(ip, port)
+			if !contains(c.sentinelAddrs, sentinelAddr) {
+				internal.Logger.Printf(ctx, "sentinel: discovered new sentinel=%q for master=%q",
+					sentinelAddr, c.opt.MasterName)
+				c.sentinelAddrs = append(c.sentinelAddrs, sentinelAddr)
 			}
 		}
 	}


### PR DESCRIPTION
why is the value of name used as addr here, it should be wrong.

```go
func (c *sentinelFailover) discoverSentinels(ctx context.Context) {
	sentinels, err := c.sentinel.Sentinels(ctx, c.opt.MasterName).Result()
	if err != nil {
		internal.Logger.Printf(ctx, "sentinel: Sentinels master=%q failed: %s", c.opt.MasterName, err)
		return
	}
	for _, sentinel := range sentinels {
		vals := sentinel.([]interface{})
		for i := 0; i < len(vals); i += 2 {
			key := vals[i].(string)
			if key == "name" {
				sentinelAddr := vals[i+1].(string)
				if !contains(c.sentinelAddrs, sentinelAddr) {
					internal.Logger.Printf(ctx, "sentinel: discovered new sentinel=%q for master=%q",
						sentinelAddr, c.opt.MasterName)
					c.sentinelAddrs = append(c.sentinelAddrs, sentinelAddr)
				}
			}
		}
	}
}

```
--------------------------------------
In the https://travis-ci.org/github/go-redis/redis/jobs/762609013 error, I found this warning and should fix it:

```go
redis: 2021/03/12 14:19:58 sentinel.go:496: sentinel: GetMasterAddrByName master="mymaster" failed: dial tcp: address 6fad22cac5057c835d0fbed2109e79d2cfcdf786: missing port in address
redis: 2021/03/12 14:19:58 sentinel.go:496: sentinel: GetMasterAddrByName master="mymaster" failed: dial tcp: address 4526c88b99115ad2a7a4e404a2fcbd56831bff27: missing port in address
redis: 2021/03/12 14:19:58 sentinel.go:496: sentinel: GetMasterAddrByName master="mymaster" failed: dial tcp: address 6cfdae94306d2cc06fcffacb0f29ded7155aecf4: missing port in address
```

Signed-off-by: monkey <golang@88.com>