### PR TITLE
Allow for custom latency and error handling

### DIFF
--- a/options.go
+++ b/options.go
@@ -109,6 +109,9 @@ type Options struct {
 
 	// Limiter interface used to implemented circuit breaker or rate limiter.
 	Limiter Limiter
+
+	// A function to call during updateLatency instead of the default (ping) to optionally do a more in depth health check
+	LatencyHealthFunc func(c *Client) bool
 }
 
 func (opt *Options) init() {


### PR DESCRIPTION
The standard method of simply calling the PING command does not take
into account failures of the ping method.  The added client option
`LatencyHealthFunc(c *Client) bool` allows for failures to be taken into
account, along with LOADING errors when using persistent Redis.  The
default behavior has been kept exactly the same as before.

Also adds a client option `OnErrFunc(n NodeExt, err error)` that exposes
a very restricted Node interface to a custom function that can mark the
node as failed (or choose not to) based on the error gotten.  E.g. a
connection refused error could cause the node to be marked as failed,
unlike the current client behavior.