### PR TITLE
fix: additional node failures in clustered pipelined reads

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1212,7 +1212,7 @@ func (c *ClusterClient) pipelineReadCmds(
 			continue
 		}
 
-		if c.opt.ReadOnly && isLoadingError(err) {
+		if c.opt.ReadOnly && (isLoadingError(err) || !isRedisError(err)) {
 			node.MarkAsFailing()
 			return err
 		}


### PR DESCRIPTION
This causes a node to be marked as failing if the client is in READONLY mode
and any error occurs that is either a LOADING error (existing behvaior) or
any non-redis error (e.g. connection error, timeout, etc.).  This prevents that
node from being tried again on the next attempt as usually non-redis errors are
a strong indication that that node is not operational or degraded in some way.