### PR TITLE
v9: Move ClientSetName to cmdable

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -87,6 +87,7 @@ type Cmdable interface {
 
 	Command(ctx context.Context) *CommandsInfoCmd
 	ClientGetName(ctx context.Context) *StringCmd
+	ClientSetName(ctx context.Context, name string) *BoolCmd
 	Echo(ctx context.Context, message interface{}) *StringCmd
 	Ping(ctx context.Context) *StatusCmd
 	Quit(ctx context.Context) *StatusCmd
@@ -394,7 +395,6 @@ type StatefulCmdable interface {
 	AuthACL(ctx context.Context, username, password string) *StatusCmd
 	Select(ctx context.Context, index int) *StatusCmd
 	SwapDB(ctx context.Context, index1, index2 int) *StatusCmd
-	ClientSetName(ctx context.Context, name string) *BoolCmd
 	Hello(ctx context.Context, ver int, username, password, clientName string) *MapStringInterfaceCmd
 }
 
@@ -445,13 +445,6 @@ func (c statefulCmdable) SwapDB(ctx context.Context, index1, index2 int) *Status
 	return cmd
 }
 
-// ClientSetName assigns a name to the connection.
-func (c statefulCmdable) ClientSetName(ctx context.Context, name string) *BoolCmd {
-	cmd := NewBoolCmd(ctx, "client", "setname", name)
-	_ = c(ctx, cmd)
-	return cmd
-}
-
 // Hello Set the resp protocol used.
 func (c statefulCmdable) Hello(ctx context.Context,
 	ver int, username, password, clientName string) *MapStringInterfaceCmd {
@@ -483,6 +476,13 @@ func (c cmdable) Command(ctx context.Context) *CommandsInfoCmd {
 // ClientGetName returns the name of the connection.
 func (c cmdable) ClientGetName(ctx context.Context) *StringCmd {
 	cmd := NewStringCmd(ctx, "client", "getname")
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// ClientSetName assigns a name to the connection.
+func (c cmdable) ClientSetName(ctx context.Context, name string) *BoolCmd {
+	cmd := NewBoolCmd(ctx, "client", "setname", name)
 	_ = c(ctx, cmd)
 	return cmd
 }


### PR DESCRIPTION
ClientSetName in a pipeline is a noop.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>