### PR TITLE
fix: add whitespace for avoid unlikely colisions

### DIFF
--- a/error.go
+++ b/error.go
@@ -134,7 +134,7 @@ func isMovedSameConnAddr(err error, addr string) bool {
 	if !strings.HasPrefix(redisError, "MOVED ") {
 		return false
 	}
-	return strings.HasSuffix(redisError, addr)
+	return strings.HasSuffix(redisError, " " + addr)
 }
 
 //------------------------------------------------------------------------------

--- a/error.go
+++ b/error.go
@@ -134,7 +134,7 @@ func isMovedSameConnAddr(err error, addr string) bool {
 	if !strings.HasPrefix(redisError, "MOVED ") {
 		return false
 	}
-	return strings.HasSuffix(redisError, " " + addr)
+	return strings.HasSuffix(redisError, " "+addr)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
@vmihailenco sorry but received some feedback from my colleagues and they suggested, which I agree, that by adding an space before the addr will remove any chance of having a false positive because of overlapping in the hostname.

Tested and works like a charm also.