### PR TITLE
sentinel: removed unused field QuerySentinelRandomly

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -40,8 +40,6 @@ type FailoverOptions struct {
 	// Now, this option only works in RandomSlaveAddr function.
 	UseDisconnectedSlaves bool
 
-	// Client queries sentinels in a random order
-	QuerySentinelRandomly bool
 	// Following options are copied from Options struct.
 
 	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)


### PR DESCRIPTION
Introduced in 8b19c310495637fb61e2b237abdedca922aced9a but all references were removed in 8d9ebc8459c6d3925c61ce3da78ac17118a118fd