### PR TITLE
Retry pipeline read commands

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -462,14 +462,24 @@ func (c *baseClient) pipelineProcessCmds(
 }
 
 func pipelineReadCmds(rd *proto.Reader, cmds []Cmder) error {
+	var firstErr error
 	for _, cmd := range cmds {
 		err := cmd.readReply(rd)
 		cmd.SetErr(err)
-		if err != nil && !isRedisError(err) {
-			return err
+		if err == nil {
+			continue
 		}
+
+		if isRedisError(err) {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		return err
 	}
-	return nil
+	return firstErr
 }
 
 func (c *baseClient) txPipelineProcessCmds(

--- a/redis.go
+++ b/redis.go
@@ -462,24 +462,14 @@ func (c *baseClient) pipelineProcessCmds(
 }
 
 func pipelineReadCmds(rd *proto.Reader, cmds []Cmder) error {
-	var firstErr error
 	for _, cmd := range cmds {
 		err := cmd.readReply(rd)
 		cmd.SetErr(err)
-		if err == nil {
-			continue
+		if err != nil && !isRedisError(err) {
+			return err
 		}
-
-		if isRedisError(err) {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-
-		return err
 	}
-	return firstErr
+	return cmds[0].Err()
 }
 
 func (c *baseClient) txPipelineProcessCmds(


### PR DESCRIPTION
Hi! First, thanks for such a great library.

In our production environment we noticed that Redis can sometimes return errors such as "LOADING redis is loading the dataset in memory".

The library already handles errors like this in a `shouldRetry` function, but for pipelined commands it never calls.

This PR enables retries for pipelined commands when using `redis.Client`