### PR TITLE
Add XAutoClaim command

### DIFF
--- a/command.go
+++ b/command.go
@@ -1602,7 +1602,7 @@ func (cmd *XAutoClaimJustIDCmd) readReply(rd *proto.Reader) error {
 			return nil, err
 		}
 
-		cmd.val = make([]string, n)
+		cmd.val = make([]string, nn)
 		for i := 0; i < nn; i++ {
 			cmd.val[i], err = rd.ReadString()
 			if err != nil {

--- a/command.go
+++ b/command.go
@@ -1501,6 +1501,121 @@ func (cmd *XPendingExtCmd) readReply(rd *proto.Reader) error {
 
 //------------------------------------------------------------------------------
 
+type XAutoClaim struct {
+	ID       string
+	Messages []XMessage
+}
+
+type XAutoClaimCmd struct {
+	baseCmd
+	val XAutoClaim
+}
+
+var _ Cmder = (*XAutoClaimCmd)(nil)
+
+func NewXAutoClaimCmd(ctx context.Context, args ...interface{}) *XAutoClaimCmd {
+	return &XAutoClaimCmd{
+		baseCmd: baseCmd{
+			ctx:  ctx,
+			args: args,
+		},
+	}
+}
+
+func (cmd *XAutoClaimCmd) Val() XAutoClaim {
+	return cmd.val
+}
+
+func (cmd *XAutoClaimCmd) Result() (XAutoClaim, error) {
+	return cmd.val, cmd.err
+}
+
+func (cmd *XAutoClaimCmd) String() string {
+	return cmdString(cmd, cmd.val)
+}
+
+func (cmd *XAutoClaimCmd) readReply(rd *proto.Reader) error {
+	_, err := rd.ReadArrayReply(func(rd *proto.Reader, n int64) (interface{}, error) {
+		var err error
+
+		cmd.val.ID, err = rd.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		cmd.val.Messages, err = readXMessageSlice(rd)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+	return err
+}
+
+type XAutoClaimJustID struct {
+	ID  string
+	IDs []string
+}
+
+type XAutoClaimJustIDCmd struct {
+	baseCmd
+	val XAutoClaimJustID
+}
+
+var _ Cmder = (*XAutoClaimJustIDCmd)(nil)
+
+func NewXAutoClaimJustIDCmd(ctx context.Context, args ...interface{}) *XAutoClaimJustIDCmd {
+	return &XAutoClaimJustIDCmd{
+		baseCmd: baseCmd{
+			ctx:  ctx,
+			args: args,
+		},
+	}
+}
+
+func (cmd *XAutoClaimJustIDCmd) Val() XAutoClaimJustID {
+	return cmd.val
+}
+
+func (cmd *XAutoClaimJustIDCmd) Result() (XAutoClaimJustID, error) {
+	return cmd.val, cmd.err
+}
+
+func (cmd *XAutoClaimJustIDCmd) String() string {
+	return cmdString(cmd, cmd.val)
+}
+
+func (cmd *XAutoClaimJustIDCmd) readReply(rd *proto.Reader) error {
+	_, err := rd.ReadArrayReply(func(rd *proto.Reader, _ int64) (interface{}, error) {
+		var err error
+
+		cmd.val.ID, err = rd.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		n, err := rd.ReadArrayLen()
+		if err != nil {
+			return nil, err
+		}
+
+		cmd.val.IDs = make([]string, n)
+		for i := 0; i < n; i++ {
+			var err error
+			cmd.val.IDs[i], err = rd.ReadString()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return nil, nil
+	})
+	return err
+}
+
+//------------------------------------------------------------------------------
+
 type XInfoConsumersCmd struct {
 	baseCmd
 	val []XInfoConsumer

--- a/commands.go
+++ b/commands.go
@@ -1870,7 +1870,7 @@ func (c cmdable) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAuto
 }
 
 func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []interface{} {
-	args := make([]interface{}, 0)
+	args := make([]interface{}, 0, 9)
 	args = append(args, "xautoclaim", a.Stream, a.Group, a.Consumer, formatMs(ctx, a.MinIdle), a.Start)
 	if a.Count > 0 {
 		args = append(args, "count", a.Count)

--- a/commands.go
+++ b/commands.go
@@ -1845,6 +1845,39 @@ func (c cmdable) XPendingExt(ctx context.Context, a *XPendingExtArgs) *XPendingE
 	return cmd
 }
 
+type XAutoClaimArgs struct {
+	Stream   string
+	Group    string
+	MinIdle  time.Duration
+	Start    string
+	Count    int64
+	Consumer string
+}
+
+func (c cmdable) XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimCmd {
+	args := xAutoClaimArgs(ctx, a)
+	cmd := NewXAutoClaimCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func (c cmdable) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimJustIDCmd {
+	args := xAutoClaimArgs(ctx, a)
+	args = append(args, "justid")
+	cmd := NewXAutoClaimJustIDCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []interface{} {
+	args := make([]interface{}, 0)
+	args = append(args, "xautoclaim", a.Stream, a.Group, a.Consumer, formatMs(ctx, a.MinIdle), a.Start)
+	if a.Count > 0 {
+		args = append(args, "count", a.Count)
+	}
+	return args
+}
+
 type XClaimArgs struct {
 	Stream   string
 	Group    string

--- a/commands_test.go
+++ b/commands_test.go
@@ -4409,13 +4409,16 @@ var _ = Describe("Commands", func() {
 				msgs, err = client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+					ID:     "2-0",
+					Values: map[string]interface{}{"uno": "un"},
+				}, {
 					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
+					Values: map[string]interface{}{"dos": "deux"},
 				}}))
 
 				msg, err := client.XAutoClaimJustID(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msg.IDs).To(Equal([]string{"3-0"}))
+				Expect(msg.IDs).To(Equal([]string{"2-0", "3-0"}))
 			})
 
 			It("should XClaim", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -4411,10 +4411,10 @@ var _ = Describe("Commands", func() {
 				Expect(start).To(Equal("3-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "2-0",
-					Values: map[string]interface{}{"uno": "un"},
+					Values: map[string]interface{}{"dos": "deux"},
 				}, {
 					ID:     "3-0",
-					Values: map[string]interface{}{"dos": "deux"},
+					Values: map[string]interface{}{"tres": "troix"},
 				}}))
 
 				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()

--- a/commands_test.go
+++ b/commands_test.go
@@ -4394,10 +4394,10 @@ var _ = Describe("Commands", func() {
 					Start:    "-",
 					Count:    2,
 				}
-				msgs, err := client.XAutoClaim(ctx, xca).Result()
+				msgs, start, err := client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msgs.ID).To(Equal("2-0"))
-				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+				Expect(start).To(Equal("2-0"))
+				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
 					Values: map[string]interface{}{"uno": "un"},
 				}, {
@@ -4405,10 +4405,11 @@ var _ = Describe("Commands", func() {
 					Values: map[string]interface{}{"dos": "deux"},
 				}}))
 
-				xca.Start = msgs.ID
-				msgs, err = client.XAutoClaim(ctx, xca).Result()
+				xca.Start = start
+				msgs, start, err = client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+				Expect(start).To(Equal("3-0"))
+				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "2-0",
 					Values: map[string]interface{}{"uno": "un"},
 				}, {
@@ -4416,9 +4417,10 @@ var _ = Describe("Commands", func() {
 					Values: map[string]interface{}{"dos": "deux"},
 				}}))
 
-				msg, err := client.XAutoClaimJustID(ctx, xca).Result()
+				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msg.IDs).To(Equal([]string{"2-0", "3-0"}))
+				Expect(start).To(Equal("3-0"))
+				Expect(ids).To(Equal([]string{"2-0", "3-0"}))
 			})
 
 			It("should XClaim", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -4386,38 +4386,36 @@ var _ = Describe("Commands", func() {
 				Expect(n).To(Equal(int64(3)))
 			})
 
-			FDescribe("XAutoClaim", func() {
-				It("should XAutoClaim", func() {
-					xca := &redis.XAutoClaimArgs{
-						Stream:   "stream",
-						Group:    "group",
-						Consumer: "consumer",
-						Start:    "-",
-						Count:    2,
-					}
-					msgs, err := client.XAutoClaim(ctx, xca).Result()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(msgs.ID).To(Equal("3-0"))
-					Expect(msgs.Messages).To(Equal([]redis.XMessage{{
-						ID:     "1-0",
-						Values: map[string]interface{}{"uno": "un"},
-					}, {
-						ID:     "2-0",
-						Values: map[string]interface{}{"dos": "deux"},
-					}}))
+			It("should XAutoClaim", func() {
+				xca := &redis.XAutoClaimArgs{
+					Stream:   "stream",
+					Group:    "group",
+					Consumer: "consumer",
+					Start:    "-",
+					Count:    2,
+				}
+				msgs, err := client.XAutoClaim(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msgs.ID).To(Equal("3-0"))
+				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+					ID:     "1-0",
+					Values: map[string]interface{}{"uno": "un"},
+				}, {
+					ID:     "2-0",
+					Values: map[string]interface{}{"dos": "deux"},
+				}}))
 
-					xca.Start = msgs.ID
-					msgs, err = client.XAutoClaim(ctx, xca).Result()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(msgs.Messages).To(Equal([]redis.XMessage{{
-						ID:     "3-0",
-						Values: map[string]interface{}{"tres": "troix"},
-					}}))
+				xca.Start = msgs.ID
+				msgs, err = client.XAutoClaim(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+					ID:     "3-0",
+					Values: map[string]interface{}{"tres": "troix"},
+				}}))
 
-					msg, err := client.XAutoClaimJustID(ctx, xca).Result()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(msg.IDs).To(Equal([]string{"3-0"}))
-				})
+				msg, err := client.XAutoClaimJustID(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msg.IDs).To(Equal([]string{"3-0"}))
 			})
 
 			It("should XClaim", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -4396,7 +4396,7 @@ var _ = Describe("Commands", func() {
 				}
 				msgs, err := client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msgs.ID).To(Equal("3-0"))
+				Expect(msgs.ID).To(Equal("2-0"))
 				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
 					Values: map[string]interface{}{"uno": "un"},

--- a/commands_test.go
+++ b/commands_test.go
@@ -4386,36 +4386,38 @@ var _ = Describe("Commands", func() {
 				Expect(n).To(Equal(int64(3)))
 			})
 
-			It("should XAutoClaim", func() {
-				xca := &redis.XAutoClaimArgs{
-					Stream:   "stream",
-					Group:    "group",
-					Consumer: "consumer",
-					Start:    "-",
-					Count:    2,
-				}
-				msgs, err := client.XAutoClaim(ctx, xca).Result()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(msgs.ID).To(Equal("3-0"))
-				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
-					ID:     "1-0",
-					Values: map[string]interface{}{"uno": "un"},
-				}, {
-					ID:     "2-0",
-					Values: map[string]interface{}{"dos": "deux"},
-				}}))
+			FDescribe("XAutoClaim", func() {
+				It("should XAutoClaim", func() {
+					xca := &redis.XAutoClaimArgs{
+						Stream:   "stream",
+						Group:    "group",
+						Consumer: "consumer",
+						Start:    "-",
+						Count:    2,
+					}
+					msgs, err := client.XAutoClaim(ctx, xca).Result()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msgs.ID).To(Equal("3-0"))
+					Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+						ID:     "1-0",
+						Values: map[string]interface{}{"uno": "un"},
+					}, {
+						ID:     "2-0",
+						Values: map[string]interface{}{"dos": "deux"},
+					}}))
 
-				xca.Start = msgs.ID
-				msgs, err = client.XAutoClaim(ctx, xca).Result()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
-					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
-				}}))
+					xca.Start = msgs.ID
+					msgs, err = client.XAutoClaim(ctx, xca).Result()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+						ID:     "3-0",
+						Values: map[string]interface{}{"tres": "troix"},
+					}}))
 
-				msg, err := client.XAutoClaimJustID(ctx, xca).Result()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(msg.IDs).To(Equal([]string{"3-0"}))
+					msg, err := client.XAutoClaimJustID(ctx, xca).Result()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msg.IDs).To(Equal([]string{"3-0"}))
+				})
 			})
 
 			It("should XClaim", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -4386,6 +4386,38 @@ var _ = Describe("Commands", func() {
 				Expect(n).To(Equal(int64(3)))
 			})
 
+			It("should XAutoClaim", func() {
+				xca := &redis.XAutoClaimArgs{
+					Stream:   "stream",
+					Group:    "group",
+					Consumer: "consumer",
+					Start:    "-",
+					Count:    2,
+				}
+				msgs, err := client.XAutoClaim(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msgs.ID).To(Equal("3-0"))
+				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+					ID:     "1-0",
+					Values: map[string]interface{}{"uno": "un"},
+				}, {
+					ID:     "2-0",
+					Values: map[string]interface{}{"dos": "deux"},
+				}}))
+
+				xca.Start = msgs.ID
+				msgs, err = client.XAutoClaim(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msgs.Messages).To(Equal([]redis.XMessage{{
+					ID:     "3-0",
+					Values: map[string]interface{}{"tres": "troix"},
+				}}))
+
+				msg, err := client.XAutoClaimJustID(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msg.IDs).To(Equal([]string{"3-0"}))
+			})
+
 			It("should XClaim", func() {
 				msgs, err := client.XClaim(ctx, &redis.XClaimArgs{
 					Stream:   "stream",


### PR DESCRIPTION
Closes https://github.com/go-redis/redis/issues/1686

Redis docs: https://redis.io/commands/xautoclaim

I don't think `ID` is the right name for the cursor returned by Redis, but not sure what would be better. https://github.com/go-redis/redis/pull/1780/files#diff-4d7d1923693fc5ce892add2ea2907a744e77ea0b50c1939ccc5067cb48a466a3R1505