### PR TITLE
fix #2057 use Options settings to ignore SetReadDeadline

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -64,8 +64,10 @@ func (cn *Conn) RemoteAddr() net.Addr {
 }
 
 func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(rd *proto.Reader) error) error {
-	if err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout)); err != nil {
-		return err
+	if timeout != 0 {
+		if err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout)); err != nil {
+			return err
+		}
 	}
 	return fn(cn.rd)
 }
@@ -73,8 +75,10 @@ func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(r
 func (cn *Conn) WithWriter(
 	ctx context.Context, timeout time.Duration, fn func(wr *proto.Writer) error,
 ) error {
-	if err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout)); err != nil {
-		return err
+	if timeout != 0 {
+		if err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout)); err != nil {
+			return err
+		}
 	}
 
 	if cn.bw.Buffered() > 0 {


### PR DESCRIPTION
when set `ReadTimeout` & `WriteTimeout` to -1 and disable `SetReadDeadline`
```golang
        cli := redis.NewClient(&redis.Options{
		ReadTimeout:  -1,
		WriteTimeout: -1,
	})
```