### PR TITLE
fix: fixes ring.SetAddrs and rebalance race 

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -95,9 +95,10 @@ func GetSlavesAddrByName(ctx context.Context, c *SentinelClient, name string) []
 }
 
 func (c *Ring) ShardByName(name string) *ringShard {
-	return c.sharding.ShardByName(name)
+	shard, _ := c.sharding.GetByName(name)
+	return shard
 }
 
-func (c *ringSharding) ShardByName(name string) *ringShard {
-	return c.shards.m[name]
+func (c *Ring) ShardByKey(key string) (*ringShard, error) {
+	return c.sharding.GetByKey(key)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -102,3 +102,7 @@ func (c *Ring) ShardByName(name string) *ringShard {
 func (c *Ring) ShardByKey(key string) (*ringShard, error) {
 	return c.sharding.GetByKey(key)
 }
+
+func (c *Ring) RebalanceLocked() {
+	c.sharding.rebalanceLocked()
+}

--- a/export_test.go
+++ b/export_test.go
@@ -98,11 +98,3 @@ func (c *Ring) ShardByName(name string) *ringShard {
 	shard, _ := c.sharding.GetByName(name)
 	return shard
 }
-
-func (c *Ring) ShardByKey(key string) (*ringShard, error) {
-	return c.sharding.GetByKey(key)
-}
-
-func (c *Ring) RebalanceLocked() {
-	c.sharding.rebalanceLocked()
-}

--- a/ring_test.go
+++ b/ring_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -740,89 +739,3 @@ var _ = Describe("Ring Tx timeout", func() {
 		testTimeout()
 	})
 })
-
-type fixedHash string
-
-func (h fixedHash) Get(string) string {
-	return string(h)
-}
-
-func TestRingSetAddrsAndRebalanceRace(t *testing.T) {
-	const (
-		ringShard1Name = "ringShardOne"
-		ringShard2Name = "ringShardTwo"
-	)
-
-	ring := redis.NewRing(&redis.RingOptions{
-		Addrs: map[string]string{
-			ringShard1Name: ":" + ringShard1Port,
-		},
-		// Disable heartbeat
-		HeartbeatFrequency: 1 * time.Hour,
-		NewConsistentHash: func(shards []string) redis.ConsistentHash {
-			switch len(shards) {
-			case 1:
-				return fixedHash(ringShard1Name)
-			case 2:
-				return fixedHash(ringShard2Name)
-			default:
-				t.Fatalf("Unexpected number of shards: %v", shards)
-				return nil
-			}
-		},
-	})
-
-	// Continuously update addresses by adding and removing one address
-	updatesDone := make(chan struct{})
-	defer func() { close(updatesDone) }()
-	go func() {
-		for i := 0; ; i++ {
-			select {
-			case <-updatesDone:
-				return
-			default:
-				if i%2 == 0 {
-					ring.SetAddrs(map[string]string{
-						ringShard1Name: ":" + ringShard1Port,
-					})
-				} else {
-					ring.SetAddrs(map[string]string{
-						ringShard1Name: ":" + ringShard1Port,
-						ringShard2Name: ":" + ringShard2Port,
-					})
-				}
-			}
-		}
-	}()
-
-	timer := time.NewTimer(1 * time.Second)
-	for running := true; running; {
-		select {
-		case <-timer.C:
-			running = false
-		default:
-			shard, err := ring.ShardByKey("whatever")
-			if err == nil && shard == nil {
-				t.Fatal("shard is nil")
-			}
-		}
-	}
-}
-
-func BenchmarkRingRebalanceLocked(b *testing.B) {
-	opts := &redis.RingOptions{
-		Addrs: make(map[string]string),
-		// Disable heartbeat
-		HeartbeatFrequency: 1 * time.Hour,
-	}
-	for i := 0; i < 100; i++ {
-		opts.Addrs[fmt.Sprintf("shard%d", i)] = fmt.Sprintf(":63%02d", i)
-	}
-
-	ring := redis.NewRing(opts)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ring.RebalanceLocked()
-	}
-}

--- a/ring_test.go
+++ b/ring_test.go
@@ -808,3 +808,21 @@ func TestRingSetAddrsAndRebalanceRace(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkRingRebalanceLocked(b *testing.B) {
+	opts := &redis.RingOptions{
+		Addrs: make(map[string]string),
+		// Disable heartbeat
+		HeartbeatFrequency: 1 * time.Hour,
+	}
+	for i := 0; i < 100; i++ {
+		opts.Addrs[fmt.Sprintf("shard%d", i)] = fmt.Sprintf(":63%02d", i)
+	}
+
+	ring := redis.NewRing(opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ring.RebalanceLocked()
+	}
+}


### PR DESCRIPTION
While working on reducing `ring.SetAddrs` lock contention (see https://github.com/go-redis/redis/pull/2190#discussion_r953040289) I have discovered a race condition between `SetAddrs` and `rebalance` which I would like to fix first and separately.

The change consists of two commits:
- a test to reproduce the race
- the fix 

The fix ensures atomic update of `c.hash` and `c.shards`, otherwise `c.hash` may return shard name that is not in the `c.shards` and cause ring operation panic. 

`BenchmarkRingRebalanceLocked` shows rebalance latency if that is a concern:
```
go test . -run=NONE -bench=BenchmarkRingRebalanceLocked -v -count=10 | benchstat /dev/stdin
name                   time/op
RingRebalanceLocked-8  8.50µs ±14%
```

(Note: it essentially reverts https://github.com/go-redis/redis/commit/a46b053aa626a005a30dfb1ac4e096abcce1ef76)

Updates https://github.com/go-redis/redis/issues/2077
FYI @szuecs