### PR TITLE
Upgrade the <sorted set> series of commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -250,8 +250,6 @@ type Cmdable interface {
 	BZPopMin(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd
 
 	// TODO: remove
-	// 		ZAddNX
-	//		ZAddXX
 	//		ZAddCh
 	//		ZIncr
 	//		ZAddNXCh
@@ -2211,12 +2209,6 @@ func (c cmdable) ZAdd(ctx context.Context, key string, members ...*Z) *IntCmd {
 }
 
 // ZAddNX Redis `ZADD key NX score member [score member ...]` command.
-// Deprecated: Use
-//		client.ZAddArgs(ctx, ZAddArgs{
-//			NX: true,
-//			Members: []Z,
-//		})
-//	remove in v9.
 func (c cmdable) ZAddNX(ctx context.Context, key string, members ...*Z) *IntCmd {
 	return c.zAdd(ctx, key, ZAddArgs{
 		NX: true,
@@ -2224,12 +2216,6 @@ func (c cmdable) ZAddNX(ctx context.Context, key string, members ...*Z) *IntCmd 
 }
 
 // ZAddXX Redis `ZADD key XX score member [score member ...]` command.
-// Deprecated: Use
-//		client.ZAddArgs(ctx, ZAddArgs{
-//			XX: true,
-//			Members: []Z,
-//		})
-//	remove in v9.
 func (c cmdable) ZAddXX(ctx context.Context, key string, members ...*Z) *IntCmd {
 	return c.zAdd(ctx, key, ZAddArgs{
 		XX: true,

--- a/commands_test.go
+++ b/commands_test.go
@@ -2976,7 +2976,6 @@ var _ = Describe("Commands", func() {
 			Expect(vals).To(Equal([]redis.Z{{Score: 1, Member: "one"}}))
 		})
 
-		// TODO: remove in v9.
 		It("should ZAddNX", func() {
 			added, err := client.ZAddNX(ctx, "zset", &redis.Z{
 				Score:  1,
@@ -3001,7 +3000,6 @@ var _ = Describe("Commands", func() {
 			Expect(vals).To(Equal([]redis.Z{{Score: 1, Member: "one"}}))
 		})
 
-		// TODO: remove in v9.
 		It("should ZAddXX", func() {
 			added, err := client.ZAddXX(ctx, "zset", &redis.Z{
 				Score:  1,


### PR DESCRIPTION
New commands and options:

- ZAdd GT and LT options ( #1789 )
- ZRange ByScore,ByLex,Rev and Limit options
- New cmd ZRangeStore
- New cmd ZUnion

  
New API：

- ZAddArgs 
- ZAddArgsIncr 
- ZRangeArgs 
- ZRangeArgsWithScores 
- ZRangeStore 
- ZUnion 
- ZUnionWithScores 

API marked `Deprecated` and removed in V9:

- ZAddNX 
- ZAddXX
- ZAddCh
- ZIncr
- ZAddNXCh
- ZAddXXCh
- ZIncrNX
- ZIncrXX