### PR TITLE
add OnGetConnect hook

### DIFF
--- a/options.go
+++ b/options.go
@@ -40,7 +40,8 @@ type Options struct {
 
 	// Hook that is called when new connection is established.
 	OnConnect func(ctx context.Context, cn *Conn) error
-
+	// Hook that is called when we got a connection
+	OnGetConnect func(ctx context.Context, cn net.Addr) error
 	// Use the specified Username to authenticate the current connection
 	// with one of the connections defined in the ACL list when connecting
 	// to a Redis 6.0 instance, or greater, that is using the Redis ACL system.

--- a/redis.go
+++ b/redis.go
@@ -201,6 +201,12 @@ func (c *baseClient) getConn(ctx context.Context) (*pool.Conn, error) {
 		return nil, err
 	}
 
+	if c.opt.OnGetConnect != nil && cn != nil {
+		if err := c.opt.OnGetConnect(ctx, cn.RemoteAddr()); err != nil {
+			return cn, err
+		}
+	}
+
 	return cn, nil
 }
 


### PR DESCRIPTION
OnGetConnect hook enables us to do things related the real connection. For example, in use of this hook, we can pass the remote address through the context, and then do some data report in the AfterProcesss hook in production.

@monkey92t 