### PR TITLE
fix: read cursor as uint64

### DIFF
--- a/command.go
+++ b/command.go
@@ -2693,11 +2693,11 @@ func (cmd *ScanCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	cursor, err := rd.ReadInt()
+	cursor, err := rd.ReadUint()
 	if err != nil {
 		return err
 	}
-	cmd.cursor = uint64(cursor)
+	cmd.cursor = cursor
 
 	n, err := rd.ReadArrayLen()
 	if err != nil {

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -319,6 +319,33 @@ func (r *Reader) ReadInt() (int64, error) {
 	return 0, fmt.Errorf("redis: can't parse int reply: %.100q", line)
 }
 
+func (r *Reader) ReadUint() (uint64, error) {
+	line, err := r.ReadLine()
+	if err != nil {
+		return 0, err
+	}
+	switch line[0] {
+	case RespInt, RespStatus:
+		return util.ParseUint(line[1:], 10, 64)
+	case RespString:
+		s, err := r.readStringReply(line)
+		if err != nil {
+			return 0, err
+		}
+		return util.ParseUint([]byte(s), 10, 64)
+	case RespBigInt:
+		b, err := r.readBigInt(line)
+		if err != nil {
+			return 0, err
+		}
+		if !b.IsUint64() {
+			return 0, fmt.Errorf("bigInt(%s) value out of range", b.String())
+		}
+		return b.Uint64(), nil
+	}
+	return 0, fmt.Errorf("redis: can't parse uint reply: %.100q", line)
+}
+
 func (r *Reader) ReadFloat() (float64, error) {
 	line, err := r.ReadLine()
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/go-redis/redis/issues/2355