### PR TITLE
fix: Use redis over SSH channel(#2057)

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -64,8 +64,10 @@ func (cn *Conn) RemoteAddr() net.Addr {
 }
 
 func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(rd *proto.Reader) error) error {
-	if err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout)); err != nil {
-		return err
+	if timeout != 0 {
+		if err := cn.netConn.SetReadDeadline(cn.deadline(ctx, timeout)); err != nil {
+			return err
+		}
 	}
 	return fn(cn.rd)
 }
@@ -73,8 +75,10 @@ func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(r
 func (cn *Conn) WithWriter(
 	ctx context.Context, timeout time.Duration, fn func(wr *proto.Writer) error,
 ) error {
-	if err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout)); err != nil {
-		return err
+	if timeout != 0 {
+		if err := cn.netConn.SetWriteDeadline(cn.deadline(ctx, timeout)); err != nil {
+			return err
+		}
 	}
 
 	if cn.bw.Buffered() > 0 {


### PR DESCRIPTION
useage:
```golang
     sshConfig := &ssh.ClientConfig{
		User:            "root",
		Auth:            []ssh.AuthMethod{ssh.Password("password")},
		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
		Timeout:         15 * time.Second,
	}

	client, err := ssh.Dial("tcp", "remoteIP:22", sshConfig)
	if err != nil {
		log.Println(fmt.Errorf("%v", err))
	}

	cli := redis.NewClient(&redis.Options{
		Addr: net.JoinHostPort("127.0.0.1", "6379"),
		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
			return client.Dial(network, addr)
		},
		ReadTimeout:  -1,
		WriteTimeout: -1,
	})
       
       

```