### PR TITLE
otel instrumentation name and version

### DIFF
--- a/extra/redisotel/redisotel.go
+++ b/extra/redisotel/redisotel.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	// todo: consider using the full module path "github.com/go-redis/redis/extra/redisotel"
-	defaultTracerName = "github.com/go-redis/redis"
+	defaultTracerName = "github.com/go-redis/redis/extra/redisotel"
 )
 
 type TracingHook struct {
@@ -32,8 +31,7 @@ func NewTracingHook(opts ...Option) *TracingHook {
 
 	tracer := cfg.tp.Tracer(
 		defaultTracerName,
-		// todo: consider adding a version
-		// trace.WithInstrumentationVersion("semver:8.11.4"),
+		trace.WithInstrumentationVersion("semver:"+redis.Version()),
 	)
 	return &TracingHook{tracer: tracer}
 }


### PR DESCRIPTION
Use full path for tracer name, and decorate traces with the library version

For example, as in other packages:
* https://github.com/open-telemetry/opentelemetry-go-contrib/blob/aad3f901baac5d79791fefb43c81d5b16ca22f99/instrumentation/github.com/gorilla/mux/otelmux/mux.go#L39
* https://github.com/open-telemetry/opentelemetry-go-contrib/blob/7e31ebe040306aee2c826972269f938f9f0e7c34/instrumentation/net/http/otelhttp/config.go#L30