### PR TITLE
fix: don't panic when test cannot start

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -82,8 +82,10 @@ func (s *clusterScenario) newClusterClient(
 
 func (s *clusterScenario) Close() error {
 	for _, port := range s.ports {
-		processes[port].Close()
-		delete(processes, port)
+		if process, ok := processes[port]; ok {
+			process.Close()
+			delete(processes, port)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Trying to get tests to run locally and getting this red herring panic:

```
go test
Running Suite: go-redis
=======================
Random Seed: 1656897392
Will run 508 of 510 specs

Failure [0.005 seconds]
[BeforeSuite] BeforeSuite 
/Users/mike/src/redis/main_test.go:68

  Unexpected error:
      <*exec.ExitError | 0x140004b9d60>: {
          ProcessState: {
              pid: 95236,
              status: 256,
              rusage: {
                  Utime: {
                      Sec: 0,
                      Usec: 271,
                      Pad_cgo_0: [0, 0, 0, 0],
                  },
                  Stime: {
                      Sec: 0,
                      Usec: 975,
                      Pad_cgo_0: [0, 0, 0, 0],
                  },
                  Maxrss: 1441792,
                  Ixrss: 0,
                  Idrss: 0,
                  Isrss: 0,
                  Minflt: 198,
                  Majflt: 0,
                  Nswap: 0,
                  Inblock: 0,
                  Oublock: 0,
                  Msgsnd: 0,
                  Msgrcv: 0,
                  Nsignals: 0,
                  Nvcsw: 2,
                  Nivcsw: 4,
              },
          },
          Stderr: nil,
      }
      exit status 1
  occurred

  /Users/mike/src/redis/main_test.go:72
------------------------------
Panic [0.000 seconds]
[AfterSuite] AfterSuite 
/Users/mike/src/redis/main_test.go:106

  Test Panicked
  runtime error: invalid memory address or nil pointer dereference
  /opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:220

  Full Stack Trace
  github.com/go-redis/redis/v9_test.(*redisProcess).Close(0x0)
        /Users/mike/src/redis/main_test.go:267 +0x20
  github.com/go-redis/redis/v9_test.(*clusterScenario).Close(...)
        /Users/mike/src/redis/cluster_test.go:85
  github.com/go-redis/redis/v9_test.glob..func10()
        /Users/mike/src/redis/main_test.go:107 +0x19c
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0x28?)
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:113 +0x90
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0x2?)
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:64 +0xd4
  github.com/onsi/ginkgo/internal/leafnodes.(*simpleSuiteNode).Run(0x14000272460, 0x100ea2cc0?, 0x0?, {0x14000036000?, 0x140000abaa8?})
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/suite_nodes.go:25 +0x5c
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runAfterSuite(0x140001f2000)
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/specrunner/spec_runner.go:138 +0x90
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0x140001f2000)
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/specrunner/spec_runner.go:71 +0xd4
  github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0x14000206a10, {0x128868030, 0x140003824e0}, {0x1012438b8, 0x8}, {0x140003aa040, 0x1, 0x1}, {0x1013d37b8?, 0x140001ee8c0}, ...)
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/suite/suite.go:79 +0x37c
  github.com/onsi/ginkgo.runSpecsWithCustomReporters({0x1013d0a78?, 0x140003824e0}, {0x1012438b8, 0x8}, {0x14000069f08, 0x1, 0x129f6373f?})
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/ginkgo_dsl.go:245 +0x120
  github.com/onsi/ginkgo.RunSpecs({0x1013d0a78, 0x140003824e0}, {0x1012438b8, 0x8})
        /Users/mike/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/ginkgo_dsl.go:220 +0x144
  github.com/go-redis/redis/v9_test.TestGinkgoSuite(0x14000382340?)
        /Users/mike/src/redis/main_test.go:117 +0x48
  testing.tRunner(0x140003824e0, 0x1013cc698)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1439 +0x110
  created by testing.(*T).Run
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1486 +0x300
------------------------------

Ran 508 of 0 Specs in 0.011 seconds
FAIL! -- 0 Passed | 508 Failed | 0 Pending | 0 Skipped
--- FAIL: TestGinkgoSuite (0.08s)
--- FAIL: Example_instrumentation (0.08s)
got:
starting processing: <ping: >
finished processing: <ping: dial tcp :6379: connect: connection refused>
want:
starting processing: <ping: >
finished processing: <ping: PONG>
--- FAIL: ExamplePipeline_instrumentation (0.00s)
got:
pipeline starting processing: [ping:  ping: ]
pipeline finished processing: [ping: dial tcp :6379: connect: connection refused ping: dial tcp :6379: connect: connection refused]
want:
pipeline starting processing: [ping:  ping: ]
pipeline finished processing: [ping: PONG ping: PONG]
--- FAIL: ExampleClient_Watch_instrumentation (0.16s)
got:
starting processing: <watch foo: >
finished processing: <watch foo: dial tcp :6379: connect: connection refused>
starting processing: <unwatch: >
finished processing: <unwatch: dial tcp :6379: connect: connection refused>
want:
starting processing: <watch foo: >
finished processing: <watch foo: OK>
starting processing: <ping: >
finished processing: <ping: PONG>
starting processing: <ping: >
finished processing: <ping: PONG>
starting processing: <unwatch: >
finished processing: <unwatch: OK>
--- FAIL: ExampleNewClient (0.11s)
got:
dial tcp [::1]:6379: connect: connection refused
want:
PONG <nil>
--- FAIL: ExampleClient (0.09s)
panic: dial tcp :6379: connect: connection refused [recovered]
        panic: dial tcp :6379: connect: connection refused

goroutine 1 [running]:
testing.(*InternalExample).processRunResult(0x140001b7c48, {0x0, 0x0}, 0x1011820c4?, 0x0, {0x10135e580, 0x14000034910})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/example.go:91 +0x3ac
testing.runExample.func2()
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/run_example.go:59 +0xfc
panic({0x10135e580, 0x14000034910})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:838 +0x204
github.com/go-redis/redis/v9_test.ExampleClient()
        /Users/mike/src/redis/example_test.go:136 +0x28c
testing.runExample({{0x101247673, 0xd}, 0x1013cc628, {0x1012572ae, 0x25}, 0x0})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/run_example.go:63 +0x228
testing.runExamples(0x140001b7e40, {0x101642e80?, 0x17, 0x4?})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/example.go:44 +0x154
testing.(*M).Run(0x1400028ebe0)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1721 +0x584
main.main()
        _testmain.go:129 +0x1d0
exit status 2
FAIL    github.com/go-redis/redis/v9    0.921s
```

No panic with this change:
```
go test
Running Suite: go-redis
=======================
Random Seed: 1656897899
Will run 508 of 510 specs

Failure [0.003 seconds]
[BeforeSuite] BeforeSuite 
/Users/mike/src/redis/main_test.go:68

  Unexpected error:
      <*exec.ExitError | 0x140003137a0>: {
          ProcessState: {
              pid: 95958,
              status: 256,
              rusage: {
                  Utime: {
                      Sec: 0,
                      Usec: 261,
                      Pad_cgo_0: [0, 0, 0, 0],
                  },
                  Stime: {
                      Sec: 0,
                      Usec: 657,
                      Pad_cgo_0: [0, 0, 0, 0],
                  },
                  Maxrss: 1441792,
                  Ixrss: 0,
                  Idrss: 0,
                  Isrss: 0,
                  Minflt: 197,
                  Majflt: 0,
                  Nswap: 0,
                  Inblock: 0,
                  Oublock: 0,
                  Msgsnd: 0,
                  Msgrcv: 0,
                  Nsignals: 0,
                  Nvcsw: 0,
                  Nivcsw: 3,
              },
          },
          Stderr: nil,
      }
      exit status 1
  occurred

  /Users/mike/src/redis/main_test.go:72
------------------------------

Ran 508 of 0 Specs in 0.003 seconds
FAIL! -- 0 Passed | 508 Failed | 0 Pending | 0 Skipped
--- FAIL: TestGinkgoSuite (0.06s)
--- FAIL: Example_instrumentation (0.07s)
got:
starting processing: <ping: >
finished processing: <ping: dial tcp :6379: connect: connection refused>
want:
starting processing: <ping: >
finished processing: <ping: PONG>
--- FAIL: ExamplePipeline_instrumentation (0.00s)
got:
pipeline starting processing: [ping:  ping: ]
pipeline finished processing: [ping: dial tcp :6379: connect: connection refused ping: dial tcp :6379: connect: connection refused]
want:
pipeline starting processing: [ping:  ping: ]
pipeline finished processing: [ping: PONG ping: PONG]
--- FAIL: ExampleClient_Watch_instrumentation (0.16s)
got:
starting processing: <watch foo: >
finished processing: <watch foo: dial tcp :6379: connect: connection refused>
starting processing: <unwatch: >
finished processing: <unwatch: dial tcp :6379: connect: connection refused>
want:
starting processing: <watch foo: >
finished processing: <watch foo: OK>
starting processing: <ping: >
finished processing: <ping: PONG>
starting processing: <ping: >
finished processing: <ping: PONG>
starting processing: <unwatch: >
finished processing: <unwatch: OK>
--- FAIL: ExampleNewClient (0.11s)
got:
dial tcp [::1]:6379: connect: connection refused
want:
PONG <nil>
--- FAIL: ExampleClient (0.09s)
panic: dial tcp :6379: connect: connection refused [recovered]
        panic: dial tcp :6379: connect: connection refused

goroutine 1 [running]:
testing.(*InternalExample).processRunResult(0x14000595c48, {0x0, 0x0}, 0x102dea114?, 0x0, {0x102fc6580, 0x140005b0320})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/example.go:91 +0x3ac
testing.runExample.func2()
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/run_example.go:59 +0xfc
panic({0x102fc6580, 0x140005b0320})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:838 +0x204
github.com/go-redis/redis/v9_test.ExampleClient()
        /Users/mike/src/redis/example_test.go:136 +0x28c
testing.runExample({{0x102eaf0f3, 0xd}, 0x103034628, {0x102ebed2e, 0x25}, 0x0})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/run_example.go:63 +0x228
testing.runExamples(0x14000595e40, {0x1032aae80?, 0x17, 0x4?})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/example.go:44 +0x154
testing.(*M).Run(0x14000284be0)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1721 +0x584
main.main()
        _testmain.go:129 +0x1d0
exit status 2
FAIL    github.com/go-redis/redis/v9    0.943s
```