### PR TITLE
docs: updated "Installation" description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,18 @@ module:
 go mod init github.com/my/repo
 ```
 
-If you are using **Redis 6**, install go-redis/**v8**:
-
-```shell
-go get github.com/go-redis/redis/v8
-```
-
 If you are using **Redis 7**, install go-redis/**v9**:
 
 ```shell
 go get github.com/go-redis/redis/v9
 ```
+
+You can also use the stable version go-redis/**v8** (v8 does not support redis 7):
+
+```shell
+go get github.com/go-redis/redis/v8
+```
+
 
 ## Quickstart
 


### PR DESCRIPTION
After testing, in the case of removing the redis-7 api, v9 can pass the test of redis6-server.

We should allow users using redis6 to install go-redis/v9.

@vmihailenco  Do we have other situations where redis6 cannot be used in v9?