### PR TITLE
feat: add support for acl sentinel auth in universal client

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -25,6 +25,7 @@ type UniversalOptions struct {
 
 	Username         string
 	Password         string
+	SentinelUsername string
 	SentinelPassword string
 
 	MaxRetries      int
@@ -114,6 +115,7 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		DB:               o.DB,
 		Username:         o.Username,
 		Password:         o.Password,
+		SentinelUsername: o.SentinelUsername,
 		SentinelPassword: o.SentinelPassword,
 
 		MaxRetries:      o.MaxRetries,


### PR DESCRIPTION
👋🏾 Hi again,

I found a consumer who is using the `UniversalClient` to support sentinel auth generically, and realized there's another spot where ACL-based auth against sentinels isn't supported. Hope this helps!