### PR TITLE
Connect hook

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -220,7 +220,6 @@ func (p *ConnPool) dialConn(ctx context.Context, pooled bool) (*Conn, error) {
 		cn = NewConn(netConn)
 		cn.pooled = pooled
 	}
-
 	event := ConnectEvent{Err:err}
 	for hookIndex--; hookIndex >= 0; hookIndex-- {
 		p.hooks.hooks[hookIndex].AfterConnect(ctx, event);

--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -3,6 +3,7 @@ package pool
 import "context"
 
 type SingleConnPool struct {
+	hooks
 	pool      Pooler
 	cn        *Conn
 	stickyErr error

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -34,6 +34,7 @@ func (e BadConnError) Unwrap() error {
 //------------------------------------------------------------------------------
 
 type StickyConnPool struct {
+	hooks
 	pool   Pooler
 	shared int32 // atomic
 

--- a/redis.go
+++ b/redis.go
@@ -147,8 +147,7 @@ func (hs hooks) withContext(ctx context.Context, fn func() error) error {
 type baseClient struct {
 	opt      *Options
 	connPool pool.Pooler
-
-	onClose func() error // hook called when client is closed
+	onClose  func() error // hook called when client is closed
 }
 
 func newBaseClient(opt *Options, connPool pool.Pooler) *baseClient {
@@ -558,9 +557,9 @@ func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) 
 // underlying connections. It's safe for concurrent use by multiple
 // goroutines.
 type Client struct {
+	hooks
 	*baseClient
 	cmdable
-	hooks
 	ctx context.Context
 }
 
@@ -573,7 +572,6 @@ func NewClient(opt *Options) *Client {
 		ctx:        context.Background(),
 	}
 	c.cmdable = c.Process
-
 	return &c
 }
 


### PR DESCRIPTION
Addresses https://github.com/go-redis/redis/discussions/1786

Added a new `PoolHook` interface allowing the user to add two new hooks that would be called before and after the creation of a connection, allowing the user - among other stuff - to measure the connection latency.

User still uses the `AddHook` interface but providing an extended interface which supports the two methods required by the pool.

An example can be found here https://github.com/go-redis/redis/pull/1803/files#diff-ee4b7901a404913de455c4b45c583a3d0bf51e6c3abc06c93c2a1fa6c3eac235R16

# What is missing

Does not support the `clone` behaviour used by functions like `Client.WithTimeout` which for the client hooks it creates a list by using a shallow copy, decoupling hooks from the former and the new cloned client.

Current proposal does not support this, since the pool is shared by all of the cloned clients.