### PR TITLE
feat: v8 remove redis7 command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -13,7 +13,7 @@ import (
 // otherwise you will receive an error: (error) ERR syntax error.
 // For example:
 //
-//    rdb.Set(ctx, key, value, redis.KeepTTL)
+//	rdb.Set(ctx, key, value, redis.KeepTTL)
 const KeepTTL = -1
 
 func usePrecise(dur time.Duration) bool {
@@ -96,10 +96,6 @@ type Cmdable interface {
 	Exists(ctx context.Context, keys ...string) *IntCmd
 	Expire(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	ExpireAt(ctx context.Context, key string, tm time.Time) *BoolCmd
-	ExpireNX(ctx context.Context, key string, expiration time.Duration) *BoolCmd
-	ExpireXX(ctx context.Context, key string, expiration time.Duration) *BoolCmd
-	ExpireGT(ctx context.Context, key string, expiration time.Duration) *BoolCmd
-	ExpireLT(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	Keys(ctx context.Context, pattern string) *StringSliceCmd
 	Migrate(ctx context.Context, host, port, key string, db int, timeout time.Duration) *StatusCmd
 	Move(ctx context.Context, key string, db int) *BoolCmd
@@ -532,22 +528,6 @@ func (c cmdable) Exists(ctx context.Context, keys ...string) *IntCmd {
 
 func (c cmdable) Expire(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
 	return c.expire(ctx, key, expiration, "")
-}
-
-func (c cmdable) ExpireNX(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
-	return c.expire(ctx, key, expiration, "NX")
-}
-
-func (c cmdable) ExpireXX(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
-	return c.expire(ctx, key, expiration, "XX")
-}
-
-func (c cmdable) ExpireGT(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
-	return c.expire(ctx, key, expiration, "GT")
-}
-
-func (c cmdable) ExpireLT(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
-	return c.expire(ctx, key, expiration, "LT")
 }
 
 func (c cmdable) expire(
@@ -2049,8 +2029,10 @@ func xClaimArgs(a *XClaimArgs) []interface{} {
 
 // xTrim If approx is true, add the "~" parameter, otherwise it is the default "=" (redis default).
 // example:
-//		XTRIM key MAXLEN/MINID threshold LIMIT limit.
-//		XTRIM key MAXLEN/MINID ~ threshold LIMIT limit.
+//
+//	XTRIM key MAXLEN/MINID threshold LIMIT limit.
+//	XTRIM key MAXLEN/MINID ~ threshold LIMIT limit.
+//
 // The redis-server version is lower than 6.2, please set limit to 0.
 func (c cmdable) xTrim(
 	ctx context.Context, key, strategy string,
@@ -2298,6 +2280,7 @@ func (c cmdable) ZAddXX(ctx context.Context, key string, members ...*Z) *IntCmd 
 
 // ZAddCh Redis `ZADD key CH score member [score member ...]` command.
 // Deprecated: Use
+//
 //		client.ZAddArgs(ctx, ZAddArgs{
 //			Ch: true,
 //			Members: []Z,
@@ -2311,6 +2294,7 @@ func (c cmdable) ZAddCh(ctx context.Context, key string, members ...*Z) *IntCmd 
 
 // ZAddNXCh Redis `ZADD key NX CH score member [score member ...]` command.
 // Deprecated: Use
+//
 //		client.ZAddArgs(ctx, ZAddArgs{
 //			NX: true,
 //			Ch: true,
@@ -2326,6 +2310,7 @@ func (c cmdable) ZAddNXCh(ctx context.Context, key string, members ...*Z) *IntCm
 
 // ZAddXXCh Redis `ZADD key XX CH score member [score member ...]` command.
 // Deprecated: Use
+//
 //		client.ZAddArgs(ctx, ZAddArgs{
 //			XX: true,
 //			Ch: true,
@@ -2341,6 +2326,7 @@ func (c cmdable) ZAddXXCh(ctx context.Context, key string, members ...*Z) *IntCm
 
 // ZIncr Redis `ZADD key INCR score member` command.
 // Deprecated: Use
+//
 //		client.ZAddArgsIncr(ctx, ZAddArgs{
 //			Members: []Z,
 //		})
@@ -2353,6 +2339,7 @@ func (c cmdable) ZIncr(ctx context.Context, key string, member *Z) *FloatCmd {
 
 // ZIncrNX Redis `ZADD key NX INCR score member` command.
 // Deprecated: Use
+//
 //		client.ZAddArgsIncr(ctx, ZAddArgs{
 //			NX: true,
 //			Members: []Z,
@@ -2367,6 +2354,7 @@ func (c cmdable) ZIncrNX(ctx context.Context, key string, member *Z) *FloatCmd {
 
 // ZIncrXX Redis `ZADD key XX INCR score member` command.
 // Deprecated: Use
+//
 //		client.ZAddArgsIncr(ctx, ZAddArgs{
 //			XX: true,
 //			Members: []Z,
@@ -2488,11 +2476,13 @@ func (c cmdable) ZPopMin(ctx context.Context, key string, count ...int64) *ZSlic
 
 // ZRangeArgs is all the options of the ZRange command.
 // In version> 6.2.0, you can replace the(cmd):
-//		ZREVRANGE,
-//		ZRANGEBYSCORE,
-//		ZREVRANGEBYSCORE,
-//		ZRANGEBYLEX,
-//		ZREVRANGEBYLEX.
+//
+//	ZREVRANGE,
+//	ZRANGEBYSCORE,
+//	ZREVRANGEBYSCORE,
+//	ZRANGEBYLEX,
+//	ZREVRANGEBYLEX.
+//
 // Please pay attention to your redis-server version.
 //
 // Rev, ByScore, ByLex and Offset+Count options require redis-server 6.2.0 and higher.
@@ -2897,7 +2887,7 @@ func (c cmdable) ClientKill(ctx context.Context, ipPort string) *StatusCmd {
 
 // ClientKillByFilter is new style syntax, while the ClientKill is old
 //
-//   CLIENT KILL <option> [value] ... <option> [value]
+//	CLIENT KILL <option> [value] ... <option> [value]
 func (c cmdable) ClientKillByFilter(ctx context.Context, keys ...string) *IntCmd {
 	args := make([]interface{}, 2+len(keys))
 	args[0] = "client"


### PR DESCRIPTION
For the v8 version, there is no plan to support redis7, so the redis7 commands are removed: ExpireNX, ExpireXX, ExpireGT, ExpireLT.