### PR TITLE
fix:redirect only when meet move|ask|loading|readonly err

### DIFF
--- a/command.go
+++ b/command.go
@@ -590,6 +590,7 @@ func (cmd *StatusCmd) String() string {
 
 func (cmd *StatusCmd) readReply(rd *proto.Reader) (err error) {
 	cmd.val, err = rd.ReadString()
+	fmt.Println(cmd.val)
 	return err
 }
 


### PR DESCRIPTION
redirect only when meet move|ask|loading|readonly err, when meet other err, such as network ,should not retry request in redirect loop, network err  request should be retry by maxretries. if we did retry in redirect loop, there may be maxretries*maxredirect request.  in other way, if we set maxretries to 0, but it may actually did retry when meet network err, which is not consistency with what option set.