### PR TITLE
Improve pubsub

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -425,7 +425,6 @@ func (c *PubSub) getContext() context.Context {
 //
 // go-redis periodically sends ping messages to test connection health
 // and re-subscribes if ping can not not received for 30 seconds.
-// Deprecated: use ChannelMessage(), remove in v9.
 func (c *PubSub) Channel(opts ...ChannelOption) <-chan *Message {
 	c.chOnce.Do(func() {
 		c.msgCh = newChannel(c, opts...)
@@ -451,7 +450,6 @@ func (c *PubSub) ChannelSize(size int) <-chan *Message {
 // reconnections.
 //
 // ChannelWithSubscriptions can not be used together with Channel or ChannelSize.
-// Deprecated: use ChannelSubscriptionMessage(), remove in v9.
 func (c *PubSub) ChannelWithSubscriptions(_ context.Context, size int) <-chan interface{} {
 	c.chOnce.Do(func() {
 		c.allCh = newChannel(c, WithChannelSize(size))
@@ -489,7 +487,7 @@ func WithChannelHealthCheckInterval(d time.Duration) ChannelOption {
 // WithChannelSendTimeout specifies that channel send timeout after which
 // the message is dropped.
 //
-// The default is 30 seconds.
+// The default is 60 seconds.
 func WithChannelSendTimeout(d time.Duration) ChannelOption {
 	return func(c *channel) {
 		c.chanSendTimeout = d

--- a/pubsub.go
+++ b/pubsub.go
@@ -466,7 +466,9 @@ func (c *PubSub) ChannelWithSubscriptions(_ context.Context, size int) <-chan in
 
 type ChannelOption func(c *channel)
 
-// WithChannelSize go-chan size(default 100).
+// WithChannelSize specifies the Go chan size that is used to buffer incoming messages.
+//
+// The default is 100 messages.
 func WithChannelSize(size int) ChannelOption {
 	return func(c *channel) {
 		c.chanSize = size
@@ -481,6 +483,16 @@ func WithChannelSize(size int) ChannelOption {
 func WithChannelHealthCheckInterval(d time.Duration) ChannelOption {
 	return func(c *channel) {
 		c.checkInterval = d
+	}
+}
+
+// WithChannelSendTimeout specifies that channel send timeout after which
+// the message is dropped.
+//
+// The default is 30 seconds.
+func WithChannelSendTimeout(d time.Duration) ChannelOption {
+	return func(c *channel) {
+		c.chanSendTimeout = d
 	}
 }
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -478,7 +478,7 @@ var _ = Describe("PubSub", func() {
 		pubsub := client.Subscribe(ctx, "mychannel")
 		defer pubsub.Close()
 
-		ch := pubsub.ChannelMessage(
+		ch := pubsub.Channel(
 			redis.WithChannelSize(10),
 			redis.WithPingTimeout(time.Second),
 			redis.WithHealthTimeout(time.Minute),

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -473,4 +473,24 @@ var _ = Describe("PubSub", func() {
 			Fail("timeout")
 		}
 	})
+
+	It("should ChannelMessage", func() {
+		pubsub := client.Subscribe(ctx, "mychannel")
+		defer pubsub.Close()
+
+		ch := pubsub.ChannelMessage(
+			redis.WithChannelSize(10),
+			redis.WithPingTimeout(time.Second),
+			redis.WithHealthTimeout(time.Minute),
+		)
+
+		text := "test channel message"
+		err := client.Publish(ctx, "mychannel", text).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		var msg *redis.Message
+		Eventually(ch).Should(Receive(&msg))
+		Expect(msg.Channel).To(Equal("mychannel"))
+		Expect(msg.Payload).To(Equal(text))
+	})
 })

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -480,8 +480,7 @@ var _ = Describe("PubSub", func() {
 
 		ch := pubsub.Channel(
 			redis.WithChannelSize(10),
-			redis.WithPingTimeout(time.Second),
-			redis.WithHealthTimeout(time.Minute),
+			redis.WithChannelHealthCheckInterval(time.Second),
 		)
 
 		text := "test channel message"


### PR DESCRIPTION
Improve pubsub, follow #1747 

ADD `ChannelMessage/ChannelSubscriptionMessage`,  mark `Channel/ChannelSize/ChannelWithSubscriptions` as `Deprecated` and remove it in v9.

Add ping command waiting time (healthTimeout), default 5 seconds.

ADD option: `WithChannelSize` `WithPingTimeout` `WithHealthTimeout`