### PR TITLE
Added maxBadConnRetries to limit the number of times to obtain broken…

### DIFF
--- a/internal/pool/export_test.go
+++ b/internal/pool/export_test.go
@@ -1,7 +1,18 @@
 package pool
 
-import "time"
+import (
+	"net"
+	"time"
+)
 
 func (cn *Conn) SetCreatedAt(tm time.Time) {
 	cn.createdAt = tm
+}
+
+func (cn *Conn) NetConn() net.Conn {
+	return cn.netConn
+}
+
+func MaxBadConnRetries() int {
+	return maxBadConnRetries
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -12,8 +12,7 @@ import (
 )
 
 // maxBadConnRetries is the maximum number of attempts to obtain a valid connection from the connection pool.
-// When this number is exceeded, a new connection is created directly and
-// no longer obtained from the connection pool.
+// When this number is exceeded, a new connection is created directly.
 const maxBadConnRetries = 2
 
 var (

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -92,8 +92,8 @@ var _ = Describe("bad conn", func() {
 			Dialer:             dummyDialer,
 			PoolSize:           10,
 			PoolTimeout:        time.Hour,
-			IdleTimeout:        time.Millisecond,
-			IdleCheckFrequency: time.Millisecond,
+			IdleTimeout:        time.Minute,
+			IdleCheckFrequency: 10 * time.Second,
 		}
 		connPool = pool.NewConnPool(opt)
 	})
@@ -110,6 +110,8 @@ var _ = Describe("bad conn", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 		for i := 0; i < opt.PoolSize; i++ {
+			// Damage it.
+			_ = conns[i].Close()
 			connPool.Put(ctx, conns[i])
 		}
 


### PR DESCRIPTION
This PR is not intended to solve #1737.

It is to limit the number of attempts. If all connections in a connection pool fail, we should not let it detect all connections in the entire connection pool.