### PR TITLE
fix #2128

### DIFF
--- a/command.go
+++ b/command.go
@@ -2047,7 +2047,7 @@ func (cmd *XInfoGroupsCmd) readReply(rd *proto.Reader) error {
 				}
 			case "entries-read":
 				group.EntriesRead, err = rd.ReadInt()
-				if err != nil {
+				if err != nil && err != Nil {
 					return err
 				}
 			case "lag":


### PR DESCRIPTION
This pr may fix the problem, now the result of running:
```shell
=== RUN   Test
    test_test.go:27: [{Name:cg1 Consumers:0 Pending:0 LastDeliveredID:0-0 EntriesRead:0 Lag:6} {Name:g1 Consumers:0 Pending:0 LastDeliveredID:0-0 EntriesRead:0 Lag:6}]
--- PASS: Test (0.00s)
```