### PR TITLE
baseClient#process(): reset retry attempts on successfully written XREAD

### DIFF
--- a/command.go
+++ b/command.go
@@ -23,6 +23,7 @@ type Cmder interface {
 	SetFirstKeyPos(int8)
 
 	readTimeout() *time.Duration
+	longRunning() bool
 	readReply(rd *proto.Reader) error
 
 	SetErr(error)
@@ -110,10 +111,11 @@ func cmdString(cmd Cmder, val interface{}) string {
 //------------------------------------------------------------------------------
 
 type baseCmd struct {
-	ctx    context.Context
-	args   []interface{}
-	err    error
-	keyPos int8
+	ctx           context.Context
+	args          []interface{}
+	err           error
+	keyPos        int8
+	isLongRunning bool
 
 	_readTimeout *time.Duration
 }
@@ -183,6 +185,14 @@ func (cmd *baseCmd) readTimeout() *time.Duration {
 
 func (cmd *baseCmd) setReadTimeout(d time.Duration) {
 	cmd._readTimeout = &d
+}
+
+func (cmd *baseCmd) longRunning() bool {
+	return cmd.isLongRunning
+}
+
+func (cmd *baseCmd) setLongRunning(b bool) {
+	cmd.isLongRunning = b
 }
 
 //------------------------------------------------------------------------------

--- a/commands.go
+++ b/commands.go
@@ -1845,6 +1845,7 @@ func (c cmdable) XRead(ctx context.Context, a *XReadArgs) *XStreamSliceCmd {
 	cmd := NewXStreamSliceCmd(ctx, args...)
 	if a.Block >= 0 {
 		cmd.setReadTimeout(a.Block)
+		cmd.setLongRunning(true)
 	}
 	cmd.SetFirstKeyPos(keyPos)
 	_ = c(ctx, cmd)


### PR DESCRIPTION
if a retryable error ocurred during waiting for the response.
Otherwise we could run out of retries despite the XREAD
was actually partially successful.

fixes #2131