### PR TITLE
Use the right redis client in tests

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -4677,7 +4677,7 @@ var _ = Describe("Commands", func() {
 			client.ConfigSet(ctx, key, "0")
 			defer client.ConfigSet(ctx, key, old[1].(string))
 
-			err := rdb.Do(ctx, "slowlog", "reset").Err()
+			err := client.Do(ctx, "slowlog", "reset").Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			client.Set(ctx, "test", "true", 0)

--- a/redis_test.go
+++ b/redis_test.go
@@ -290,18 +290,18 @@ var _ = Describe("Client", func() {
 
 	It("should set and scan time", func() {
 		tm := time.Now()
-		err := rdb.Set(ctx, "now", tm, 0).Err()
+		err := client.Set(ctx, "now", tm, 0).Err()
 		Expect(err).NotTo(HaveOccurred())
 
 		var tm2 time.Time
-		err = rdb.Get(ctx, "now").Scan(&tm2)
+		err = client.Get(ctx, "now").Scan(&tm2)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(tm2).To(BeTemporally("==", tm))
 	})
 
 	It("should Conn", func() {
-		err := rdb.Conn(ctx).Get(ctx, "this-key-does-not-exist").Err()
+		err := client.Conn(ctx).Get(ctx, "this-key-does-not-exist").Err()
 		Expect(err).To(Equal(redis.Nil))
 	})
 })


### PR DESCRIPTION
The client used in some tests is mistaken.