### PR TITLE
fix test error

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -457,6 +457,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Object", func() {
+			start := time.Now()
 			set := client.Set(ctx, "key", "hello", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -470,7 +471,13 @@ var _ = Describe("Commands", func() {
 
 			idleTime := client.ObjectIdleTime(ctx, "key")
 			Expect(idleTime.Err()).NotTo(HaveOccurred())
-			Expect(idleTime.Val()).To(Equal(time.Duration(0)))
+
+			//Redis returned milliseconds/1000, which may cause ObjectIdleTime to be at a critical value,
+			//should be +1s to deal with the critical value problem.
+			//if too much time (>1s) is used during command execution, it may also cause the test to fail.
+			//so the ObjectIdleTime result should be <=now-start+1s
+			//link: https://github.com/redis/redis/blob/5b48d900498c85bbf4772c1d466c214439888115/src/object.c#L1265-L1272
+			Expect(idleTime.Val()).To(BeNumerically("<=", time.Now().Sub(start) + time.Second))
 		})
 
 		It("should Persist", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -1465,7 +1465,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetEX", func() {
-			err := client.SetEX(ctx, "key", "hello", 100*time.Millisecond).Err()
+			err := client.SetEX(ctx, "key", "hello", 1*time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			val, err := client.Get(ctx, "key").Result()
@@ -1474,7 +1474,7 @@ var _ = Describe("Commands", func() {
 
 			Eventually(func() error {
 				return client.Get(ctx, "foo").Err()
-			}, "1s", "100ms").Should(Equal(redis.Nil))
+			}, "2s", "100ms").Should(Equal(redis.Nil))
 		})
 
 		It("should SetNX", func() {


### PR DESCRIPTION
fix test error:

The critical value of time may appear to cause test errors, link: https://github.com/redis/redis/blob/5b48d900498c85bbf4772c1d466c214439888115/src/object.c#L1265-L1272
```go
• Failure [0.068 seconds]
Commands
/redis/commands_test.go:17
  keys
  /redis/commands_test.go:304
    should Object [It]
    /redis/commands_test.go:462

    Expected
        <time.Duration>: 1000000000
    to equal
        <time.Duration>: 0

    /redis/commands_test.go:473
```
--------------------------------------------------------------

In addition, I tracked down more test errors: `CLUSTERDOWN The cluster is down`.
but I can't determine the cause for the time being. It may be redis-server instability or go-redis cluster problems. I will keep track of them.

I still can't reproduce https://github.com/go-redis/redis/issues/1657, maybe it's a problem with my test environment?
The go developers said that it might be a problem with pool: sync.pool{}, but they can’t confirm it. 
We can wait for the go developers’ investigation results, link: https://github.com/golang/go/issues/44672