### PR TITLE
Add NewXPendingResult for unit testing XPending

### DIFF
--- a/result.go
+++ b/result.go
@@ -178,3 +178,11 @@ func NewXStreamSliceCmdResult(val []XStream, err error) *XStreamSliceCmd {
 	cmd.SetErr(err)
 	return &cmd
 }
+
+// NewXPendingResult returns a XPendingCmd initialised with val and err for testing.
+func NewXPendingResult(val *XPending, err error) *XPendingCmd {
+	var cmd XPendingCmd
+	cmd.val = val
+	cmd.SetErr(err)
+	return &cmd
+}


### PR DESCRIPTION
I came across this gap whilst writing a unit test. Hopefully this is the right way to add it!