### PR TITLE
GOMAXPROCS usage instead of NumCPU for the pool size

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -91,7 +91,7 @@ func (opt *ClusterOptions) init() {
 	}
 
 	if opt.PoolSize == 0 {
-		opt.PoolSize = 5 * runtime.NumCPU()
+		opt.PoolSize = 5 * runtime.GOMAXPROCS(0)
 	}
 
 	switch opt.ReadTimeout {

--- a/options.go
+++ b/options.go
@@ -77,7 +77,7 @@ type Options struct {
 	WriteTimeout time.Duration
 
 	// Maximum number of socket connections.
-	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
+	// Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
 	PoolSize int
 	// Minimum number of idle connections which is useful when establishing
 	// new connection is slow.
@@ -136,7 +136,7 @@ func (opt *Options) init() {
 		}
 	}
 	if opt.PoolSize == 0 {
-		opt.PoolSize = 10 * runtime.NumCPU()
+		opt.PoolSize = 10 * runtime.GOMAXPROCS(0)
 	}
 	switch opt.ReadTimeout {
 	case -1:


### PR DESCRIPTION
# What 

`runtime.GOMAXPROCS()` is used instead of `runtime.NumCPU()` to detect a default pool size.

# Why

We are running our services in the Kubernetes cluster and usually, each of them consumes (and is limited to) 2-3 CPUs. 
But it's a logical restriction and `runtime.NumCPU()` will return all available CPUs on the _node_(64 in our case). 
That's why we set the `GOMAXPROCS` env variable to improve system's performance.

In the current implementation, each of our services can create 5 * 64 connections to each Redis node, which in our case means ~300 * 5 * 64 = ~100k connections to the single node (if I'm not mistaken)
 
Thanks to the lazy connection initialization it happens rarely and completely unexpected. Once service or Redis node is busy the client starts generating a huge number of connections:

<img width="918" alt="Screenshot 2021-06-28 at 18 00 13" src="https://user-images.githubusercontent.com/557879/123659067-fa103100-d83a-11eb-8e9d-6bf0fe343e96.png">


# Pros and cons

The main benefit of the change will be the more reasonable defaults. Less unexpected behavior and fewer incidents in production :)

The main downside is that default behavior has changed in some cases. In most cases, GOMAXPROCS is equal to num CPU, but sometimes is not. But I do believe that it's more reasonable value and more aligned with the original purpose of using `NumCPU()` as a pool size