### PR TITLE
fix: Handle panic in ringShards Hash function when Ring got closed

### DIFF
--- a/ring_test.go
+++ b/ring_test.go
@@ -114,6 +114,21 @@ var _ = Describe("Redis Ring", func() {
 	})
 
 	Describe("pipeline", func() {
+		It("doesn't panic closed ring, returns error", func() {
+			pipe := ring.Pipeline()
+			for i := 0; i < 3; i++ {
+				err := pipe.Set(ctx, fmt.Sprintf("key%d", i), "value", 0).Err()
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			Expect(ring.Close()).NotTo(HaveOccurred())
+
+			Expect(func() {
+				_, execErr := pipe.Exec(ctx)
+				Expect(execErr).To(HaveOccurred())
+			}).NotTo(Panic())
+		})
+
 		It("distributes keys", func() {
 			pipe := ring.Pipeline()
 			for i := 0; i < 100; i++ {


### PR DESCRIPTION
Fixes #2126 

Tried to figure out how we can fix the #2126 the panic that raises from `func (c *ringShards) Hash(key string)`. And the easiest way is no add missing wiping of `numShard` on `ringShards`, so `c.hash.Get` (where `hash` is nil) will not be called.

Interesting thing that without moving the `c.mu.RUnlock()` in `func (c *ringShards) Hash(key string)` up and to make it deferred test got completely stuck. I think it is connected to the unhandled panic. In a deferred approach mutex will be released no matter how the function exited. So I changed some of the locks to avoid similar problems in other places.