### PR TITLE
refactor: remove unused context attributes

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -708,7 +708,6 @@ type ClusterClient struct {
 	*clusterClient
 	cmdable
 	hooks
-	ctx context.Context
 }
 
 // NewClusterClient returns a Redis Cluster client as described in

--- a/cluster.go
+++ b/cluster.go
@@ -721,7 +721,6 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 			opt:   opt,
 			nodes: newClusterNodes(opt),
 		},
-		ctx: context.Background(),
 	}
 	c.state = newClusterStateHolder(c.loadState)
 	c.cmdsInfoCache = newCmdsInfoCache(c.cmdsInfo)
@@ -765,8 +764,8 @@ func (c *ClusterClient) Process(ctx context.Context, cmd Cmder) error {
 }
 
 func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
-	cmdInfo := c.cmdInfo(cmd.Name())
-	slot := c.cmdSlot(cmd)
+	cmdInfo := c.cmdInfo(ctx, cmd.Name())
+	slot := c.cmdSlot(ctx, cmd)
 
 	var node *clusterNode
 	var ask bool
@@ -1141,9 +1140,9 @@ func (c *ClusterClient) mapCmdsByNode(ctx context.Context, cmdsMap *cmdsMap, cmd
 		return err
 	}
 
-	if c.opt.ReadOnly && c.cmdsAreReadOnly(cmds) {
+	if c.opt.ReadOnly && c.cmdsAreReadOnly(ctx, cmds) {
 		for _, cmd := range cmds {
-			slot := c.cmdSlot(cmd)
+			slot := c.cmdSlot(ctx, cmd)
 			node, err := c.slotReadOnlyNode(state, slot)
 			if err != nil {
 				return err
@@ -1154,7 +1153,7 @@ func (c *ClusterClient) mapCmdsByNode(ctx context.Context, cmdsMap *cmdsMap, cmd
 	}
 
 	for _, cmd := range cmds {
-		slot := c.cmdSlot(cmd)
+		slot := c.cmdSlot(ctx, cmd)
 		node, err := state.slotMasterNode(slot)
 		if err != nil {
 			return err
@@ -1164,9 +1163,9 @@ func (c *ClusterClient) mapCmdsByNode(ctx context.Context, cmdsMap *cmdsMap, cmd
 	return nil
 }
 
-func (c *ClusterClient) cmdsAreReadOnly(cmds []Cmder) bool {
+func (c *ClusterClient) cmdsAreReadOnly(ctx context.Context, cmds []Cmder) bool {
 	for _, cmd := range cmds {
-		cmdInfo := c.cmdInfo(cmd.Name())
+		cmdInfo := c.cmdInfo(ctx, cmd.Name())
 		if cmdInfo == nil || !cmdInfo.ReadOnly {
 			return false
 		}
@@ -1278,7 +1277,7 @@ func (c *ClusterClient) _processTxPipeline(ctx context.Context, cmds []Cmder) er
 		return err
 	}
 
-	cmdsMap := c.mapCmdsBySlot(cmds)
+	cmdsMap := c.mapCmdsBySlot(ctx, cmds)
 	for slot, cmds := range cmdsMap {
 		node, err := state.slotMasterNode(slot)
 		if err != nil {
@@ -1329,10 +1328,10 @@ func (c *ClusterClient) _processTxPipeline(ctx context.Context, cmds []Cmder) er
 	return cmdsFirstErr(cmds)
 }
 
-func (c *ClusterClient) mapCmdsBySlot(cmds []Cmder) map[int][]Cmder {
+func (c *ClusterClient) mapCmdsBySlot(ctx context.Context, cmds []Cmder) map[int][]Cmder {
 	cmdsMap := make(map[int][]Cmder)
 	for _, cmd := range cmds {
-		slot := c.cmdSlot(cmd)
+		slot := c.cmdSlot(ctx, cmd)
 		cmdsMap[slot] = append(cmdsMap[slot], cmd)
 	}
 	return cmdsMap
@@ -1602,8 +1601,8 @@ func (c *ClusterClient) cmdsInfo(ctx context.Context) (map[string]*CommandInfo, 
 	return nil, firstErr
 }
 
-func (c *ClusterClient) cmdInfo(name string) *CommandInfo {
-	cmdsInfo, err := c.cmdsInfoCache.Get(c.ctx)
+func (c *ClusterClient) cmdInfo(ctx context.Context, name string) *CommandInfo {
+	cmdsInfo, err := c.cmdsInfoCache.Get(ctx)
 	if err != nil {
 		internal.Logger.Printf(context.TODO(), "getting command info: %s", err)
 		return nil
@@ -1616,13 +1615,13 @@ func (c *ClusterClient) cmdInfo(name string) *CommandInfo {
 	return info
 }
 
-func (c *ClusterClient) cmdSlot(cmd Cmder) int {
+func (c *ClusterClient) cmdSlot(ctx context.Context, cmd Cmder) int {
 	args := cmd.Args()
 	if args[0] == "cluster" && args[1] == "getkeysinslot" {
 		return args[2].(int)
 	}
 
-	cmdInfo := c.cmdInfo(cmd.Name())
+	cmdInfo := c.cmdInfo(ctx, cmd.Name())
 	return cmdSlot(cmd, cmdFirstKeyPos(cmd, cmdInfo))
 }
 

--- a/redis.go
+++ b/redis.go
@@ -546,7 +546,6 @@ type Client struct {
 	*baseClient
 	cmdable
 	hooks
-	ctx context.Context
 }
 
 // NewClient returns a client to the Redis Server specified by Options.
@@ -555,7 +554,6 @@ func NewClient(opt *Options) *Client {
 
 	c := Client{
 		baseClient: newBaseClient(opt, newConnPool(opt)),
-		ctx:        context.Background(),
 	}
 	c.cmdable = c.Process
 

--- a/ring.go
+++ b/ring.go
@@ -410,7 +410,6 @@ type Ring struct {
 	*ring
 	cmdable
 	hooks
-	ctx context.Context
 }
 
 func NewRing(opt *RingOptions) *Ring {
@@ -421,7 +420,6 @@ func NewRing(opt *RingOptions) *Ring {
 			opt:    opt,
 			shards: newRingShards(opt),
 		},
-		ctx: context.Background(),
 	}
 
 	ring.cmdsInfoCache = newCmdsInfoCache(ring.cmdsInfo)

--- a/sentinel.go
+++ b/sentinel.go
@@ -209,7 +209,6 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 
 	c := Client{
 		baseClient: newBaseClient(opt, connPool),
-		ctx:        context.Background(),
 	}
 	c.cmdable = c.Process
 	c.onClose = failover.Close

--- a/tx.go
+++ b/tx.go
@@ -20,17 +20,15 @@ type Tx struct {
 	cmdable
 	statefulCmdable
 	hooks
-	ctx context.Context
 }
 
-func (c *Client) newTx(ctx context.Context) *Tx {
+func (c *Client) newTx() *Tx {
 	tx := Tx{
 		baseClient: baseClient{
 			opt:      c.opt,
 			connPool: pool.NewStickyConnPool(c.connPool),
 		},
 		hooks: c.hooks.clone(),
-		ctx:   ctx,
 	}
 	tx.init()
 	return &tx
@@ -50,7 +48,7 @@ func (c *Tx) Process(ctx context.Context, cmd Cmder) error {
 //
 // The transaction is automatically closed when fn exits.
 func (c *Client) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
-	tx := c.newTx(ctx)
+	tx := c.newTx()
 	defer tx.Close(ctx)
 	if len(keys) > 0 {
 		if err := tx.Watch(ctx, keys...).Err(); err != nil {


### PR DESCRIPTION
For many types the context attribute was not removed after moving to context propagation via function parameters.
