### PR TITLE
feat: add acl auth support for sentinels

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -40,15 +40,27 @@ const (
 	sentinelPort3      = "9128"
 )
 
+const (
+	aclSentinelUsername = "sentinel-user"
+	aclSentinelPassword = "sentinel-pass"
+	aclSentinelName     = "my_server"
+	aclServerPort       = "10001"
+	aclSentinelPort1    = "10002"
+	aclSentinelPort2    = "10003"
+	aclSentinelPort3    = "10004"
+)
+
 var (
 	sentinelAddrs = []string{":" + sentinelPort1, ":" + sentinelPort2, ":" + sentinelPort3}
+	aclSentinelAddrs = []string {":" + aclSentinelPort1, ":" + aclSentinelPort2, ":" + aclSentinelPort3}
 
 	processes map[string]*redisProcess
 
-	redisMain                                      *redisProcess
+	redisMain, aclServer                           *redisProcess
 	ringShard1, ringShard2, ringShard3             *redisProcess
 	sentinelMaster, sentinelSlave1, sentinelSlave2 *redisProcess
 	sentinel1, sentinel2, sentinel3                *redisProcess
+	aclSentinel1, aclSentinel2, aclSentinel3       *redisProcess
 )
 
 var cluster = &clusterScenario{
@@ -101,6 +113,18 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(startCluster(ctx, cluster)).NotTo(HaveOccurred())
+
+	aclServer, err = startRedis(aclServerPort)
+	Expect(err).NotTo(HaveOccurred())
+
+	aclSentinel1, err = startSentinelWithAcl(aclSentinelPort1, aclSentinelName, aclServerPort)
+	Expect(err).NotTo(HaveOccurred())
+
+	aclSentinel2, err = startSentinelWithAcl(aclSentinelPort2, aclSentinelName, aclServerPort)
+	Expect(err).NotTo(HaveOccurred())
+
+	aclSentinel3, err = startSentinelWithAcl(aclSentinelPort3, aclSentinelName, aclServerPort)
+	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
@@ -362,6 +386,28 @@ func startSentinel(port, masterName, masterPort string) (*redisProcess, error) {
 	p := &redisProcess{process, client}
 	registerProcess(port, p)
 	return p, nil
+}
+
+func startSentinelWithAcl(port, masterName, masterPort string) (*redisProcess, error) {
+	process, err := startSentinel(port, masterName, masterPort)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cmd := range []*redis.StatusCmd{
+		redis.NewStatusCmd(ctx, "ACL", "SETUSER", aclSentinelUsername, "ON", ">" + aclSentinelPassword, "-@all",
+			"+auth", "+client|getname", "+client|id", "+client|setname", "+command", "+hello", "+ping", "+role",
+			"+sentinel|get-master-addr-by-name", "+sentinel|master", "+sentinel|myid", "+sentinel|replicas",
+			"+sentinel|sentinels"),
+	} {
+		process.Client.Process(ctx, cmd)
+		if err := cmd.Err(); err != nil {
+			process.Kill()
+			return nil, err
+		}
+	}
+
+	return process, nil
 }
 
 //------------------------------------------------------------------------------

--- a/sentinel.go
+++ b/sentinel.go
@@ -23,7 +23,13 @@ type FailoverOptions struct {
 	MasterName string
 	// A seed list of host:port addresses of sentinel nodes.
 	SentinelAddrs []string
-	// Sentinel password from "requirepass <password>" (if enabled) in Sentinel configuration
+
+	// If specified with SentinelPassword, enables ACL-based authentication (via
+	// AUTH <user> <pass>).
+	SentinelUsername string
+	// Sentinel password from "requirepass <password>" (if enabled) in Sentinel
+	// configuration, or, if SentinelUsername is also supplied, used for ACL-based
+	// authentication.
 	SentinelPassword string
 
 	// Allows routing read-only commands to the closest master or slave node.
@@ -109,6 +115,7 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		OnConnect: opt.OnConnect,
 
 		DB:       0,
+		Username: opt.SentinelUsername,
 		Password: opt.SentinelPassword,
 
 		MaxRetries:      opt.MaxRetries,

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -214,14 +214,31 @@ var _ = Describe("NewFailoverClusterClient", func() {
 })
 
 var _ = Describe("SentinelAclAuth", func() {
+	const (
+		aclSentinelUsername = "sentinel-user"
+		aclSentinelPassword = "sentinel-pass"
+	)
+
 	var client *redis.Client
-	var server *redis.Client
 	var sentinel *redis.SentinelClient
+	var sentinels = func() []*redisProcess {
+		return []*redisProcess{ sentinel1, sentinel2, sentinel3 }
+	}
 
 	BeforeEach(func() {
+		authCmd := redis.NewStatusCmd(ctx, "ACL", "SETUSER", aclSentinelUsername, "ON",
+			">" + aclSentinelPassword, "-@all", "+auth", "+client|getname", "+client|id", "+client|setname",
+			"+command", "+hello", "+ping", "+role", "+sentinel|get-master-addr-by-name", "+sentinel|master",
+			"+sentinel|myid", "+sentinel|replicas", "+sentinel|sentinels")
+
+		for _, process := range sentinels() {
+			err := process.Client.Process(ctx, authCmd)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		client = redis.NewFailoverClient(&redis.FailoverOptions{
-			MasterName: aclSentinelName,
-			SentinelAddrs: aclSentinelAddrs,
+			MasterName: sentinelName,
+			SentinelAddrs: sentinelAddrs,
 			MaxRetries: -1,
 			SentinelUsername: aclSentinelUsername,
 			SentinelPassword: aclSentinelPassword,
@@ -230,35 +247,32 @@ var _ = Describe("SentinelAclAuth", func() {
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 
 		sentinel = redis.NewSentinelClient(&redis.Options{
-			Addr: aclSentinelAddrs[0],
+			Addr: sentinelAddrs[0],
 			MaxRetries: -1,
 			Username: aclSentinelUsername,
 			Password: aclSentinelPassword,
 		})
 
-		addr, err := sentinel.GetMasterAddrByName(ctx, aclSentinelName).Result()
+		_, err := sentinel.GetMasterAddrByName(ctx, sentinelName).Result()
 		Expect(err).NotTo(HaveOccurred())
 
-		server = redis.NewClient(&redis.Options{
-			Addr:       net.JoinHostPort(addr[0], addr[1]),
-			MaxRetries: -1,
-		})
-
 		// Wait until sentinels are picked up by each other.
-		Eventually(func() string {
-			return aclSentinel1.Info(ctx).Val()
-		}, "15s", "100ms").Should(ContainSubstring("sentinels=3"))
-		Eventually(func() string {
-			return aclSentinel2.Info(ctx).Val()
-		}, "15s", "100ms").Should(ContainSubstring("sentinels=3"))
-		Eventually(func() string {
-			return aclSentinel3.Info(ctx).Val()
-		}, "15s", "100ms").Should(ContainSubstring("sentinels=3"))
+		for _, process := range sentinels() {
+			Eventually(func() string {
+				return process.Info(ctx).Val()
+			}, "15s", "100ms").Should(ContainSubstring("sentinels=3"))
+		}
 	})
 
 	AfterEach(func() {
+		unauthCommand := redis.NewStatusCmd(ctx, "ACL", "DELUSER", aclSentinelUsername)
+
+		for _, process := range sentinels() {
+			err := process.Client.Process(ctx, unauthCommand)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		_ = client.Close()
-		_ = server.Close()
 		_ = sentinel.Close()
 	})
 


### PR DESCRIPTION
👋🏾 Hey There!

Hopefully this is a pretty straightforward one. I have a redis installation that I'm trying to leverage that has Redis6 ACL auth against the Sentinels. This exposes a `SentinelUsername` field that propagates down to the underlying client (which already switches between Redis < 6 auth and ACL auth).

While I was there, I added a new test suite for the ACL'd sentinels!