### PR TITLE
fix #1758

### DIFF
--- a/command.go
+++ b/command.go
@@ -2040,7 +2040,7 @@ func readXInfoStreamConsumers(rd *proto.Reader) ([]XInfoStreamConsumer, error) {
 
 				c.Pending = make([]XInfoStreamConsumerPending, 0, pendingNumber)
 
-				for f := 0; f < pendingNumber; f++ {
+				for pn := 0; pn < pendingNumber; pn++ {
 					nn, err := rd.ReadArrayLen()
 					if err != nil {
 						return nil, err

--- a/command.go
+++ b/command.go
@@ -1769,8 +1769,14 @@ func xStreamInfoParser(rd *proto.Reader, n int64) (interface{}, error) {
 			info.LastGeneratedID, err = rd.ReadString()
 		case "first-entry":
 			info.FirstEntry, err = readXMessage(rd)
+			if err == Nil {
+				err = nil
+			}
 		case "last-entry":
 			info.LastEntry, err = readXMessage(rd)
+			if err == Nil {
+				err = nil
+			}
 		default:
 			return nil, fmt.Errorf("redis: unexpected content %s "+
 				"in XINFO STREAM reply", key)

--- a/commands_test.go
+++ b/commands_test.go
@@ -4390,6 +4390,26 @@ var _ = Describe("Commands", func() {
 					FirstEntry:      redis.XMessage{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
 					LastEntry:       redis.XMessage{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
 				}))
+
+				// stream is empty
+				n, err := client.XDel(ctx, "stream", "1-0", "2-0", "3-0").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(n).To(Equal(int64(3)))
+
+				res, err = client.XInfoStream(ctx, "stream").Result()
+				Expect(err).NotTo(HaveOccurred())
+				res.RadixTreeKeys = 0
+				res.RadixTreeNodes = 0
+
+				Expect(res).To(Equal(&redis.XInfoStream{
+					Length:          0,
+					RadixTreeKeys:   0,
+					RadixTreeNodes:  0,
+					Groups:          2,
+					LastGeneratedID: "3-0",
+					FirstEntry:      redis.XMessage{},
+					LastEntry:       redis.XMessage{},
+				}))
 			})
 
 			It("should XINFO STREAM FULL", func() {


### PR DESCRIPTION
fix #1758 , and added related tests.

For an empty stream, `first-entry` and `last-entry` are redis.Nil.