### PR TITLE
Check Failing() before serving random node

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -595,8 +595,13 @@ func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {
 	if len(nodes) == 0 {
 		return c.nodes.Random()
 	}
-	n := rand.Intn(len(nodes))
-	return nodes[n], nil
+	for _, idx := range rand.Perm(len(nodes)) {
+		if nodes[idx].Failing() {
+			continue
+		}
+		return nodes[idx], nil
+	}
+	return c.nodes.Random()
 }
 
 func (c *clusterState) slotNodes(slot int) []*clusterNode {

--- a/cluster.go
+++ b/cluster.go
@@ -598,12 +598,13 @@ func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {
 	if len(nodes) == 1 {
 		return nodes[0], nil
 	}
-	for _, idx := range rand.Perm(len(nodes)) {
+	randomNodes := rand.Perm(len(nodes))
+	for _, idx := range randomNodes {
 		if node := nodes[idx]; !node.Failing() {
 			return node, nil
 		}
 	}
-	return nodes[0], nil
+	return nodes[randomNodes[0]], nil
 }
 
 func (c *clusterState) slotNodes(slot int) []*clusterNode {

--- a/cluster.go
+++ b/cluster.go
@@ -595,12 +595,15 @@ func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {
 	if len(nodes) == 0 {
 		return c.nodes.Random()
 	}
+	if len(nodes) == 1 {
+		return nodes[0], nil
+	}
 	for _, idx := range rand.Perm(len(nodes)) {
-		if !nodes[idx].Failing() {
-			return nodes[idx], nil
+		if node := nodes[idx]; !node.Failing() {
+			return node, nil
 		}
 	}
-	return c.nodes.Random()
+	return nodes[0], nil
 }
 
 func (c *clusterState) slotNodes(slot int) []*clusterNode {

--- a/cluster.go
+++ b/cluster.go
@@ -596,10 +596,9 @@ func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {
 		return c.nodes.Random()
 	}
 	for _, idx := range rand.Perm(len(nodes)) {
-		if nodes[idx].Failing() {
-			continue
+		if !nodes[idx].Failing() {
+			return nodes[idx], nil
 		}
-		return nodes[idx], nil
 	}
 	return c.nodes.Random()
 }


### PR DESCRIPTION
We encounter errors during Redis failover with `RouteRandomly` set to `true`.

After some debugging we found that `Failing` is never checked when serving random node for the slot.

This should be pretty easy to reproduce:

1. Start cluster using this docker-compose service:
```
  redis-cluster:
    image: grokzen/redis-cluster:6.0.9
    container_name: redis-cluster.go-redis-test
    environment:
      - "IP=0.0.0.0"
    ports:
      - 7000-7005:7000-7005
```
2. Connect to cluster, perform read/write operations
3. `docker-compose exec redis-cluster supervisorctl stop redis-2`

