### PR TITLE
feat: add redis.nil field to GeoPos result

### DIFF
--- a/command.go
+++ b/command.go
@@ -3189,6 +3189,11 @@ func (cmd *GeoSearchLocationCmd) readReply(rd *proto.Reader) error {
 
 type GeoPos struct {
 	Longitude, Latitude float64
+	Err                 error
+}
+
+func (g GeoPos) IsRedisNil() bool {
+	return g.Err == Nil
 }
 
 type GeoPosCmd struct {
@@ -3235,7 +3240,9 @@ func (cmd *GeoPosCmd) readReply(rd *proto.Reader) error {
 		err = rd.ReadFixedArrayLen(2)
 		if err != nil {
 			if err == Nil {
-				cmd.val[i] = nil
+				cmd.val[i] = &GeoPos{
+					Err: Nil,
+				}
 				continue
 			}
 			return err

--- a/commands_test.go
+++ b/commands_test.go
@@ -5119,7 +5119,9 @@ var _ = Describe("Commands", func() {
 					Longitude: 15.087267458438873,
 					Latitude:  37.50266842333162,
 				},
-				nil,
+				{
+					Err: redis.Nil,
+				},
 			}))
 		})
 


### PR DESCRIPTION
Close https://github.com/go-redis/redis/issues/2121

This will work as:
```go
v, _ := rdb.GeoPos(ctx, "Sicily", "Palermo", "NonExisting").Result()
for _, g := range v {
    if !g.IsRedisNil() {
	fmt.Println(g)
    }
}
```