### PR TITLE
support resp3 protocol

### DIFF
--- a/bench_decode_test.go
+++ b/bench_decode_test.go
@@ -18,14 +18,17 @@ type ClientStub struct {
 	resp []byte
 }
 
+var initHello = []byte("%1\r\n+proto\r\n:3\r\n")
+
 func NewClientStub(resp []byte) *ClientStub {
 	stub := &ClientStub{
 		resp: resp,
 	}
+
 	stub.Cmdable = NewClient(&Options{
 		PoolSize: 128,
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return stub.stubConn(), nil
+			return stub.stubConn(initHello), nil
 		},
 	})
 	return stub
@@ -40,7 +43,7 @@ func NewClusterClientStub(resp []byte) *ClientStub {
 		PoolSize: 128,
 		Addrs:    []string{"127.0.0.1:6379"},
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return stub.stubConn(), nil
+			return stub.stubConn(initHello), nil
 		},
 		ClusterSlots: func(_ context.Context) ([]ClusterSlot, error) {
 			return []ClusterSlot{
@@ -65,18 +68,27 @@ func NewClusterClientStub(resp []byte) *ClientStub {
 	return stub
 }
 
-func (c *ClientStub) stubConn() *ConnStub {
+func (c *ClientStub) stubConn(init []byte) *ConnStub {
 	return &ConnStub{
+		init: init,
 		resp: c.resp,
 	}
 }
 
 type ConnStub struct {
+	init []byte
 	resp []byte
 	pos  int
 }
 
 func (c *ConnStub) Read(b []byte) (n int, err error) {
+	// Return conn.init()
+	if len(c.init) > 0 {
+		n = copy(b, c.init)
+		c.init = c.init[n:]
+		return n, nil
+	}
+
 	if len(c.resp) == 0 {
 		return 0, io.EOF
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -1384,7 +1384,7 @@ func (c *ClusterClient) txPipelineReadQueued(
 	}
 
 	// Parse number of replies.
-	line, err := rd.ReadLine()
+	line, err := rd.Pathfinder()
 	if err != nil {
 		if err == Nil {
 			err = TxFailedErr
@@ -1392,12 +1392,7 @@ func (c *ClusterClient) txPipelineReadQueued(
 		return err
 	}
 
-	switch line[0] {
-	case proto.ErrorReply:
-		return proto.ParseErrorReply(line)
-	case proto.ArrayReply:
-		// ok
-	default:
+	if line[0] != proto.RespArray {
 		return fmt.Errorf("redis: expected '*', but got line %q", line)
 	}
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1182,16 +1182,17 @@ var _ = Describe("ClusterClient with unavailable Cluster", func() {
 	var client *redis.ClusterClient
 
 	BeforeEach(func() {
-		for _, node := range cluster.clients {
-			err := node.ClientPause(ctx, 5*time.Second).Err()
-			Expect(err).NotTo(HaveOccurred())
-		}
-
 		opt := redisClusterOptions()
 		opt.ReadTimeout = 250 * time.Millisecond
 		opt.WriteTimeout = 250 * time.Millisecond
 		opt.MaxRedirects = 1
 		client = cluster.newClusterClientUnstable(opt)
+		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+
+		for _, node := range cluster.clients {
+			err := node.ClientPause(ctx, 5*time.Second).Err()
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {

--- a/example_test.go
+++ b/example_test.go
@@ -615,7 +615,7 @@ func ExampleClient_SlowLogGet() {
 
 	old := rdb.ConfigGet(ctx, key).Val()
 	rdb.ConfigSet(ctx, key, "0")
-	defer rdb.ConfigSet(ctx, key, old[1].(string))
+	defer rdb.ConfigSet(ctx, key, old[key])
 
 	if err := rdb.Do(ctx, "slowlog", "reset").Err(); err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-redis/redis/v8
 
-go 1.13
+go 1.14
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -38,6 +38,10 @@ func NewConn(netConn net.Conn) *Conn {
 	return cn
 }
 
+func (cn *Conn) SetResp(v int) {
+	cn.rd.SetResp(v)
+}
+
 func (cn *Conn) UsedAt() time.Time {
 	unix := atomic.LoadInt64(&cn.usedAt)
 	return time.Unix(unix, 0)

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -86,6 +86,7 @@ func (r *Reader) Reset(rd io.Reader) {
 	r.rd.Reset(rd)
 }
 
+// ReadLine may return unexpected attribute types, it is best to use Pathfinder.
 func (r *Reader) ReadLine() ([]byte, error) {
 	return r.readLine()
 }
@@ -162,14 +163,6 @@ func (r *Reader) ReadReply(a AggregateBulkParse) (interface{}, error) {
 			return nil, fmt.Errorf("redis: got %.100q, but multi bulk parser is nil", line)
 		}
 		return a(r, line[0], int64(n))
-	case RespAttr:
-		// Ignore the attribute type, it is generally used by redis-cli.
-		if err = r.Discard(line); err != nil {
-			return nil, err
-		}
-
-		// read data
-		return r.ReadReply(a)
 	}
 	return nil, fmt.Errorf("redis: can't parse %.100q", line)
 }
@@ -231,7 +224,7 @@ func (r *Reader) readVerb(line []byte) (string, error) {
 
 // -------------------------------
 
-// Pathfinder find up possible errors in redis responses and discard attr attributes,
+// Pathfinder find up possible errors in redis responses and discard attributes types,
 // `line` that returns the true reply.
 func (r *Reader) Pathfinder() ([]byte, error) {
 	line, err := r.readLine()

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -4,17 +4,35 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
+	"strconv"
 
 	"github.com/go-redis/redis/v8/internal/util"
 )
 
 const (
-	ErrorReply  = '-'
-	StatusReply = '+'
-	IntReply    = ':'
-	StringReply = '$'
-	ArrayReply  = '*'
+	RespStatus    = '+' // +<string>\r\n
+	RespError     = '-' // -<string>\r\n
+	RespString    = '$' // $<length>\r\n<bytes>\r\n
+	RespInteger   = ':' // :<number>\r\n
+	RespNil       = '_' // _\r\n
+	RespFloat     = ',' // ,<floating-point-number>\r\n (golang float)
+	RespBool      = '#' // true: #t\r\n false: #f\r\n
+	RespBlobError = '!' // !<length>\r\n<bytes>\r\n
+	RespVerb      = '=' // =<length>\r\nFORMAT:<bytes>\r\n
+	RespBigInt    = '(' // (<big number>\r\n
+	RespArray     = '*' // *<len>\r\n... (same as resp2)
+	RespMap       = '%' // %<len>\r\n(key)\r\n(value)\r\n... (golang map)
+	RespSet       = '~' // ~<len>\r\n... (same as Array)
+	RespAttr      = '|' // |<len>\r\n(key)\r\n(value)\r\n... + command reply
+	RespPush      = '>' // ><len>\r\n... (same as Array)
 )
+
+// Not used temporarily.
+// Redis has not used these two data types for the time being, and will implement them later.
+// Streamed           = "EOF:"
+// StreamedAggregated = '?'
 
 //------------------------------------------------------------------------------
 
@@ -28,18 +46,32 @@ func (RedisError) RedisError() {}
 
 //------------------------------------------------------------------------------
 
-type MultiBulkParse func(*Reader, int64) (interface{}, error)
+var (
+	uvinf    = math.Inf(1)
+	uvneginf = math.Inf(-1)
+)
+
+type (
+	AggregateBulkParse func(*Reader, byte, int64) (interface{}, error)
+	MultiBulkParse     func(*Reader, int64) (interface{}, error)
+)
 
 type Reader struct {
-	rd   *bufio.Reader
-	_buf []byte
+	rd *bufio.Reader
+
+	// redis.RESP version
+	Resp int
 }
 
 func NewReader(rd io.Reader) *Reader {
 	return &Reader{
 		rd:   bufio.NewReader(rd),
-		_buf: make([]byte, 64),
+		Resp: 2,
 	}
+}
+
+func (r *Reader) SetResp(v int) {
+	r.Resp = v
 }
 
 func (r *Reader) Buffered() int {
@@ -55,14 +87,16 @@ func (r *Reader) Reset(rd io.Reader) {
 }
 
 func (r *Reader) ReadLine() ([]byte, error) {
-	line, err := r.readLine()
+	return r.readLine()
+}
+
+// NextType get the data type of the next row.
+func (r *Reader) NextType() (byte, error) {
+	b, err := r.rd.Peek(1)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	if isNilReply(line) {
-		return nil, Nil
-	}
-	return line, nil
+	return b[0], nil
 }
 
 // readLine that returns an error if:
@@ -92,240 +126,385 @@ func (r *Reader) readLine() ([]byte, error) {
 	return b[:len(b)-2], nil
 }
 
-func (r *Reader) ReadReply(m MultiBulkParse) (interface{}, error) {
-	line, err := r.ReadLine()
+func (r *Reader) ReadReply(a AggregateBulkParse) (interface{}, error) {
+	line, err := r.Pathfinder()
 	if err != nil {
 		return nil, err
 	}
 
 	switch line[0] {
-	case ErrorReply:
-		return nil, ParseErrorReply(line)
-	case StatusReply:
+	case RespStatus:
 		return string(line[1:]), nil
-	case IntReply:
+	case RespInteger:
 		return util.ParseInt(line[1:], 10, 64)
-	case StringReply:
+	case RespFloat:
+		return r.readFloat(line)
+	case RespBool:
+		return r.readBool(line)
+	case RespBigInt:
+		return r.readBigInt(line)
+	//--------
+
+	case RespString:
 		return r.readStringReply(line)
-	case ArrayReply:
-		n, err := parseArrayLen(line)
+	case RespVerb:
+		return r.readVerb(line)
+
+	//-----------
+
+	case RespArray, RespSet, RespPush, RespMap:
+		var n int
+		n, err = replyLen(line)
 		if err != nil {
 			return nil, err
 		}
-		if m == nil {
-			err := fmt.Errorf("redis: got %.100q, but multi bulk parser is nil", line)
+		if a == nil {
+			return nil, fmt.Errorf("redis: got %.100q, but multi bulk parser is nil", line)
+		}
+		return a(r, line[0], int64(n))
+	case RespAttr:
+		// Ignore the attribute type, it is generally used by redis-cli.
+		if err = r.Discard(line); err != nil {
 			return nil, err
 		}
-		return m(r, n)
+
+		// read data
+		return r.ReadReply(a)
 	}
 	return nil, fmt.Errorf("redis: can't parse %.100q", line)
 }
 
-func (r *Reader) ReadIntReply() (int64, error) {
-	line, err := r.ReadLine()
-	if err != nil {
-		return 0, err
+func (r *Reader) readFloat(line []byte) (float64, error) {
+	v := string(line[1:])
+	switch string(line[1:]) {
+	case "inf":
+		return uvinf, nil
+	case "-inf":
+		return uvneginf, nil
 	}
-	switch line[0] {
-	case ErrorReply:
-		return 0, ParseErrorReply(line)
-	case IntReply:
-		return util.ParseInt(line[1:], 10, 64)
-	default:
-		return 0, fmt.Errorf("redis: can't parse int reply: %.100q", line)
-	}
+	return strconv.ParseFloat(v, 64)
 }
 
-func (r *Reader) ReadString() (string, error) {
-	line, err := r.ReadLine()
-	if err != nil {
-		return "", err
+func (r *Reader) readBool(line []byte) (bool, error) {
+	switch string(line[1:]) {
+	case "t":
+		return true, nil
+	case "f":
+		return false, nil
 	}
-	switch line[0] {
-	case ErrorReply:
-		return "", ParseErrorReply(line)
-	case StringReply:
-		return r.readStringReply(line)
-	case StatusReply:
-		return string(line[1:]), nil
-	case IntReply:
-		return string(line[1:]), nil
-	default:
-		return "", fmt.Errorf("redis: can't parse reply=%.100q reading string", line)
+	return false, fmt.Errorf("redis: can't parse bool reply: %q", line)
+}
+
+func (r *Reader) readBigInt(line []byte) (*big.Int, error) {
+	i := new(big.Int)
+	if i, ok := i.SetString(string(line[1:]), 10); ok {
+		return i, nil
 	}
+	return nil, fmt.Errorf("redis: can't parse bigInt reply: %q", line)
 }
 
 func (r *Reader) readStringReply(line []byte) (string, error) {
-	if isNilReply(line) {
-		return "", Nil
-	}
-
-	replyLen, err := util.Atoi(line[1:])
+	n, err := replyLen(line)
 	if err != nil {
 		return "", err
 	}
 
-	b := make([]byte, replyLen+2)
+	b := make([]byte, n+2)
 	_, err = io.ReadFull(r.rd, b)
 	if err != nil {
 		return "", err
 	}
 
-	return util.BytesToString(b[:replyLen]), nil
+	return util.BytesToString(b[:n]), nil
 }
 
-func (r *Reader) ReadArrayReply(m MultiBulkParse) (interface{}, error) {
-	line, err := r.ReadLine()
+func (r *Reader) readVerb(line []byte) (string, error) {
+	s, err := r.readStringReply(line)
+	if err != nil {
+		return "", err
+	}
+	if len(s) < 4 || s[3] != ':' {
+		return "", fmt.Errorf("redis: can't parse verbatim string reply: %q", line)
+	}
+	return s[4:], nil
+}
+
+// -------------------------------
+
+// Pathfinder find up possible errors in redis responses and discard attr attributes,
+// `line` that returns the true reply.
+func (r *Reader) Pathfinder() ([]byte, error) {
+	line, err := r.readLine()
 	if err != nil {
 		return nil, err
 	}
 	switch line[0] {
-	case ErrorReply:
+	case RespError:
 		return nil, ParseErrorReply(line)
-	case ArrayReply:
-		n, err := parseArrayLen(line)
+	case RespNil:
+		return nil, Nil
+	case RespBlobError:
+		var blobErr string
+		blobErr, err = r.readStringReply(line)
+		if err == nil {
+			err = RedisError(blobErr)
+		}
+		return nil, err
+	case RespAttr:
+		if err = r.Discard(line); err != nil {
+			return nil, err
+		}
+		return r.Pathfinder()
+	}
+
+	// Compatible with RESP2
+	if IsNilReply(line) {
+		return nil, Nil
+	}
+
+	return line, nil
+}
+
+func (r *Reader) ReadInt() (int64, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return 0, err
+	}
+	switch line[0] {
+	case RespInteger, RespStatus:
+		return util.ParseInt(line[1:], 10, 64)
+	case RespString:
+		s, err := r.readStringReply(line)
+		if err != nil {
+			return 0, err
+		}
+		return util.ParseInt([]byte(s), 10, 64)
+	case RespBigInt:
+		b, err := r.readBigInt(line)
+		if err != nil {
+			return 0, err
+		}
+		if !b.IsInt64() {
+			return 0, fmt.Errorf("bigInt(%s) value out of range", b.String())
+		}
+		return b.Int64(), nil
+	}
+	return 0, fmt.Errorf("redis: can't parse int reply: %.100q", line)
+}
+
+func (r *Reader) ReadFloat() (float64, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return 0, err
+	}
+	switch line[0] {
+	case RespFloat:
+		return r.readFloat(line)
+	case RespStatus:
+		return strconv.ParseFloat(string(line[1:]), 64)
+	case RespString:
+		s, err := r.readStringReply(line)
+		if err != nil {
+			return 0, err
+		}
+		return strconv.ParseFloat(s, 64)
+	}
+	return 0, fmt.Errorf("redis: can't parse float reply: %.100q", line)
+}
+
+func (r *Reader) ReadString() (string, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return "", err
+	}
+
+	switch line[0] {
+	case RespStatus, RespInteger, RespFloat:
+		return string(line[1:]), nil
+	case RespString:
+		return r.readStringReply(line)
+	case RespBool:
+		b, err := r.readBool(line)
+		return strconv.FormatBool(b), err
+	case RespVerb:
+		return r.readVerb(line)
+	case RespBigInt:
+		b, err := r.readBigInt(line)
+		if err != nil {
+			return "", err
+		}
+		return b.String(), nil
+	}
+	return "", fmt.Errorf("redis: can't parse reply=%.100q reading string", line)
+}
+
+func (r *Reader) ReadAggregateReply(a AggregateBulkParse) (interface{}, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return nil, err
+	}
+	switch line[0] {
+	case RespArray, RespSet, RespPush, RespMap:
+		n, err := replyLen(line)
 		if err != nil {
 			return nil, err
 		}
-		return m(r, n)
+		return a(r, line[0], int64(n))
 	default:
-		return nil, fmt.Errorf("redis: can't parse array reply: %.100q", line)
+		return nil, fmt.Errorf("redis: can't parse aggregate(array/set/push/map) reply: %.100q", line)
+	}
+}
+
+func (r *Reader) ReadArrayReply(m MultiBulkParse) (interface{}, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return nil, err
+	}
+	switch line[0] {
+	case RespArray, RespSet, RespPush:
+		n, err := replyLen(line)
+		if err != nil {
+			return nil, err
+		}
+		return m(r, int64(n))
+	default:
+		return nil, fmt.Errorf("redis: can't parse array(array/set/push) reply: %.100q", line)
+	}
+}
+
+func (r *Reader) ReadMapReply(m MultiBulkParse) (interface{}, error) {
+	line, err := r.Pathfinder()
+	if err != nil {
+		return nil, err
+	}
+	switch line[0] {
+	case RespMap:
+		n, err := replyLen(line)
+		if err != nil {
+			return nil, err
+		}
+		return m(r, int64(n))
+	case RespArray, RespSet, RespPush:
+		n, err := replyLen(line)
+		if err != nil {
+			return nil, err
+		}
+		return m(r, int64(n/2))
+	default:
+		return nil, fmt.Errorf("redis: can't parse map reply: %.100q", line)
 	}
 }
 
 func (r *Reader) ReadArrayLen() (int, error) {
-	line, err := r.ReadLine()
+	line, err := r.Pathfinder()
 	if err != nil {
 		return 0, err
 	}
 	switch line[0] {
-	case ErrorReply:
-		return 0, ParseErrorReply(line)
-	case ArrayReply:
-		n, err := parseArrayLen(line)
+	case RespArray, RespSet, RespPush:
+		n, err := replyLen(line)
 		if err != nil {
 			return 0, err
 		}
-		return int(n), nil
+		return n, nil
 	default:
-		return 0, fmt.Errorf("redis: can't parse array reply: %.100q", line)
+		return 0, fmt.Errorf("redis: can't parse array(array/set/push) reply: %.100q", line)
 	}
 }
 
-func (r *Reader) ReadScanReply() ([]string, uint64, error) {
-	n, err := r.ReadArrayLen()
-	if err != nil {
-		return nil, 0, err
-	}
-	if n != 2 {
-		return nil, 0, fmt.Errorf("redis: got %d elements in scan reply, expected 2", n)
-	}
-
-	cursor, err := r.ReadUint()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	n, err = r.ReadArrayLen()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	keys := make([]string, n)
-
-	for i := 0; i < n; i++ {
-		key, err := r.ReadString()
-		if err != nil {
-			return nil, 0, err
-		}
-		keys[i] = key
-	}
-
-	return keys, cursor, err
-}
-
-func (r *Reader) ReadInt() (int64, error) {
-	b, err := r.readTmpBytesReply()
+func (r *Reader) ReadMapLen() (int, error) {
+	line, err := r.Pathfinder()
 	if err != nil {
 		return 0, err
-	}
-	return util.ParseInt(b, 10, 64)
-}
-
-func (r *Reader) ReadUint() (uint64, error) {
-	b, err := r.readTmpBytesReply()
-	if err != nil {
-		return 0, err
-	}
-	return util.ParseUint(b, 10, 64)
-}
-
-func (r *Reader) ReadFloatReply() (float64, error) {
-	b, err := r.readTmpBytesReply()
-	if err != nil {
-		return 0, err
-	}
-	return util.ParseFloat(b, 64)
-}
-
-func (r *Reader) readTmpBytesReply() ([]byte, error) {
-	line, err := r.ReadLine()
-	if err != nil {
-		return nil, err
 	}
 	switch line[0] {
-	case ErrorReply:
-		return nil, ParseErrorReply(line)
-	case StringReply:
-		return r._readTmpBytesReply(line)
-	case StatusReply:
-		return line[1:], nil
+	case RespMap:
+		n, err := replyLen(line)
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	case RespArray, RespSet, RespPush:
+		n, err := replyLen(line)
+		if err != nil {
+			return 0, err
+		}
+		return n / 2, nil
 	default:
-		return nil, fmt.Errorf("redis: can't parse string reply: %.100q", line)
+		return 0, fmt.Errorf("redis: can't parse map reply: %.100q", line)
 	}
 }
 
-func (r *Reader) _readTmpBytesReply(line []byte) ([]byte, error) {
-	if isNilReply(line) {
-		return nil, Nil
+// Discard the data represented by line, if line is nil, read the next line.
+func (r *Reader) Discard(line []byte) (err error) {
+	if len(line) == 0 {
+		line, err = r.readLine()
+		if err != nil {
+			return err
+		}
+	}
+	switch line[0] {
+	case RespStatus, RespError, RespInteger, RespNil, RespFloat, RespBool, RespBigInt:
+		return nil
 	}
 
-	replyLen, err := util.Atoi(line[1:])
+	n, err := replyLen(line)
+	if err != nil && err != Nil {
+		return err
+	}
+
+	switch line[0] {
+	case RespBlobError, RespString, RespVerb:
+		// +\r\n
+		_, err = r.rd.Discard(n + 2)
+		return err
+	case RespArray, RespSet, RespPush:
+		for i := 0; i < n; i++ {
+			if err = r.Discard(nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	case RespMap, RespAttr:
+		// Read key & value.
+		for i := 0; i < n*2; i++ {
+			if err = r.Discard(nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return fmt.Errorf("redis: can't parse %.100q", line)
+}
+
+func replyLen(line []byte) (n int, err error) {
+	n, err = util.Atoi(line[1:])
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	buf := r.buf(replyLen + 2)
-	_, err = io.ReadFull(r.rd, buf)
-	if err != nil {
-		return nil, err
+	if n < -1 {
+		return 0, fmt.Errorf("redis: invalid reply: %q", line)
 	}
 
-	return buf[:replyLen], nil
+	switch line[0] {
+	case RespString, RespVerb, RespBlobError,
+		RespArray, RespSet, RespPush, RespMap, RespAttr:
+		if n == -1 {
+			return 0, Nil
+		}
+	}
+	return n, nil
 }
 
-func (r *Reader) buf(n int) []byte {
-	if n <= cap(r._buf) {
-		return r._buf[:n]
-	}
-	d := n - cap(r._buf)
-	r._buf = append(r._buf, make([]byte, d)...)
-	return r._buf
-}
-
-func isNilReply(b []byte) bool {
-	return len(b) == 3 &&
-		(b[0] == StringReply || b[0] == ArrayReply) &&
-		b[1] == '-' && b[2] == '1'
+// IsNilReply detect redis.Nil of RESP2.
+func IsNilReply(line []byte) bool {
+	return len(line) == 3 &&
+		(line[0] == RespString || line[0] == RespArray) &&
+		line[1] == '-' && line[2] == '1'
 }
 
 func ParseErrorReply(line []byte) error {
-	return RedisError(string(line[1:]))
-}
-
-func parseArrayLen(line []byte) (int64, error) {
-	if isNilReply(line) {
-		return 0, Nil
-	}
-	return util.ParseInt(line[1:], 10, 64)
+	return RedisError(line[1:])
 }

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -16,16 +16,56 @@ func BenchmarkReader_ParseReply_Int(b *testing.B) {
 	benchmarkParseReply(b, ":1\r\n", nil, false)
 }
 
+func BenchmarkReader_ParseReply_Float(b *testing.B) {
+	benchmarkParseReply(b, ",123.456\r\n", nil, false)
+}
+
+func BenchmarkReader_ParseReply_Bool(b *testing.B) {
+	benchmarkParseReply(b, "#t\r\n", nil, false)
+}
+
+func BenchmarkReader_ParseReply_BigInt(b *testing.B) {
+	benchmarkParseReply(b, "(3492890328409238509324850943850943825024385\r\n", nil, false)
+}
+
 func BenchmarkReader_ParseReply_Error(b *testing.B) {
 	benchmarkParseReply(b, "-Error message\r\n", nil, true)
+}
+
+func BenchmarkReader_ParseReply_Nil(b *testing.B) {
+	benchmarkParseReply(b, "_\r\n", nil, true)
+}
+
+func BenchmarkReader_ParseReply_BlobError(b *testing.B) {
+	benchmarkParseReply(b, "!21\r\nSYNTAX invalid syntax", nil, true)
 }
 
 func BenchmarkReader_ParseReply_String(b *testing.B) {
 	benchmarkParseReply(b, "$5\r\nhello\r\n", nil, false)
 }
 
+func BenchmarkReader_ParseReply_Verb(b *testing.B) {
+	benchmarkParseReply(b, "$9\r\ntxt:hello\r\n", nil, false)
+}
+
 func BenchmarkReader_ParseReply_Slice(b *testing.B) {
-	benchmarkParseReply(b, "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", multiBulkParse, false)
+	benchmarkParseReply(b, "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", aggregateBulkParse, false)
+}
+
+func BenchmarkReader_ParseReply_Set(b *testing.B) {
+	benchmarkParseReply(b, "~2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", aggregateBulkParse, false)
+}
+
+func BenchmarkReader_ParseReply_Push(b *testing.B) {
+	benchmarkParseReply(b, ">2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", aggregateBulkParse, false)
+}
+
+func BenchmarkReader_ParseReply_Map(b *testing.B) {
+	benchmarkParseReply(b, "%2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", aggregateBulkParse, false)
+}
+
+func BenchmarkReader_ParseReply_Attr(b *testing.B) {
+	benchmarkParseReply(b, "%1\r\n+key\r\n+value\r\n+hello\r\n", aggregateBulkParse, false)
 }
 
 func TestReader_ReadLine(t *testing.T) {
@@ -43,7 +83,7 @@ func TestReader_ReadLine(t *testing.T) {
 	}
 }
 
-func benchmarkParseReply(b *testing.B, reply string, m proto.MultiBulkParse, wanterr bool) {
+func benchmarkParseReply(b *testing.B, reply string, m proto.AggregateBulkParse, wanterr bool) {
 	buf := new(bytes.Buffer)
 	for i := 0; i < b.N; i++ {
 		buf.WriteString(reply)
@@ -59,10 +99,10 @@ func benchmarkParseReply(b *testing.B, reply string, m proto.MultiBulkParse, wan
 	}
 }
 
-func multiBulkParse(p *proto.Reader, n int64) (interface{}, error) {
+func aggregateBulkParse(p *proto.Reader, typ byte, n int64) (interface{}, error) {
 	vv := make([]interface{}, 0, n)
 	for i := int64(0); i < n; i++ {
-		v, err := p.ReadReply(multiBulkParse)
+		v, err := p.ReadReply(aggregateBulkParse)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -34,7 +34,7 @@ func NewWriter(wr writer) *Writer {
 }
 
 func (w *Writer) WriteArgs(args []interface{}) error {
-	if err := w.WriteByte(ArrayReply); err != nil {
+	if err := w.WriteByte(RespArray); err != nil {
 		return err
 	}
 
@@ -111,7 +111,7 @@ func (w *Writer) WriteArg(v interface{}) error {
 }
 
 func (w *Writer) bytes(b []byte) error {
-	if err := w.WriteByte(StringReply); err != nil {
+	if err := w.WriteByte(RespString); err != nil {
 		return err
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -230,21 +230,22 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	}
 	cn.Inited = true
 
-	if c.opt.Password == "" &&
-		c.opt.DB == 0 &&
-		!c.opt.readOnly &&
-		c.opt.OnConnect == nil {
-		return nil
-	}
-
 	ctx, span := internal.StartSpan(ctx, "redis.init_conn")
 	defer span.End()
 
 	connPool := pool.NewSingleConnPool(c.connPool, cn)
 	conn := newConn(ctx, c.opt, connPool)
 
+	var auth bool
+
+	// The low version of redis-server does not support the hello command.
+	if conn.Hello(ctx, 3, c.opt.Username, c.opt.Password, "").Err() == nil {
+		cn.SetResp(3)
+		auth = true
+	}
+
 	_, err := conn.Pipelined(ctx, func(pipe Pipeliner) error {
-		if c.opt.Password != "" {
+		if !auth && c.opt.Password != "" {
 			if c.opt.Username != "" {
 				pipe.AuthACL(ctx, c.opt.Username, c.opt.Password)
 			} else {
@@ -534,7 +535,7 @@ func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) 
 	}
 
 	// Parse number of replies.
-	line, err := rd.ReadLine()
+	line, err := rd.Pathfinder()
 	if err != nil {
 		if err == Nil {
 			err = TxFailedErr
@@ -542,14 +543,8 @@ func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) 
 		return err
 	}
 
-	switch line[0] {
-	case proto.ErrorReply:
-		return proto.ParseErrorReply(line)
-	case proto.ArrayReply:
-		// ok
-	default:
-		err := fmt.Errorf("redis: expected '*', but got line %q", line)
-		return err
+	if line[0] != proto.RespArray {
+		return fmt.Errorf("redis: expected '*', but got line %q", line)
 	}
 
 	return nil

--- a/ring_test.go
+++ b/ring_test.go
@@ -177,6 +177,7 @@ var _ = Describe("Redis Ring", func() {
 		It("can be initialized with a new client callback", func() {
 			opts := redisRingOptions()
 			opts.NewClient = func(name string, opt *redis.Options) *redis.Client {
+				opt.Username = "username1"
 				opt.Password = "password1"
 				return redis.NewClient(opt)
 			}
@@ -184,7 +185,7 @@ var _ = Describe("Redis Ring", func() {
 
 			err := ring.Ping(ctx).Err()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("ERR AUTH"))
+			Expect(err.Error()).To(ContainSubstring("WRONGPASS"))
 		})
 	})
 


### PR DESCRIPTION
Support RESP2 and RESP3 protocols.  On this basis, a richer`Redis server-assisted client side caching` can be achieved

But it breaks the API in v8, should it be merged into v9?
