### PR TITLE
cluster: log errors from cmdsInfoCache

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1605,6 +1605,7 @@ func (c *ClusterClient) cmdsInfo(ctx context.Context) (map[string]*CommandInfo, 
 func (c *ClusterClient) cmdInfo(name string) *CommandInfo {
 	cmdsInfo, err := c.cmdsInfoCache.Get(c.ctx)
 	if err != nil {
+		internal.Logger.Printf(context.TODO(), "getting command info: %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
Since the error gets swallowed in cmdInfo(), it's important to log it so it's possible for the user to see what the error was.