### PR TITLE
refactor: remove unused context attribute from conn

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -155,7 +155,7 @@ func ExampleClient() {
 }
 
 func ExampleConn() {
-	conn := rdb.Conn(context.Background())
+	conn := rdb.Conn()
 
 	err := conn.ClientSetName(ctx, "foobar").Err()
 	if err != nil {

--- a/redis.go
+++ b/redis.go
@@ -225,7 +225,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	}
 
 	connPool := pool.NewSingleConnPool(c.connPool, cn)
-	conn := newConn(ctx, c.opt, connPool)
+	conn := newConn(c.opt, connPool)
 
 	var auth bool
 
@@ -575,8 +575,8 @@ func (c *Client) WithTimeout(timeout time.Duration) *Client {
 	return clone
 }
 
-func (c *Client) Conn(ctx context.Context) *Conn {
-	return newConn(ctx, c.opt, pool.NewStickyConnPool(c.connPool))
+func (c *Client) Conn() *Conn {
+	return newConn(c.opt, pool.NewStickyConnPool(c.connPool))
 }
 
 // Do creates a Cmd from the args and processes the cmd.
@@ -707,10 +707,9 @@ type conn struct {
 // for a continuous single Redis connection.
 type Conn struct {
 	*conn
-	ctx context.Context
 }
 
-func newConn(ctx context.Context, opt *Options, connPool pool.Pooler) *Conn {
+func newConn(opt *Options, connPool pool.Pooler) *Conn {
 	c := Conn{
 		conn: &conn{
 			baseClient: baseClient{
@@ -718,7 +717,6 @@ func newConn(ctx context.Context, opt *Options, connPool pool.Pooler) *Conn {
 				connPool: connPool,
 			},
 		},
-		ctx: ctx,
 	}
 	c.cmdable = c.Process
 	c.statefulCmdable = c.Process

--- a/redis_test.go
+++ b/redis_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Client", func() {
 	})
 
 	It("should Conn", func() {
-		err := client.Conn(ctx).Get(ctx, "this-key-does-not-exist").Err()
+		err := client.Conn().Get(ctx, "this-key-does-not-exist").Err()
 		Expect(err).To(Equal(redis.Nil))
 	})
 


### PR DESCRIPTION
The existing context attribute of `conn` was never used.
