### PR TITLE
feat(scan): add Scanner interface

### DIFF
--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -10,6 +10,12 @@ import (
 // decoderFunc represents decoding functions for default built-in types.
 type decoderFunc func(reflect.Value, string) error
 
+// Scanner is the interface implemented by themselves,
+// which will override the decoding behavior of decoderFunc.
+type Scanner interface {
+	ScanRedis(s string) error
+}
+
 var (
 	// List of built-in decoders indexed by their numeric constant values (eg: reflect.Bool = 1).
 	decoders = []decoderFunc{

--- a/redis.go
+++ b/redis.go
@@ -10,9 +10,13 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v9/internal"
+	"github.com/go-redis/redis/v9/internal/hscan"
 	"github.com/go-redis/redis/v9/internal/pool"
 	"github.com/go-redis/redis/v9/internal/proto"
 )
+
+// Scanner internal/hscan.Scanner exposed interface.
+type Scanner = hscan.Scanner
 
 // Nil reply returned by Redis when key does not exist.
 const Nil = proto.Nil


### PR DESCRIPTION
Add Scanner interface, scanner is an interface for custom decoding:

See #2298 #2295 #1631 

```go
type TimeValue struct {
	time.Time
}

func (t *TimeValue) ScanRedis(s string) (err error) {
	t.Time, err = time.Parse(time.RFC3339Nano, s)
	return
}

type Data struct {
	Name      string     `redis:"name"`
	LoginTime TimeValue  `redis:"login_time"`
}

var d Data
err := client.MGet(ctx, "name", "login_time").Scan(&d)
```