### PR TITLE
Listen for context.Cancelled, try to cancel read if detected, still racy

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -156,7 +157,9 @@ func (c *PubSub) closeTheCn(reason error) error {
 		return nil
 	}
 	if !c.closed {
-		internal.Logger.Printf(c.getContext(), "redis: discarding bad PubSub connection: %s", reason)
+		if !errors.Is(reason, context.Canceled) {
+			internal.Logger.Printf(c.getContext(), "redis: discarding bad PubSub connection: %s", reason)
+		}
 	}
 	err := c.closeConn(c.cn)
 	c.cn = nil


### PR DESCRIPTION
This is somewhat of an 80% attempt at solving #2117 - as net.Conn doesn't have a cancellation context:

- I've started a background goroutine in Conn.WithReader that tries to listen for that cancellation,
- If cancellation has been caught, the net.Conn read is cancelled with a SetReadDeadline,
- Maintain a context.Canceled value with error wrapping and an explicit early exit cancellation check,

I'm still not entirely happy about this, as some error details get lost on cancellation (reader error returned). The function produces 3 error objects, which could be merged with go-uber/multierr to enable value checks with errors.Is.