### PR TITLE
after the connection pool is closed, no new connections should be added

### DIFF
--- a/internal/pool/export_test.go
+++ b/internal/pool/export_test.go
@@ -1,14 +1,9 @@
 package pool
 
 import (
-	"sync/atomic"
 	"time"
 )
 
 func (cn *Conn) SetCreatedAt(tm time.Time) {
 	cn.createdAt = tm
-}
-
-func (p *ConnPool) RunGoroutineNumber() int {
-	return int(atomic.LoadInt32(&p.runGoroutine))
 }

--- a/internal/pool/export_test.go
+++ b/internal/pool/export_test.go
@@ -1,7 +1,14 @@
 package pool
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 func (cn *Conn) SetCreatedAt(tm time.Time) {
 	cn.createdAt = tm
+}
+
+func (p *ConnPool) RunGoroutineNumber() int {
+	return int(atomic.LoadInt32(&p.runGoroutine))
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -31,22 +31,6 @@ var _ = Describe("ConnPool", func() {
 		connPool.Close()
 	})
 
-	It("should run goroutine is 0", func() {
-		connPool = pool.NewConnPool(&pool.Options{
-			Dialer:             dummyDialer,
-			PoolSize:           10,
-			MinIdleConns:       10,
-			PoolTimeout:        time.Hour,
-			IdleTimeout:        time.Millisecond,
-			IdleCheckFrequency: time.Millisecond,
-		})
-		connPool.Close()
-
-		Eventually(func() int {
-			return connPool.RunGoroutineNumber()
-		}, "5s", "10ms").Should(Equal(0))
-	})
-
 	It("should safe close", func() {
 		const minIdleConns = 10
 
@@ -71,9 +55,8 @@ var _ = Describe("ConnPool", func() {
 		Expect(connPool.Close()).NotTo(HaveOccurred())
 		close(closedChan)
 
-		Eventually(func() int {
-			return connPool.RunGoroutineNumber()
-		}, "5s", "10ms").Should(Equal(0))
+		// We wait for 1 second and believe that checkMinIdleConns has been executed.
+		time.Sleep(time.Second)
 
 		Expect(connPool.Stats()).To(Equal(&pool.Stats{
 			Hits:       0,

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -19,7 +19,7 @@ const (
 
 //------------------------------------------------------------------------------
 
-const Nil = RedisError("redis: nil")
+const Nil = RedisError("redis: nil") // nolint:errname
 
 type RedisError string
 


### PR DESCRIPTION
linked: #1861

When the connection pool is closed, we will still add new connections to the connection pool, and this part of the connection cannot be closed.

It may also cause errors such as `Stats`, as described in #1861

I added a count of `runGoroutine`, I am not sure if adding it is a good decision, although it is only for testing.

@vmihailenco Do you have any ideas?