### PR TITLE
fix(redisotel): correct metrics.DialHook attrs

### DIFF
--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -193,7 +193,11 @@ func (mh *metricsHook) DialHook(hook redis.DialHook) redis.DialHook {
 
 		conn, err := hook(ctx, network, addr)
 
-		mh.createTime.Record(ctx, milliseconds(time.Since(start)), mh.attrs...)
+		attrs := make([]attribute.KeyValue, 0, len(mh.attrs)+1)
+		attrs = append(attrs, mh.attrs...)
+		attrs = append(attrs, statusAttr(err))
+
+		mh.createTime.Record(ctx, milliseconds(time.Since(start)), attrs...)
 		return conn, err
 	}
 }


### PR DESCRIPTION
- pass attrs by value instead of by reference to the otel histogram `Record` function
   - the histograms in the otel sdk perform an in-place sort on the attrs passed into `Record`
   - a race condition can occur when separate goroutines concurrently interact with the various redisotel hooks
   - this PR converts the dialhook to a read operation which is consistent with the behavior of the other hooks
- side benefit of including the error status attr which is another step towards consistency with the other hooks
