### PR TITLE
Added CredentialsProvider callback for getting username and password

### DIFF
--- a/options.go
+++ b/options.go
@@ -51,6 +51,9 @@ type Options struct {
 	// or the User Password when connecting to a Redis 6.0 instance, or greater,
 	// that is using the Redis ACL system.
 	Password string
+	// CredentialsProvider allows the username and password to be updated
+	// before reconnecting. It should return the current username and password.
+	CredentialsProvider func() (username string, password string)
 
 	// Database to be selected after connecting to the server.
 	DB int


### PR DESCRIPTION
Recently encountered a security problem, the running process was scanned to the redis plaintext username and password.

so I was inspired by [CredentialsProvider](https://github.com/eclipse/paho.mqtt.golang/blob/87173763ce056ff2dd4e61c01efae663539178e8/message.go#L115) and added the same method to the redis library.

I use the [cheatengine](https://cheatengine.org/) scanner to run the memory password string.

I block the initConn method, and then use cheatengine to scan the memory of the program. After the initConn method is executed, the password in the memory will be delete immediately.

```go

func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
	if cn.Inited {
		return nil
	}
	cn.Inited = true

	username, password := c.opt.Username, c.opt.Password
	if c.opt.CredentialsProvider != nil {
		username, password = c.opt.CredentialsProvider()
		defer fmt.Scanln() // blocking method while testing
	}

	if password == "" &&
		c.opt.DB == 0 &&
		!c.opt.readOnly &&
		c.opt.OnConnect == nil {
		return nil
	}

	connPool := pool.NewSingleConnPool(c.connPool, cn)
	conn := newConn(ctx, c.opt, connPool)

	_, err := conn.Pipelined(ctx, func(pipe Pipeliner) error {
		if password != "" {
			if username != "" {
				pipe.AuthACL(ctx, username, password)
			} else {
				pipe.Auth(ctx, password)
			}
		}

		if c.opt.DB > 0 {
			pipe.Select(ctx, c.opt.DB)
		}

		if c.opt.readOnly {
			pipe.ReadOnly(ctx)
		}

		return nil
	})
	if err != nil {
		return err
	}

	if c.opt.OnConnect != nil {
		return c.opt.OnConnect(ctx, conn)
	}
	return nil
}
```

Here is my test process.

![test.gif](https://user-images.githubusercontent.com/14202095/170850720-63bca799-a298-41ef-bef7-1d3b3d10507c.gif)

